### PR TITLE
fix: stabilize Swap and Borrow loading states

### DIFF
--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -113,6 +113,7 @@ import type {
   IAddEarnOrderParams,
   IEarnOrderItem,
 } from '../dbs/simple/entity/SimpleDbEntityEarnOrders';
+import type { IAccountDeriveTypes } from '../vaults/types';
 
 interface ICheckAmountResponse {
   code: number;
@@ -1756,9 +1757,16 @@ class ServiceStaking extends ServiceBase {
     accountId: string;
     networkId: string;
     indexedAccountId?: string;
+    deriveType?: IAccountDeriveTypes;
     btcOnlyTaproot?: boolean;
   }) {
-    const { accountId, networkId, indexedAccountId, btcOnlyTaproot } = params;
+    const {
+      accountId,
+      networkId,
+      indexedAccountId,
+      deriveType: requestedDeriveType,
+      btcOnlyTaproot,
+    } = params;
     if (!accountId && !indexedAccountId) {
       return null;
     }
@@ -1803,9 +1811,10 @@ class ServiceStaking extends ServiceBase {
     }
     try {
       const globalDeriveType =
-        await this.backgroundApi.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+        requestedDeriveType ??
+        (await this.backgroundApi.serviceNetwork.getGlobalDeriveTypeOfNetwork({
           networkId,
-        });
+        }));
       let deriveType = globalDeriveType;
       // only support taproot for earn
       if (networkUtils.isBTCNetwork(networkId) && btcOnlyTaproot) {

--- a/packages/kit/src/components/AmountInput/index.tsx
+++ b/packages/kit/src/components/AmountInput/index.tsx
@@ -369,9 +369,15 @@ export function AmountInput({
     }
     if (balanceProps.loading) {
       return (
-        <Stack m="$1" px="$2.5" py="$1">
+        <XStack m="$1" px="$2.5" py="$1" alignItems="center">
           <Skeleton h="$4" w="$16" />
-        </Stack>
+          {enableMaxAmount ? (
+            <SizableText pl="$1" size="$bodySmMedium" color="$textPlaceholder">
+              {maxAmountText ??
+                intl.formatMessage({ id: ETranslations.send_max })}
+            </SizableText>
+          ) : null}
+        </XStack>
       );
     }
     if (balanceProps.value) {
@@ -396,15 +402,17 @@ export function AmountInput({
           borderRadius={6}
           onPress={balanceProps.onPress}
           testID={balanceProps.testID}
-          {...(enableMaxAmount && {
-            userSelect: 'none',
-            hoverStyle: {
-              bg: '$bgHover',
-            },
-            pressStyle: {
-              bg: '$bgActive',
-            },
-          })}
+          {...(enableMaxAmount && balanceProps.onPress
+            ? {
+                userSelect: 'none',
+                hoverStyle: {
+                  bg: '$bgHover',
+                },
+                pressStyle: {
+                  bg: '$bgActive',
+                },
+              }
+            : undefined)}
           {...(balanceHelperProps && {
             px: '$1.5',
             mr: '$-2',
@@ -426,7 +434,13 @@ export function AmountInput({
             </SizableText>
           ) : null}
           {enableMaxAmount ? (
-            <SizableText pl="$1" size="$bodySmMedium" color="$textInteractive">
+            <SizableText
+              pl="$1"
+              size="$bodySmMedium"
+              color={
+                balanceProps.onPress ? '$textInteractive' : '$textPlaceholder'
+              }
+            >
               {maxAmountText ??
                 intl.formatMessage({ id: ETranslations.send_max })}
             </SizableText>

--- a/packages/kit/src/views/Borrow/borrowDataStatus.test.ts
+++ b/packages/kit/src/views/Borrow/borrowDataStatus.test.ts
@@ -99,6 +99,16 @@ describe('deriveBorrowDataStatus', () => {
     ).toBe(EBorrowDataStatus.LoadingReserves);
   });
 
+  it('waits for account resolution before creating a reserves fetch scope', () => {
+    expect(
+      deriveBorrowDataStatus({
+        ...settledActiveState,
+        hasFetchKey: false,
+        shouldWaitForAccount: true,
+      }),
+    ).toBe(EBorrowDataStatus.WaitingForAccount);
+  });
+
   it('keeps a cacheless active scope pending before its request effect runs', () => {
     const status = deriveBorrowDataStatus(settledActiveState);
 

--- a/packages/kit/src/views/Borrow/borrowDataStatus.ts
+++ b/packages/kit/src/views/Borrow/borrowDataStatus.ts
@@ -45,8 +45,9 @@ export function deriveBorrowDataStatus({
     }
     return EBorrowDataStatus.Refreshing;
   }
-  if (!hasMarket || !hasFetchKey) return EBorrowDataStatus.Idle;
+  if (!hasMarket) return EBorrowDataStatus.Idle;
   if (shouldWaitForAccount) return EBorrowDataStatus.WaitingForAccount;
+  if (!hasFetchKey) return EBorrowDataStatus.Idle;
 
   // The request starts in a passive effect. Keep the new scope pending during
   // the render before usePromiseResult publishes its loading flag.

--- a/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
@@ -7,10 +7,6 @@ import { isEmpty } from 'lodash';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useRouteIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
-import {
-  EAppEventBusNames,
-  appEventBus,
-} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import type { IBorrowReserveItem } from '@onekeyhq/shared/types/staking';
 
@@ -36,7 +32,6 @@ import {
 
 const BORROW_POLLING_INTERVAL = 1 * 60 * 1000; // 1 minute
 const BORROW_STALE_TTL = BORROW_POLLING_INTERVAL;
-const BORROW_DERIVE_TYPE_REFRESH_DELAY_MS = 300;
 
 type IScopedBorrowReservesResult = {
   scopeKey: string;
@@ -127,46 +122,6 @@ export const BorrowDataGate = ({
     networkId: market?.networkId,
   });
 
-  useEffect(() => {
-    if (!market?.networkId) {
-      return undefined;
-    }
-
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const refreshAccountAfterDeriveTypeChanged = () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      timer = setTimeout(() => {
-        timer = undefined;
-        void refreshAccount({ alwaysSetState: true });
-      }, BORROW_DERIVE_TYPE_REFRESH_DELAY_MS);
-    };
-
-    appEventBus.on(
-      EAppEventBusNames.GlobalDeriveTypeUpdate,
-      refreshAccountAfterDeriveTypeChanged,
-    );
-    appEventBus.on(
-      EAppEventBusNames.NetworkDeriveTypeChanged,
-      refreshAccountAfterDeriveTypeChanged,
-    );
-
-    return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      appEventBus.off(
-        EAppEventBusNames.GlobalDeriveTypeUpdate,
-        refreshAccountAfterDeriveTypeChanged,
-      );
-      appEventBus.off(
-        EAppEventBusNames.NetworkDeriveTypeChanged,
-        refreshAccountAfterDeriveTypeChanged,
-      );
-    };
-  }, [market?.networkId, refreshAccount]);
-
   const { fetchReserves } = useBorrowReserves();
   const lastFetchKeyRef = useRef<string | null>(null);
   const prevFetchKeyRef = useRef<string | null>(null);
@@ -198,12 +153,19 @@ export const BorrowDataGate = ({
     (hasAccountContext && scopedEarnAccountData === undefined);
   const fetchKey = useMemo(
     () =>
-      !isEmpty(market)
+      !shouldWaitForAccount && !isEmpty(market)
         ? `${marketProvider}-${marketNetworkId}-${marketAddress}-${
             accountId ?? 'public'
           }`
         : null,
-    [market, marketProvider, marketNetworkId, marketAddress, accountId],
+    [
+      accountId,
+      market,
+      marketAddress,
+      marketNetworkId,
+      marketProvider,
+      shouldWaitForAccount,
+    ],
   );
   const reservesSWRKey = useMemo(
     () =>

--- a/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
@@ -11,6 +11,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import type { IBorrowReserveItem } from '@onekeyhq/shared/types/staking';
 
 import { useEarnAccount } from '../../Staking/hooks/useEarnAccount';
@@ -36,6 +37,11 @@ import {
 const BORROW_POLLING_INTERVAL = 1 * 60 * 1000; // 1 minute
 const BORROW_STALE_TTL = BORROW_POLLING_INTERVAL;
 const BORROW_DERIVE_TYPE_REFRESH_DELAY_MS = 300;
+
+type IScopedBorrowReservesResult = {
+  scopeKey: string;
+  data: IBorrowReserveItem;
+};
 
 export const BorrowDataGate = ({
   children,
@@ -77,11 +83,11 @@ export const BorrowDataGate = ({
     setBorrowDataStatus,
   } = useBorrowContext();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setMarkets(availableMarkets);
   }, [availableMarkets, setMarkets]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setMarket((currentMarket) => {
       if (!availableMarkets.length) {
         return currentMarket ? null : currentMarket;
@@ -166,7 +172,6 @@ export const BorrowDataGate = ({
   const prevFetchKeyRef = useRef<string | null>(null);
   const lastReservesUpdatedAtRef = useRef<number | null>(null);
   const reservesResultRef = useRef<IBorrowReserveItem | undefined>(undefined);
-  const reservesResultOwnerKeyRef = useRef<string | null>(null);
   const reservesRequestIdRef = useRef(0);
   const forceRefreshCounterRef = useRef(0);
   const lastForceRefreshCounterRef = useRef(0);
@@ -200,6 +205,18 @@ export const BorrowDataGate = ({
         : null,
     [market, marketProvider, marketNetworkId, marketAddress, accountId],
   );
+  const reservesSWRKey = useMemo(
+    () =>
+      fetchKey && marketProvider && marketNetworkId && marketAddress
+        ? swrKeys.borrowReserves({
+            provider: marketProvider,
+            networkId: marketNetworkId,
+            marketAddress,
+            accountId,
+          })
+        : undefined,
+    [accountId, fetchKey, marketAddress, marketNetworkId, marketProvider],
+  );
 
   // Invalidate before usePromiseResult reruns for the new key; a later effect
   // can let that rerun reuse the previous account's still-fresh TTL cache.
@@ -208,7 +225,6 @@ export const BorrowDataGate = ({
     reservesRequestIdRef.current += 1;
     lastReservesUpdatedAtRef.current = null;
     reservesResultRef.current = undefined;
-    reservesResultOwnerKeyRef.current = null;
   }
 
   // Reset staleness on modal dismiss so revalidateOnFocus triggers a fresh fetch.
@@ -232,7 +248,7 @@ export const BorrowDataGate = ({
     isLoading: reservesLoading = true,
     run: refreshReserves,
   } = usePromiseResult(
-    async () => {
+    async (): Promise<IScopedBorrowReservesResult | undefined> => {
       if (
         !fetchKey ||
         !marketProvider ||
@@ -240,12 +256,16 @@ export const BorrowDataGate = ({
         !marketAddress ||
         shouldWaitForAccount
       ) {
-        return reservesResultRef.current;
+        return fetchKey && reservesResultRef.current
+          ? { scopeKey: fetchKey, data: reservesResultRef.current }
+          : undefined;
       }
       const shouldForceRefresh =
         forceRefreshCounterRef.current > lastForceRefreshCounterRef.current;
       if (!isViewActiveRef.current && !shouldForceRefresh) {
-        return reservesResultRef.current;
+        return reservesResultRef.current
+          ? { scopeKey: fetchKey, data: reservesResultRef.current }
+          : undefined;
       }
       const lastUpdatedAt = lastReservesUpdatedAtRef.current;
       const isStale =
@@ -254,7 +274,9 @@ export const BorrowDataGate = ({
       const hasNoCache = reservesResultRef.current === undefined;
       const shouldFetch = shouldForceRefresh || isStale || hasNoCache;
       if (!shouldFetch) {
-        return reservesResultRef.current;
+        return reservesResultRef.current
+          ? { scopeKey: fetchKey, data: reservesResultRef.current }
+          : undefined;
       }
       lastForceRefreshCounterRef.current = forceRefreshCounterRef.current;
       const requestKey = fetchKey;
@@ -276,12 +298,13 @@ export const BorrowDataGate = ({
           accountId,
         });
         if (!isCurrentRequest()) {
-          return reservesResultRef.current;
+          return reservesResultRef.current
+            ? { scopeKey: fetchKey, data: reservesResultRef.current }
+            : undefined;
         }
         reservesResultRef.current = result;
-        reservesResultOwnerKeyRef.current = requestKey;
         lastReservesUpdatedAtRef.current = Date.now();
-        return result;
+        return { scopeKey: requestKey, data: result };
       } catch (error) {
         if (isCurrentRequest()) {
           setReservesErrorOwnerKey(requestKey);
@@ -301,18 +324,26 @@ export const BorrowDataGate = ({
     {
       watchLoading: true,
       checkIsFocused: true,
-      undefinedResultIfReRun: true,
+      // The SWR entry is scoped by the complete request identity, so keep it
+      // visible while the authoritative refresh runs instead of returning the
+      // page to independently loading skeletons.
+      undefinedResultIfReRun: false,
       undefinedResultIfError: true,
       pollingInterval: isViewActive ? BORROW_POLLING_INTERVAL : undefined,
       revalidateOnFocus: true,
       alwaysSetState: true,
+      swrKey: reservesSWRKey,
+      swrShouldPersist: (result) => Boolean(result?.data.overview),
     },
   );
   const ownedReservesResult = getOwnedBorrowReservesResult({
-    result: reservesResult,
-    resultOwnerKey: reservesResultOwnerKeyRef.current,
+    result: reservesResult?.data,
+    resultOwnerKey: reservesResult?.scopeKey ?? null,
     currentKey: fetchKey,
   });
+  if (ownedReservesResult !== undefined && fetchKey) {
+    reservesResultRef.current = ownedReservesResult;
+  }
 
   const refreshReservesWithForce = useMemo(() => {
     return async () => {
@@ -326,13 +357,17 @@ export const BorrowDataGate = ({
       deriveBorrowDataStatus({
         isViewActive,
         wasViewActive: wasActiveRef.current,
-        hasCachedReserves: Boolean(prevReservesDataRef.current),
+        hasCachedReserves: Boolean(
+          prevReservesDataRef.current || ownedReservesResult,
+        ),
         marketsLoading,
         hasMarket: Boolean(market),
         hasFetchKey: Boolean(fetchKey),
         shouldWaitForAccount,
         reservesLoading,
-        isCurrentFetchKey: lastFetchKeyRef.current === fetchKey,
+        isCurrentFetchKey:
+          lastFetchKeyRef.current === fetchKey ||
+          ownedReservesResult !== undefined,
         hasOwnedReservesResult: ownedReservesResult !== undefined,
         hasReservesError: reservesErrorOwnerKey === fetchKey,
       }),
@@ -396,12 +431,12 @@ export const BorrowDataGate = ({
     let dataToSet: IBorrowReserveItem | null = prevReservesDataRef.current;
     if (lastFetchKeyRef.current !== fetchKey) {
       lastFetchKeyRef.current = fetchKey;
-      dataToSet = null;
+      dataToSet = ownedReservesResult ?? null;
     } else if (
       dataStatus === EBorrowDataStatus.LoadingMarkets ||
       dataStatus === EBorrowDataStatus.WaitingForAccount
     ) {
-      dataToSet = null;
+      dataToSet = ownedReservesResult ?? null;
     } else if (
       dataStatus === EBorrowDataStatus.Ready &&
       ownedReservesResult !== undefined

--- a/packages/kit/src/views/Borrow/hooks/useBorrowEModeStatus.ts
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowEModeStatus.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import { EBorrowProviderEnum } from '@onekeyhq/shared/types/staking';
 import type { IBorrowEModeStatus } from '@onekeyhq/shared/types/staking';
 
@@ -50,6 +51,9 @@ export const useBorrowEModeStatus = ({
     [accountId, enabled, marketAddress, networkId, provider],
   );
   const canRequestStatus = Boolean(requestParams);
+  const swrKey = requestParams
+    ? swrKeys.borrowEModeStatus(requestParams)
+    : undefined;
   const {
     result: scopedResult,
     run,
@@ -89,6 +93,9 @@ export const useBorrowEModeStatus = ({
       checkIsFocused: true,
       revalidateOnFocus: true,
       undefinedResultIfError: true,
+      swrKey,
+      swrShouldPersist: (result) =>
+        result?.state === 'resolved' && Boolean(result.eModeStatus),
     },
   );
 

--- a/packages/kit/src/views/Borrow/hooks/useBorrowHealthFactor.ts
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowHealthFactor.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import type { IBorrowHealthFactor } from '@onekeyhq/shared/types/staking';
 
 interface IUseBorrowHealthFactorParams {
@@ -42,6 +43,9 @@ export const useBorrowHealthFactor = ({
         : null,
     [accountId, enabled, marketAddress, networkId, provider],
   );
+  const swrKey = requestParams
+    ? swrKeys.borrowHealthFactor(requestParams)
+    : undefined;
   const lastSuccessfulResultRef = useRef<{
     scopeKey: string;
     data: IBorrowHealthFactor;
@@ -83,6 +87,9 @@ export const useBorrowHealthFactor = ({
       watchLoading: true,
       pollingInterval: POLLING_INTERVAL,
       revalidateOnFocus: true,
+      swrKey,
+      swrShouldPersist: (result) =>
+        result?.state === 'resolved' && Boolean(result.data),
       // Fix: Ensure API responses update state even when page loses focus during request
       alwaysSetState: true,
     },

--- a/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.test.tsx
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => {
 });
 
 jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
   const state: {
     current: {
       result: unknown[];
@@ -22,6 +23,8 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
       run: jest.Mock;
     };
     method?: () => Promise<unknown[]>;
+    firstRunResult?: unknown[];
+    firstRunPromise?: Promise<void>;
   } = {
     current: { result: [], isLoading: false, run: jest.fn() },
   };
@@ -34,12 +37,20 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
   return {
     usePromiseResult: (method: () => Promise<unknown[]>) => {
       state.method = method;
+      React.useEffect(() => {
+        state.firstRunPromise = method().then((result) => {
+          state.firstRunResult = result;
+        });
+        // The real hook reruns from its deps effect. This mock intentionally
+        // registers at the same hook position to preserve effect ordering.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
       return state.current;
     },
   };
 });
 
-import { renderHook } from '@testing-library/react-native';
+import { act, renderHook } from '@testing-library/react-native';
 
 import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
 
@@ -54,6 +65,8 @@ const promiseResultMock = (
         run: jest.Mock;
       };
       method?: () => Promise<IBorrowMarketItem[]>;
+      firstRunResult?: IBorrowMarketItem[];
+      firstRunPromise?: Promise<void>;
     };
   }
 ).__borrowMarketsPromiseResultMock;
@@ -71,6 +84,8 @@ describe('useBorrowMarkets SWR hydration', () => {
       run: jest.fn(),
     };
     promiseResultMock.method = undefined;
+    promiseResultMock.firstRunResult = undefined;
+    promiseResultMock.firstRunPromise = undefined;
     serviceMock.mockReset();
   });
 
@@ -89,7 +104,11 @@ describe('useBorrowMarkets SWR hydration', () => {
 
     const { result } = renderHook(() => useBorrowMarkets({ isActive: false }));
 
-    await expect(promiseResultMock.method?.()).resolves.toBe(cachedMarkets);
+    await act(async () => {
+      await promiseResultMock.firstRunPromise;
+    });
+
+    expect(promiseResultMock.firstRunResult).toBe(cachedMarkets);
     expect(result.current.markets).toBe(cachedMarkets);
     expect(serviceMock).not.toHaveBeenCalled();
   });

--- a/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.test.tsx
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.test.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable import/first */
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => {
+  const getBorrowMarkets = jest.fn();
+  (
+    globalThis as unknown as {
+      __borrowMarketsServiceMock: jest.Mock;
+    }
+  ).__borrowMarketsServiceMock = getBorrowMarkets;
+
+  return {
+    __esModule: true,
+    default: { serviceStaking: { getBorrowMarkets } },
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
+  const state: {
+    current: {
+      result: unknown[];
+      isLoading: boolean;
+      run: jest.Mock;
+    };
+    method?: () => Promise<unknown[]>;
+  } = {
+    current: { result: [], isLoading: false, run: jest.fn() },
+  };
+  (
+    globalThis as unknown as {
+      __borrowMarketsPromiseResultMock: typeof state;
+    }
+  ).__borrowMarketsPromiseResultMock = state;
+
+  return {
+    usePromiseResult: (method: () => Promise<unknown[]>) => {
+      state.method = method;
+      return state.current;
+    },
+  };
+});
+
+import { renderHook } from '@testing-library/react-native';
+
+import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
+
+import { useBorrowMarkets } from './useBorrowMarkets';
+
+const promiseResultMock = (
+  globalThis as unknown as {
+    __borrowMarketsPromiseResultMock: {
+      current: {
+        result: IBorrowMarketItem[];
+        isLoading: boolean;
+        run: jest.Mock;
+      };
+      method?: () => Promise<IBorrowMarketItem[]>;
+    };
+  }
+).__borrowMarketsPromiseResultMock;
+const serviceMock = (
+  globalThis as unknown as {
+    __borrowMarketsServiceMock: jest.Mock;
+  }
+).__borrowMarketsServiceMock;
+
+describe('useBorrowMarkets SWR hydration', () => {
+  beforeEach(() => {
+    promiseResultMock.current = {
+      result: [],
+      isLoading: false,
+      run: jest.fn(),
+    };
+    promiseResultMock.method = undefined;
+    serviceMock.mockReset();
+  });
+
+  it('keeps a hydrated snapshot when the hidden Borrow page first runs', async () => {
+    const cachedMarkets = [
+      {
+        provider: 'aave',
+        networkId: 'evm--1',
+        name: 'Aave',
+        logoURI: 'https://example.com/aave.png',
+        marketAddress: '0xmarket',
+        network: { name: 'Ethereum' },
+      },
+    ] as IBorrowMarketItem[];
+    promiseResultMock.current.result = cachedMarkets;
+
+    const { result } = renderHook(() => useBorrowMarkets({ isActive: false }));
+
+    await expect(promiseResultMock.method?.()).resolves.toBe(cachedMarkets);
+    expect(result.current.markets).toBe(cachedMarkets);
+    expect(serviceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.ts
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.ts
@@ -54,11 +54,12 @@ export const useBorrowMarkets = ({
     },
   );
 
-  useEffect(() => {
-    if (markets) {
-      marketsRef.current = markets;
-    }
-  }, [markets]);
+  // usePromiseResult starts its request effect before effects declared below.
+  // Mirror a synchronously hydrated SWR result during render so an inactive
+  // first run returns that snapshot instead of overwriting it with [].
+  if (markets) {
+    marketsRef.current = markets;
+  }
 
   const refetchMarkets = useCallback(async () => {
     lastUpdatedAtRef.current = null;

--- a/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.ts
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
@@ -43,6 +44,8 @@ export const useBorrowMarkets = ({
     [],
     {
       initResult: defaultMarkets,
+      swrKey: swrKeys.borrowMarkets(),
+      swrShouldPersist: (result) => result.length > 0,
       watchLoading: true,
       checkIsFocused: true,
       undefinedResultIfReRun: false,

--- a/packages/kit/src/views/Borrow/hooks/useBorrowRewards.ts
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowRewards.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import type { IBorrowRewards } from '@onekeyhq/shared/types/staking';
 
 type IScopedBorrowRewardsResult = {
@@ -38,6 +39,9 @@ export const useBorrowRewards = ({
         : null,
     [accountId, enabled, marketAddress, networkId, provider],
   );
+  const swrKey = requestParams
+    ? swrKeys.borrowRewards(requestParams)
+    : undefined;
   const lastSuccessfulResultRef = useRef<{
     scopeKey: string;
     data: IBorrowRewards;
@@ -78,6 +82,9 @@ export const useBorrowRewards = ({
       initResult: null,
       watchLoading: true,
       alwaysSetState: true,
+      swrKey,
+      swrShouldPersist: (result) =>
+        result?.state === 'resolved' && Boolean(result.data),
     },
   );
   const hasSettledCurrentScope = scopedResult?.scopeKey === scopeKey;

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.test.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.test.tsx
@@ -1,0 +1,117 @@
+/* eslint-disable import/first */
+
+jest.mock('react-intl', () => {
+  const locale = { current: 'en-US' };
+  (
+    globalThis as unknown as {
+      __protocolDetailLocaleMock: typeof locale;
+    }
+  ).__protocolDetailLocaleMock = locale;
+  return { useIntl: () => ({ locale: locale.current }) };
+});
+
+jest.mock('@onekeyhq/kit/src/components/Currency', () => {
+  const currency = { current: 'usd' };
+  (
+    globalThis as unknown as {
+      __protocolDetailCurrencyMock: typeof currency;
+    }
+  ).__protocolDetailCurrencyMock = currency;
+  return { useCurrency: () => ({ id: currency.current }) };
+});
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: { serviceStaking: { getProtocolDetailsV2: jest.fn() } },
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Staking/hooks/useEarnAccount', () => ({
+  useEarnAccount: () => ({
+    earnAccount: undefined,
+    refreshAccount: jest.fn(),
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
+  const state: {
+    deps?: unknown[];
+    options?: { swrKey?: string };
+  } = {};
+  (
+    globalThis as unknown as {
+      __protocolDetailPromiseResultMock: typeof state;
+    }
+  ).__protocolDetailPromiseResultMock = state;
+
+  return {
+    usePromiseResult: (
+      _method: () => Promise<unknown>,
+      deps: unknown[],
+      options: { swrKey?: string },
+    ) => {
+      state.deps = deps;
+      state.options = options;
+      return { result: undefined, isLoading: false, run: jest.fn() };
+    },
+  };
+});
+
+import { renderHook } from '@testing-library/react-native';
+
+import { useProtocolDetailData } from './useProtocolDetailData';
+
+const localeMock = (
+  globalThis as unknown as {
+    __protocolDetailLocaleMock: { current: string };
+  }
+).__protocolDetailLocaleMock;
+const currencyMock = (
+  globalThis as unknown as {
+    __protocolDetailCurrencyMock: { current: string };
+  }
+).__protocolDetailCurrencyMock;
+const promiseResultMock = (
+  globalThis as unknown as {
+    __protocolDetailPromiseResultMock: {
+      deps?: unknown[];
+      options?: { swrKey?: string };
+    };
+  }
+).__protocolDetailPromiseResultMock;
+
+describe('useProtocolDetailData cache identity', () => {
+  beforeEach(() => {
+    localeMock.current = 'en-US';
+    currencyMock.current = 'usd';
+    promiseResultMock.deps = undefined;
+    promiseResultMock.options = undefined;
+  });
+
+  it('reruns in a new cache scope after locale or currency changes', () => {
+    const { rerender } = renderHook(() =>
+      useProtocolDetailData({
+        accountId: '',
+        networkId: 'evm--1',
+        indexedAccountId: undefined,
+        symbol: 'USDC',
+        provider: 'AAVE',
+        vault: '0xVault',
+      }),
+    );
+
+    expect(promiseResultMock.deps).toEqual(
+      expect.arrayContaining(['en-US', 'usd']),
+    );
+    expect(promiseResultMock.options?.swrKey).toContain(':en-us:usd');
+
+    localeMock.current = 'zh-CN';
+    currencyMock.current = 'cny';
+    rerender(undefined);
+
+    expect(promiseResultMock.deps).toEqual(
+      expect.arrayContaining(['zh-CN', 'cny']),
+    );
+    expect(promiseResultMock.options?.swrKey).toContain(':zh-cn:cny');
+  });
+});

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.ts
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
+import { useIntl } from 'react-intl';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useEarnAccount } from '@onekeyhq/kit/src/views/Staking/hooks/useEarnAccount';
 import { buildLocalTxStatusSyncId } from '@onekeyhq/kit/src/views/Staking/utils/utils';
@@ -28,6 +30,8 @@ export function useProtocolDetailData({
   provider: string;
   vault: string | undefined;
 }) {
+  const { locale } = useIntl();
+  const { id: currencyId } = useCurrency();
   const {
     earnAccount,
     refreshAccount,
@@ -51,7 +55,10 @@ export function useProtocolDetailData({
         provider,
         vault,
       }),
-    [networkId, symbol, provider, vault],
+    // Locale and currency invalidate interceptor-owned request headers even
+    // though getProtocolDetailsV2 does not receive them as explicit params.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [networkId, symbol, provider, vault, locale, currencyId],
     {
       watchLoading: true,
       swrKey: swrKeys.earnProtocolDetail({
@@ -59,6 +66,8 @@ export function useProtocolDetailData({
         symbol,
         provider,
         vault,
+        locale,
+        currencyId,
       }),
       swrShouldPersist: (result) =>
         Boolean(result.protocol || result.subscriptionValue?.token),

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.ts
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.ts
@@ -6,6 +6,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useEarnAccount } from '@onekeyhq/kit/src/views/Staking/hooks/useEarnAccount';
 import { buildLocalTxStatusSyncId } from '@onekeyhq/kit/src/views/Staking/utils/utils';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import type {
   IEarnTokenInfo,
   IEarnWithdrawActionIcon,
@@ -51,7 +52,17 @@ export function useProtocolDetailData({
         vault,
       }),
     [networkId, symbol, provider, vault],
-    { watchLoading: true },
+    {
+      watchLoading: true,
+      swrKey: swrKeys.earnProtocolDetail({
+        networkId,
+        symbol,
+        provider,
+        vault,
+      }),
+      swrShouldPersist: (result) =>
+        Boolean(result.protocol || result.subscriptionValue?.token),
+    },
   );
 
   const tokenInfo = useMemo<IEarnTokenInfo | undefined>(() => {

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -47,7 +47,7 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
     deriveRun: jest.Mock;
     accountMethod?: () => Promise<unknown>;
     accountDeps?: unknown[];
-    accountOptions?: { swrKey?: string };
+    accountOptions?: { swrKey?: string; watchLoading?: boolean };
     accountRun: jest.Mock;
   } = {
     deriveResult: 'default',
@@ -120,7 +120,7 @@ const promiseResultMock = (
       deriveRun: jest.Mock;
       accountMethod?: () => Promise<unknown>;
       accountDeps?: unknown[];
-      accountOptions?: { swrKey?: string };
+      accountOptions?: { swrKey?: string; watchLoading?: boolean };
       accountRun: jest.Mock;
     };
   }
@@ -158,6 +158,7 @@ describe('useEarnAccount cache identity', () => {
 
     expect(promiseResultMock.deriveOptions?.undefinedResultIfReRun).toBe(true);
     expect(promiseResultMock.accountOptions?.swrKey).toBeUndefined();
+    expect(promiseResultMock.accountOptions?.watchLoading).toBe(true);
 
     promiseResultMock.deriveResult = 'default';
     rerender(undefined);

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -201,12 +201,18 @@ describe('useEarnAccount cache identity', () => {
   });
 
   it('keeps an HD accountId with indexedAccountId in the derive scope', async () => {
-    renderHook(() =>
+    promiseResultMock.deriveResult = undefined;
+    const { rerender } = renderHook(() =>
       useEarnAccount({
         networkId: 'evm--1',
         accountId: 'hd-1--m/44/60/0/0/0',
       }),
     );
+
+    expect(promiseResultMock.accountOptions?.swrKey).toBeUndefined();
+
+    promiseResultMock.deriveResult = 'default';
+    rerender(undefined);
 
     expect(promiseResultMock.accountOptions?.swrKey).toBe(
       'earnAccount:v3:evm--1:hd-1--m/44/60/0/0/0:wallet-1--1:default:1',

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -143,7 +143,7 @@ describe('useEarnAccount cache identity', () => {
     promiseResultMock.accountDeps = undefined;
     promiseResultMock.accountOptions = undefined;
     promiseResultMock.accountRun.mockReset();
-    earnAccountServiceMock.mockResolvedValue(null);
+    earnAccountServiceMock.mockReset().mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -198,5 +198,36 @@ describe('useEarnAccount cache identity', () => {
       alwaysSetState: true,
     });
     expect(promiseResultMock.accountRun).not.toHaveBeenCalled();
+  });
+
+  it('keeps an HD accountId with indexedAccountId in the derive scope', async () => {
+    renderHook(() =>
+      useEarnAccount({
+        networkId: 'evm--1',
+        accountId: 'hd-1--m/44/60/0/0/0',
+      }),
+    );
+
+    expect(promiseResultMock.accountOptions?.swrKey).toBe(
+      'earnAccount:v3:evm--1:hd-1--m/44/60/0/0/0:wallet-1--1:default:1',
+    );
+
+    await promiseResultMock.accountMethod?.();
+
+    expect(earnAccountServiceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 'hd-1--m/44/60/0/0/0',
+        indexedAccountId: 'wallet-1--1',
+        deriveType: 'default',
+      }),
+    );
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.NetworkDeriveTypeChanged, undefined);
+    });
+
+    expect(promiseResultMock.deriveRun).toHaveBeenCalledWith({
+      alwaysSetState: true,
+    });
   });
 });

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -29,7 +29,8 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
   const state: {
     deps?: unknown[];
     options?: { swrKey?: string };
-  } = {};
+    run: jest.Mock;
+  } = { run: jest.fn() };
   (
     globalThis as unknown as {
       __earnAccountPromiseResultMock: typeof state;
@@ -44,12 +45,17 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
     ) => {
       state.deps = deps;
       state.options = options;
-      return { result: undefined, run: jest.fn(), isLoading: false };
+      return { result: undefined, run: state.run, isLoading: false };
     },
   };
 });
 
-import { renderHook } from '@testing-library/react-native';
+import { act, renderHook } from '@testing-library/react-native';
+
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 
 import { useEarnAccount } from './useEarnAccount';
 
@@ -69,29 +75,45 @@ const promiseResultMock = (
     __earnAccountPromiseResultMock: {
       deps?: unknown[];
       options?: { swrKey?: string };
+      run: jest.Mock;
     };
   }
 ).__earnAccountPromiseResultMock;
 
 describe('useEarnAccount cache identity', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     selectedAccountMock.current.deriveType = 'default';
     promiseResultMock.deps = undefined;
     promiseResultMock.options = undefined;
+    promiseResultMock.run.mockReset();
   });
 
-  it('reruns and swaps cache scope when the selected derive type changes', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('ignores another selector network derive type and refreshes from events', () => {
     const { rerender } = renderHook(() =>
       useEarnAccount({ networkId: 'evm--1' }),
     );
 
-    expect(promiseResultMock.deps).toContain('default');
-    expect(promiseResultMock.options?.swrKey).toContain(':default:');
+    const initialDeps = promiseResultMock.deps;
+    const initialSWRKey = promiseResultMock.options?.swrKey;
 
     selectedAccountMock.current.deriveType = 'BIP44';
     rerender(undefined);
 
-    expect(promiseResultMock.deps).toContain('BIP44');
-    expect(promiseResultMock.options?.swrKey).toContain(':BIP44:');
+    expect(promiseResultMock.deps).toEqual(initialDeps);
+    expect(promiseResultMock.options?.swrKey).toBe(initialSWRKey);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.GlobalDeriveTypeUpdate, undefined);
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(promiseResultMock.run).toHaveBeenCalledWith({
+      alwaysSetState: true,
+    });
   });
 });

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -1,9 +1,21 @@
 /* eslint-disable import/first */
 
-jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
-  __esModule: true,
-  default: { serviceStaking: { getEarnAccount: jest.fn() } },
-}));
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => {
+  const getEarnAccount = jest.fn();
+  (
+    globalThis as unknown as {
+      __earnAccountServiceMock: typeof getEarnAccount;
+    }
+  ).__earnAccountServiceMock = getEarnAccount;
+
+  return {
+    __esModule: true,
+    default: {
+      serviceNetwork: { getGlobalDeriveTypeOfNetwork: jest.fn() },
+      serviceStaking: { getEarnAccount },
+    },
+  };
+});
 
 jest.mock('@onekeyhq/kit/src/states/jotai/contexts/accountSelector', () => {
   const selectedAccount = {
@@ -27,10 +39,21 @@ jest.mock('@onekeyhq/kit/src/states/jotai/contexts/accountSelector', () => {
 
 jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
   const state: {
-    deps?: unknown[];
-    options?: { swrKey?: string };
-    run: jest.Mock;
-  } = { run: jest.fn() };
+    deriveResult?: string;
+    deriveDeps?: unknown[];
+    deriveOptions?: {
+      undefinedResultIfReRun?: boolean;
+    };
+    deriveRun: jest.Mock;
+    accountMethod?: () => Promise<unknown>;
+    accountDeps?: unknown[];
+    accountOptions?: { swrKey?: string };
+    accountRun: jest.Mock;
+  } = {
+    deriveResult: 'default',
+    deriveRun: jest.fn(),
+    accountRun: jest.fn(),
+  };
   (
     globalThis as unknown as {
       __earnAccountPromiseResultMock: typeof state;
@@ -41,11 +64,29 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
     usePromiseResult: (
       _method: () => Promise<unknown>,
       deps: unknown[],
-      options: { swrKey?: string },
+      options: {
+        swrKey?: string;
+        swrShouldPersist?: (result: unknown) => boolean;
+        undefinedResultIfReRun?: boolean;
+      },
     ) => {
-      state.deps = deps;
-      state.options = options;
-      return { result: undefined, run: state.run, isLoading: false };
+      if (options.swrShouldPersist) {
+        state.accountMethod = _method;
+        state.accountDeps = deps;
+        state.accountOptions = options;
+        return {
+          result: undefined,
+          run: state.accountRun,
+          isLoading: false,
+        };
+      }
+      state.deriveDeps = deps;
+      state.deriveOptions = options;
+      return {
+        result: state.deriveResult,
+        run: state.deriveRun,
+        isLoading: false,
+      };
     },
   };
 });
@@ -73,47 +114,89 @@ const selectedAccountMock = (
 const promiseResultMock = (
   globalThis as unknown as {
     __earnAccountPromiseResultMock: {
-      deps?: unknown[];
-      options?: { swrKey?: string };
-      run: jest.Mock;
+      deriveResult?: string;
+      deriveDeps?: unknown[];
+      deriveOptions?: { undefinedResultIfReRun?: boolean };
+      deriveRun: jest.Mock;
+      accountMethod?: () => Promise<unknown>;
+      accountDeps?: unknown[];
+      accountOptions?: { swrKey?: string };
+      accountRun: jest.Mock;
     };
   }
 ).__earnAccountPromiseResultMock;
+const earnAccountServiceMock = (
+  globalThis as unknown as {
+    __earnAccountServiceMock: jest.Mock;
+  }
+).__earnAccountServiceMock;
 
 describe('useEarnAccount cache identity', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     selectedAccountMock.current.deriveType = 'default';
-    promiseResultMock.deps = undefined;
-    promiseResultMock.options = undefined;
-    promiseResultMock.run.mockReset();
+    promiseResultMock.deriveResult = 'default';
+    promiseResultMock.deriveDeps = undefined;
+    promiseResultMock.deriveOptions = undefined;
+    promiseResultMock.deriveRun.mockReset();
+    promiseResultMock.accountMethod = undefined;
+    promiseResultMock.accountDeps = undefined;
+    promiseResultMock.accountOptions = undefined;
+    promiseResultMock.accountRun.mockReset();
+    earnAccountServiceMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it('ignores another selector network derive type and refreshes from events', () => {
+  it('keys and fetches with the authoritative derive type of the target network', async () => {
+    promiseResultMock.deriveResult = undefined;
     const { rerender } = renderHook(() =>
       useEarnAccount({ networkId: 'evm--1' }),
     );
 
-    const initialDeps = promiseResultMock.deps;
-    const initialSWRKey = promiseResultMock.options?.swrKey;
+    expect(promiseResultMock.deriveOptions?.undefinedResultIfReRun).toBe(true);
+    expect(promiseResultMock.accountOptions?.swrKey).toBeUndefined();
+
+    promiseResultMock.deriveResult = 'default';
+    rerender(undefined);
+
+    expect(promiseResultMock.accountOptions?.swrKey).toBe(
+      'earnAccount:v3:evm--1::wallet-1--1:default:1',
+    );
+
+    await promiseResultMock.accountMethod?.();
+
+    expect(earnAccountServiceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkId: 'evm--1',
+        indexedAccountId: 'wallet-1--1',
+        deriveType: 'default',
+      }),
+    );
 
     selectedAccountMock.current.deriveType = 'BIP44';
     rerender(undefined);
 
-    expect(promiseResultMock.deps).toEqual(initialDeps);
-    expect(promiseResultMock.options?.swrKey).toBe(initialSWRKey);
+    expect(promiseResultMock.accountOptions?.swrKey).toBe(
+      'earnAccount:v3:evm--1::wallet-1--1:default:1',
+    );
+
+    promiseResultMock.deriveResult = 'ledgerLive';
+    rerender(undefined);
+
+    expect(promiseResultMock.accountOptions?.swrKey).toBe(
+      'earnAccount:v3:evm--1::wallet-1--1:ledgerLive:1',
+    );
 
     act(() => {
       appEventBus.emit(EAppEventBusNames.GlobalDeriveTypeUpdate, undefined);
-      jest.advanceTimersByTime(300);
     });
 
-    expect(promiseResultMock.run).toHaveBeenCalledWith({
+    expect(promiseResultMock.deriveRun).toHaveBeenCalledWith({
       alwaysSetState: true,
     });
+    expect(promiseResultMock.accountRun).not.toHaveBeenCalled();
   });
 });

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -43,6 +43,7 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
     deriveDeps?: unknown[];
     deriveOptions?: {
       undefinedResultIfReRun?: boolean;
+      watchLoading?: boolean;
     };
     deriveRun: jest.Mock;
     accountMethod?: () => Promise<unknown>;
@@ -116,7 +117,10 @@ const promiseResultMock = (
     __earnAccountPromiseResultMock: {
       deriveResult?: string;
       deriveDeps?: unknown[];
-      deriveOptions?: { undefinedResultIfReRun?: boolean };
+      deriveOptions?: {
+        undefinedResultIfReRun?: boolean;
+        watchLoading?: boolean;
+      };
       deriveRun: jest.Mock;
       accountMethod?: () => Promise<unknown>;
       accountDeps?: unknown[];
@@ -148,6 +152,20 @@ describe('useEarnAccount cache identity', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it('keeps derive loading watched when the network arrives after mount', () => {
+    promiseResultMock.deriveResult = undefined;
+    const params: { networkId?: string } = {};
+    const { rerender } = renderHook(() => useEarnAccount(params));
+
+    expect(promiseResultMock.deriveOptions?.watchLoading).toBe(true);
+
+    params.networkId = 'evm--1';
+    rerender(undefined);
+
+    expect(promiseResultMock.deriveDeps).toEqual(['evm--1', true]);
+    expect(promiseResultMock.deriveOptions?.watchLoading).toBe(true);
   });
 
   it('keys and fetches with the authoritative derive type of the target network', async () => {

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.test.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable import/first */
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: { serviceStaking: { getEarnAccount: jest.fn() } },
+}));
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/accountSelector', () => {
+  const selectedAccount = {
+    current: {
+      indexedAccountId: 'wallet-1--1',
+      othersWalletAccountId: undefined,
+      deriveType: 'default',
+    },
+  };
+  (
+    globalThis as unknown as {
+      __earnSelectedAccountMock: typeof selectedAccount;
+    }
+  ).__earnSelectedAccountMock = selectedAccount;
+
+  return {
+    useActiveAccount: () => ({ activeAccount: { indexedAccount: undefined } }),
+    useSelectedAccount: () => ({ selectedAccount: selectedAccount.current }),
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
+  const state: {
+    deps?: unknown[];
+    options?: { swrKey?: string };
+  } = {};
+  (
+    globalThis as unknown as {
+      __earnAccountPromiseResultMock: typeof state;
+    }
+  ).__earnAccountPromiseResultMock = state;
+
+  return {
+    usePromiseResult: (
+      _method: () => Promise<unknown>,
+      deps: unknown[],
+      options: { swrKey?: string },
+    ) => {
+      state.deps = deps;
+      state.options = options;
+      return { result: undefined, run: jest.fn(), isLoading: false };
+    },
+  };
+});
+
+import { renderHook } from '@testing-library/react-native';
+
+import { useEarnAccount } from './useEarnAccount';
+
+const selectedAccountMock = (
+  globalThis as unknown as {
+    __earnSelectedAccountMock: {
+      current: {
+        indexedAccountId: string;
+        othersWalletAccountId?: string;
+        deriveType: string;
+      };
+    };
+  }
+).__earnSelectedAccountMock;
+const promiseResultMock = (
+  globalThis as unknown as {
+    __earnAccountPromiseResultMock: {
+      deps?: unknown[];
+      options?: { swrKey?: string };
+    };
+  }
+).__earnAccountPromiseResultMock;
+
+describe('useEarnAccount cache identity', () => {
+  beforeEach(() => {
+    selectedAccountMock.current.deriveType = 'default';
+    promiseResultMock.deps = undefined;
+    promiseResultMock.options = undefined;
+  });
+
+  it('reruns and swaps cache scope when the selected derive type changes', () => {
+    const { rerender } = renderHook(() =>
+      useEarnAccount({ networkId: 'evm--1' }),
+    );
+
+    expect(promiseResultMock.deps).toContain('default');
+    expect(promiseResultMock.options?.swrKey).toContain(':default:');
+
+    selectedAccountMock.current.deriveType = 'BIP44';
+    rerender(undefined);
+
+    expect(promiseResultMock.deps).toContain('BIP44');
+    expect(promiseResultMock.options?.swrKey).toContain(':BIP44:');
+  });
+});

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -1,10 +1,18 @@
+import { useEffect } from 'react';
+
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useActiveAccount,
   useSelectedAccount,
 } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
+
+const DERIVE_TYPE_REFRESH_DELAY_MS = 300;
 
 type IUseEarnAccountParams = {
   networkId?: string;
@@ -32,13 +40,14 @@ export function useEarnAccount({
   // bypassing the async activeAccount resolution delay.
   const resolvedIndexedAccountId =
     indexedAccountId || selectedAccount.indexedAccountId || indexedAccount?.id;
+  const deriveType = selectedAccount.deriveType;
   const swrKey =
     networkId && (resolvedAccountId || resolvedIndexedAccountId)
       ? swrKeys.earnAccount({
           networkId,
           accountId: resolvedAccountId,
           indexedAccountId: resolvedIndexedAccountId,
-          deriveType: selectedAccount.deriveType,
+          deriveType,
           btcOnlyTaproot,
         })
       : undefined;
@@ -62,7 +71,16 @@ export function useEarnAccount({
         }),
       };
     },
-    [networkId, resolvedAccountId, resolvedIndexedAccountId, btcOnlyTaproot],
+    // deriveType invalidates a request whose authoritative network-scoped
+    // value is resolved inside ServiceStaking rather than this closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      networkId,
+      resolvedAccountId,
+      resolvedIndexedAccountId,
+      deriveType,
+      btcOnlyTaproot,
+    ],
     {
       watchLoading: true,
       undefinedResultIfReRun: false,
@@ -70,6 +88,48 @@ export function useEarnAccount({
       swrShouldPersist: (result) => Boolean(result?.earnAccount),
     },
   );
+
+  useEffect(() => {
+    if (!networkId) {
+      return undefined;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const refreshAfterDeriveTypeChanged = () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = undefined;
+        // The service resolves the authoritative derive type for networkId.
+        void refreshAccount({ alwaysSetState: true });
+      }, DERIVE_TYPE_REFRESH_DELAY_MS);
+    };
+
+    appEventBus.on(
+      EAppEventBusNames.GlobalDeriveTypeUpdate,
+      refreshAfterDeriveTypeChanged,
+    );
+    appEventBus.on(
+      EAppEventBusNames.NetworkDeriveTypeChanged,
+      refreshAfterDeriveTypeChanged,
+    );
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      appEventBus.off(
+        EAppEventBusNames.GlobalDeriveTypeUpdate,
+        refreshAfterDeriveTypeChanged,
+      );
+      appEventBus.off(
+        EAppEventBusNames.NetworkDeriveTypeChanged,
+        refreshAfterDeriveTypeChanged,
+      );
+    };
+  }, [networkId, refreshAccount]);
+
   const earnAccount =
     earnAccountResult && earnAccountResult.networkId === networkId
       ? earnAccountResult.earnAccount

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -121,7 +121,7 @@ export function useEarnAccount({
       hasResolvedAccountScope,
     ],
     {
-      watchLoading: hasResolvedAccountScope,
+      watchLoading: true,
       undefinedResultIfReRun: false,
       swrKey,
       swrShouldPersist: (result) => Boolean(result?.earnAccount),

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -11,6 +11,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
@@ -41,7 +42,9 @@ export function useEarnAccount({
   const resolvedIndexedAccountId =
     indexedAccountId || selectedAccount.indexedAccountId || indexedAccount?.id;
   const isIndexedAccountScope = Boolean(
-    !resolvedAccountId && resolvedIndexedAccountId,
+    resolvedIndexedAccountId &&
+    (!resolvedAccountId ||
+      !accountUtils.isOthersAccount({ accountId: resolvedAccountId })),
   );
   const fixedDeriveType: IAccountDeriveTypes | undefined =
     isIndexedAccountScope &&

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -40,14 +40,12 @@ export function useEarnAccount({
   // bypassing the async activeAccount resolution delay.
   const resolvedIndexedAccountId =
     indexedAccountId || selectedAccount.indexedAccountId || indexedAccount?.id;
-  const deriveType = selectedAccount.deriveType;
   const swrKey =
     networkId && (resolvedAccountId || resolvedIndexedAccountId)
       ? swrKeys.earnAccount({
           networkId,
           accountId: resolvedAccountId,
           indexedAccountId: resolvedIndexedAccountId,
-          deriveType,
           btcOnlyTaproot,
         })
       : undefined;
@@ -71,16 +69,7 @@ export function useEarnAccount({
         }),
       };
     },
-    // deriveType invalidates a request whose authoritative network-scoped
-    // value is resolved inside ServiceStaking rather than this closure.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      networkId,
-      resolvedAccountId,
-      resolvedIndexedAccountId,
-      deriveType,
-      btcOnlyTaproot,
-    ],
+    [networkId, resolvedAccountId, resolvedIndexedAccountId, btcOnlyTaproot],
     {
       watchLoading: true,
       undefinedResultIfReRun: false,

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -4,6 +4,7 @@ import {
   useActiveAccount,
   useSelectedAccount,
 } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
 type IUseEarnAccountParams = {
   networkId?: string;
@@ -31,6 +32,16 @@ export function useEarnAccount({
   // bypassing the async activeAccount resolution delay.
   const resolvedIndexedAccountId =
     indexedAccountId || selectedAccount.indexedAccountId || indexedAccount?.id;
+  const swrKey =
+    networkId && (resolvedAccountId || resolvedIndexedAccountId)
+      ? swrKeys.earnAccount({
+          networkId,
+          accountId: resolvedAccountId,
+          indexedAccountId: resolvedIndexedAccountId,
+          deriveType: selectedAccount.deriveType,
+          btcOnlyTaproot,
+        })
+      : undefined;
 
   const {
     result: earnAccountResult,
@@ -52,7 +63,12 @@ export function useEarnAccount({
       };
     },
     [networkId, resolvedAccountId, resolvedIndexedAccountId, btcOnlyTaproot],
-    { watchLoading: true, undefinedResultIfReRun: true },
+    {
+      watchLoading: true,
+      undefinedResultIfReRun: false,
+      swrKey,
+      swrShouldPersist: (result) => Boolean(result?.earnAccount),
+    },
   );
   const earnAccount =
     earnAccountResult && earnAccountResult.networkId === networkId

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -6,13 +6,13 @@ import {
   useActiveAccount,
   useSelectedAccount,
 } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
-
-const DERIVE_TYPE_REFRESH_DELAY_MS = 300;
 
 type IUseEarnAccountParams = {
   networkId?: string;
@@ -40,12 +40,51 @@ export function useEarnAccount({
   // bypassing the async activeAccount resolution delay.
   const resolvedIndexedAccountId =
     indexedAccountId || selectedAccount.indexedAccountId || indexedAccount?.id;
+  const isIndexedAccountScope = Boolean(
+    !resolvedAccountId && resolvedIndexedAccountId,
+  );
+  const fixedDeriveType: IAccountDeriveTypes | undefined =
+    isIndexedAccountScope &&
+    networkId &&
+    btcOnlyTaproot &&
+    networkUtils.isBTCNetwork(networkId)
+      ? 'BIP86'
+      : undefined;
+  const shouldResolveNetworkDeriveType = Boolean(
+    isIndexedAccountScope && networkId && !fixedDeriveType,
+  );
+  const {
+    result: networkDeriveType,
+    run: refreshNetworkDeriveType,
+    isLoading: isDeriveTypeLoading,
+  } = usePromiseResult(
+    async () => {
+      if (!networkId || !shouldResolveNetworkDeriveType) {
+        return undefined;
+      }
+      return backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+        networkId,
+      });
+    },
+    [networkId, shouldResolveNetworkDeriveType],
+    {
+      watchLoading: shouldResolveNetworkDeriveType,
+      undefinedResultIfReRun: true,
+    },
+  );
+  const effectiveDeriveType = isIndexedAccountScope
+    ? fixedDeriveType || networkDeriveType
+    : undefined;
+  const hasResolvedAccountScope = Boolean(
+    resolvedAccountId || (resolvedIndexedAccountId && effectiveDeriveType),
+  );
   const swrKey =
-    networkId && (resolvedAccountId || resolvedIndexedAccountId)
+    networkId && hasResolvedAccountScope
       ? swrKeys.earnAccount({
           networkId,
           accountId: resolvedAccountId,
           indexedAccountId: resolvedIndexedAccountId,
+          deriveType: effectiveDeriveType,
           btcOnlyTaproot,
         })
       : undefined;
@@ -56,7 +95,7 @@ export function useEarnAccount({
     isLoading,
   } = usePromiseResult(
     async () => {
-      if (!networkId || (!resolvedAccountId && !resolvedIndexedAccountId)) {
+      if (!networkId || !hasResolvedAccountScope) {
         return undefined;
       }
       return {
@@ -65,13 +104,21 @@ export function useEarnAccount({
           accountId: resolvedAccountId,
           networkId,
           indexedAccountId: resolvedIndexedAccountId,
+          deriveType: effectiveDeriveType,
           btcOnlyTaproot,
         }),
       };
     },
-    [networkId, resolvedAccountId, resolvedIndexedAccountId, btcOnlyTaproot],
+    [
+      networkId,
+      resolvedAccountId,
+      resolvedIndexedAccountId,
+      effectiveDeriveType,
+      btcOnlyTaproot,
+      hasResolvedAccountScope,
+    ],
     {
-      watchLoading: true,
+      watchLoading: hasResolvedAccountScope,
       undefinedResultIfReRun: false,
       swrKey,
       swrShouldPersist: (result) => Boolean(result?.earnAccount),
@@ -79,20 +126,14 @@ export function useEarnAccount({
   );
 
   useEffect(() => {
-    if (!networkId) {
+    if (!networkId || !shouldResolveNetworkDeriveType) {
       return undefined;
     }
 
-    let timer: ReturnType<typeof setTimeout> | undefined;
     const refreshAfterDeriveTypeChanged = () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      timer = setTimeout(() => {
-        timer = undefined;
-        // The service resolves the authoritative derive type for networkId.
-        void refreshAccount({ alwaysSetState: true });
-      }, DERIVE_TYPE_REFRESH_DELAY_MS);
+      // Clear the previous derive scope before resolving the new authoritative
+      // value so stale account data cannot remain actionable during refresh.
+      void refreshNetworkDeriveType({ alwaysSetState: true });
     };
 
     appEventBus.on(
@@ -105,9 +146,6 @@ export function useEarnAccount({
     );
 
     return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
       appEventBus.off(
         EAppEventBusNames.GlobalDeriveTypeUpdate,
         refreshAfterDeriveTypeChanged,
@@ -117,7 +155,7 @@ export function useEarnAccount({
         refreshAfterDeriveTypeChanged,
       );
     };
-  }, [networkId, refreshAccount]);
+  }, [networkId, refreshNetworkDeriveType, shouldResolveNetworkDeriveType]);
 
   const earnAccount =
     earnAccountResult && earnAccountResult.networkId === networkId
@@ -126,7 +164,9 @@ export function useEarnAccount({
 
   return {
     earnAccount,
-    isLoading,
+    isLoading:
+      isLoading ||
+      (shouldResolveNetworkDeriveType && isDeriveTypeLoading !== false),
     refreshAccount,
   };
 }

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -78,9 +78,9 @@ export function useEarnAccount({
   const effectiveDeriveType = isIndexedAccountScope
     ? fixedDeriveType || networkDeriveType
     : undefined;
-  const hasResolvedAccountScope = Boolean(
-    resolvedAccountId || (resolvedIndexedAccountId && effectiveDeriveType),
-  );
+  const hasResolvedAccountScope = isIndexedAccountScope
+    ? Boolean(resolvedIndexedAccountId && effectiveDeriveType)
+    : Boolean(resolvedAccountId);
   const swrKey =
     networkId && hasResolvedAccountScope
       ? swrKeys.earnAccount({

--- a/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
+++ b/packages/kit/src/views/Staking/hooks/useEarnAccount.ts
@@ -71,7 +71,7 @@ export function useEarnAccount({
     },
     [networkId, shouldResolveNetworkDeriveType],
     {
-      watchLoading: shouldResolveNetworkDeriveType,
+      watchLoading: true,
       undefinedResultIfReRun: true,
     },
   );

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1276,7 +1276,7 @@ function StockAmountInput({
                 }
               : undefined,
         }}
-        enableMaxAmount={balanceActionsReady}
+        enableMaxAmount={Boolean(inputToken)}
       />
       {platformEnv.isNativeIOS && balanceActionsReady ? (
         <InputAccessoryView nativeID={SwapAmountInputAccessoryViewID}>
@@ -1515,6 +1515,11 @@ function StockMarketTokenHeader({
     });
   const tokenName =
     tokenDetail?.name ?? currentStockToken?.name ?? tokenSymbol ?? '';
+  const priceChange24hPercent = tokenDetail?.priceChange24hPercent;
+  const hasPriceChange24hPercent =
+    priceChange24hPercent !== undefined &&
+    priceChange24hPercent !== null &&
+    priceChange24hPercent !== '';
   const tokenSubtitle = getStockMarketTokenSubtitle({
     currentStockSubtitle: selectedStock?.subtitle,
     tokenDetailStockSubtitle: stock?.subtitle,
@@ -1637,8 +1642,8 @@ function StockMarketTokenHeader({
       >
         {tokenInfoContent}
       </XStack>
-      {tokenDetail ? (
-        <YStack alignItems="flex-end" w="$20" minWidth={0} flexShrink={0}>
+      <YStack alignItems="flex-end" w="$20" minWidth={0} flexShrink={0}>
+        {tokenDetail ? (
           <BaseMarketTokenPrice
             size="$bodyLg"
             color="$text"
@@ -1650,17 +1655,21 @@ function StockMarketTokenHeader({
             lastUpdated={String(tokenDetail.lastUpdated ?? '')}
             currency="$"
           />
-          <PriceChangePercentage size="$bodySm">
-            {tokenDetail.priceChange24hPercent}
-          </PriceChangePercentage>
-        </YStack>
-      ) : (
-        <YStack alignItems="flex-end" w="$20" minWidth={0} flexShrink={0}>
+        ) : (
           <SizableText size="$bodyLg" color="$textSubdued">
             --
           </SizableText>
-        </YStack>
-      )}
+        )}
+        {hasPriceChange24hPercent ? (
+          <PriceChangePercentage size="$bodySm">
+            {priceChange24hPercent}
+          </PriceChangePercentage>
+        ) : (
+          <SizableText size="$bodySm" color="$textSubdued">
+            -
+          </SizableText>
+        )}
+      </YStack>
     </XStack>
   );
 }

--- a/packages/shared/src/utils/swrCacheUtils.test.ts
+++ b/packages/shared/src/utils/swrCacheUtils.test.ts
@@ -172,9 +172,10 @@ describe('SWR cache keys', () => {
       swrKeys.earnAccount({
         networkId: 'evm--1',
         indexedAccountId: 'wallet-1--1',
+        deriveType: 'default',
         btcOnlyTaproot: true,
       }),
-    ).toBe('earnAccount:v2:evm--1::wallet-1--1:1');
+    ).toBe('earnAccount:v3:evm--1::wallet-1--1:default:1');
     expect(
       swrKeys.earnProtocolDetail({
         networkId: 'evm--1',

--- a/packages/shared/src/utils/swrCacheUtils.test.ts
+++ b/packages/shared/src/utils/swrCacheUtils.test.ts
@@ -134,6 +134,58 @@ describe('SWR cache keys', () => {
     ).toBe('swapStockPayTokenDetails:v1:1:usdc|usdt:idx:acc');
   });
 
+  it('scopes Borrow and Earn bootstrap data by its authoritative identity', () => {
+    expect(swrKeys.borrowMarkets()).toBe('borrowMarkets:v1');
+    expect(
+      swrKeys.borrowReserves({
+        networkId: 'evm--1',
+        provider: 'AAVE',
+        marketAddress: '0xMarket',
+        accountId: 'account-1',
+      }),
+    ).toBe('borrowReserves:v1:evm--1:aave:0xMarket:account-1');
+    expect(
+      swrKeys.borrowHealthFactor({
+        networkId: 'evm--1',
+        provider: 'AAVE',
+        marketAddress: '0xMarket',
+        accountId: 'account-1',
+      }),
+    ).toBe('borrowHealthFactor:v1:evm--1:aave:0xMarket:account-1');
+    expect(
+      swrKeys.borrowRewards({
+        networkId: 'evm--1',
+        provider: 'AAVE',
+        marketAddress: '0xMarket',
+        accountId: 'account-1',
+      }),
+    ).toBe('borrowRewards:v1:evm--1:aave:0xMarket:account-1');
+    expect(
+      swrKeys.borrowEModeStatus({
+        networkId: 'evm--1',
+        provider: 'AAVE',
+        marketAddress: '0xMarket',
+        accountId: 'account-1',
+      }),
+    ).toBe('borrowEModeStatus:v1:evm--1:aave:0xMarket:account-1');
+    expect(
+      swrKeys.earnAccount({
+        networkId: 'evm--1',
+        indexedAccountId: 'wallet-1--1',
+        deriveType: 'default',
+        btcOnlyTaproot: true,
+      }),
+    ).toBe('earnAccount:v1:evm--1::wallet-1--1:default:1');
+    expect(
+      swrKeys.earnProtocolDetail({
+        networkId: 'evm--1',
+        provider: 'AAVE',
+        symbol: 'usdc',
+        vault: '0xVault',
+      }),
+    ).toBe('earnProtocolDetail:v1:evm--1:aave:USDC:0xVault');
+  });
+
   it('scopes specified token balances by owner, network, and token set', () => {
     expect(
       swrKeys.specifiedTokenSelectorView({

--- a/packages/shared/src/utils/swrCacheUtils.test.ts
+++ b/packages/shared/src/utils/swrCacheUtils.test.ts
@@ -182,8 +182,10 @@ describe('SWR cache keys', () => {
         provider: 'AAVE',
         symbol: 'usdc',
         vault: '0xVault',
+        locale: 'zh-CN',
+        currencyId: 'CNY',
       }),
-    ).toBe('earnProtocolDetail:v1:evm--1:aave:USDC:0xVault');
+    ).toBe('earnProtocolDetail:v2:evm--1:aave:USDC:0xVault:zh-cn:cny');
   });
 
   it('scopes specified token balances by owner, network, and token set', () => {

--- a/packages/shared/src/utils/swrCacheUtils.test.ts
+++ b/packages/shared/src/utils/swrCacheUtils.test.ts
@@ -172,10 +172,9 @@ describe('SWR cache keys', () => {
       swrKeys.earnAccount({
         networkId: 'evm--1',
         indexedAccountId: 'wallet-1--1',
-        deriveType: 'default',
         btcOnlyTaproot: true,
       }),
-    ).toBe('earnAccount:v1:evm--1::wallet-1--1:default:1');
+    ).toBe('earnAccount:v2:evm--1::wallet-1--1:1');
     expect(
       swrKeys.earnProtocolDetail({
         networkId: 'evm--1',

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -681,19 +681,22 @@ export const swrKeys = {
     networkId,
     accountId,
     indexedAccountId,
+    deriveType,
     btcOnlyTaproot,
   }: {
     networkId: string;
     accountId?: string;
     indexedAccountId?: string;
+    deriveType?: string;
     btcOnlyTaproot: boolean;
   }) =>
     [
       NS.earnAccount,
-      'v2',
+      'v3',
       networkId,
       accountId ?? '',
       indexedAccountId ?? '',
+      deriveType ?? '',
       btcOnlyTaproot ? '1' : '0',
     ].join(':'),
   earnProtocolDetail: ({

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -311,10 +311,42 @@ const NS = {
   swapStockSpeedConfig: 'swapStockSpeedConfig',
   swapStockPayTokenDetails: 'swapStockPayTokenDetails',
   swapStockPositionsMetadata: 'swapStockPositionsMetadata',
+  borrowMarkets: 'borrowMarkets',
+  borrowReserves: 'borrowReserves',
+  borrowHealthFactor: 'borrowHealthFactor',
+  borrowRewards: 'borrowRewards',
+  borrowEModeStatus: 'borrowEModeStatus',
+  earnAccount: 'earnAccount',
+  earnProtocolDetail: 'earnProtocolDetail',
 } as const;
 export type ISwrCacheNamespace = (typeof NS)[keyof typeof NS];
 export const swrCacheNamespaces = NS;
 export const prefixOf = (namespace: ISwrCacheNamespace) => `${namespace}:`;
+
+type IBorrowScopedSWRKeyParams = {
+  networkId: string;
+  provider: string;
+  marketAddress: string;
+  accountId?: string;
+};
+
+function buildBorrowScopedSWRKey(
+  namespace:
+    | typeof NS.borrowReserves
+    | typeof NS.borrowHealthFactor
+    | typeof NS.borrowRewards
+    | typeof NS.borrowEModeStatus,
+  { networkId, provider, marketAddress, accountId }: IBorrowScopedSWRKeyParams,
+) {
+  return [
+    namespace,
+    'v1',
+    networkId,
+    provider.toLowerCase(),
+    marketAddress,
+    accountId ?? 'public',
+  ].join(':');
+}
 
 // --- Centralized SWR key builders ---
 export const swrKeys = {
@@ -636,6 +668,56 @@ export const swrKeys = {
     [NS.swapStockPayTokenDetails, 'v1', scope].join(':'),
   swapStockPositionsMetadata: ({ scope }: { scope: string }) =>
     [NS.swapStockPositionsMetadata, 'v1', scope].join(':'),
+  borrowMarkets: () => [NS.borrowMarkets, 'v1'].join(':'),
+  borrowReserves: (params: IBorrowScopedSWRKeyParams) =>
+    buildBorrowScopedSWRKey(NS.borrowReserves, params),
+  borrowHealthFactor: (params: IBorrowScopedSWRKeyParams) =>
+    buildBorrowScopedSWRKey(NS.borrowHealthFactor, params),
+  borrowRewards: (params: IBorrowScopedSWRKeyParams) =>
+    buildBorrowScopedSWRKey(NS.borrowRewards, params),
+  borrowEModeStatus: (params: IBorrowScopedSWRKeyParams) =>
+    buildBorrowScopedSWRKey(NS.borrowEModeStatus, params),
+  earnAccount: ({
+    networkId,
+    accountId,
+    indexedAccountId,
+    deriveType,
+    btcOnlyTaproot,
+  }: {
+    networkId: string;
+    accountId?: string;
+    indexedAccountId?: string;
+    deriveType?: string;
+    btcOnlyTaproot: boolean;
+  }) =>
+    [
+      NS.earnAccount,
+      'v1',
+      networkId,
+      accountId ?? '',
+      indexedAccountId ?? '',
+      deriveType ?? '',
+      btcOnlyTaproot ? '1' : '0',
+    ].join(':'),
+  earnProtocolDetail: ({
+    networkId,
+    symbol,
+    provider,
+    vault,
+  }: {
+    networkId: string;
+    symbol: string;
+    provider: string;
+    vault?: string;
+  }) =>
+    [
+      NS.earnProtocolDetail,
+      'v1',
+      networkId,
+      provider.toLowerCase(),
+      symbol.toUpperCase(),
+      vault ?? '',
+    ].join(':'),
 };
 
 function uniqueCacheKeys(keys: string[]) {

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -681,22 +681,19 @@ export const swrKeys = {
     networkId,
     accountId,
     indexedAccountId,
-    deriveType,
     btcOnlyTaproot,
   }: {
     networkId: string;
     accountId?: string;
     indexedAccountId?: string;
-    deriveType?: string;
     btcOnlyTaproot: boolean;
   }) =>
     [
       NS.earnAccount,
-      'v1',
+      'v2',
       networkId,
       accountId ?? '',
       indexedAccountId ?? '',
-      deriveType ?? '',
       btcOnlyTaproot ? '1' : '0',
     ].join(':'),
   earnProtocolDetail: ({

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -704,19 +704,25 @@ export const swrKeys = {
     symbol,
     provider,
     vault,
+    locale,
+    currencyId,
   }: {
     networkId: string;
     symbol: string;
     provider: string;
     vault?: string;
+    locale: string;
+    currencyId: string;
   }) =>
     [
       NS.earnProtocolDetail,
-      'v1',
+      'v2',
       networkId,
       provider.toLowerCase(),
       symbol.toUpperCase(),
       vault ?? '',
+      locale.toLowerCase(),
+      currencyId.toLowerCase(),
     ].join(':'),
 };
 


### PR DESCRIPTION
## Summary
- Keep the Stock Max control visually stable while authoritative balance actions are still loading.
- Reserve stable Stock price/change geometry and reuse identity-scoped Borrow/Earn bootstrap data during silent revalidation.
- Add scoped SWR key coverage for Borrow markets, reserves, health factor, rewards, E-Mode, Earn accounts, and protocol details.

## Intent & Context
This change follows UI performance feedback from the [Slack discussion](https://onekeygroup.slack.com/archives/D09K3D8B415/p1787192036438099):

- Stock Max visibly flashed when returning from Limit even though the selected asset had not changed.
- The Stock header jumped when the price-change row arrived one frame later.
- Borrow data and icons loaded independently by component on each entry, producing repeated skeletons.

The Slack thread does not reference a Jira issue, so this PR intentionally has no `OK-xxxxx` metadata.

## Root Cause
Stock used the authoritative `balanceActionsReady` state for both visibility and interaction. This delayed the Max label until balance metadata was executable, while ordinary Swap kept a stable display shell.

Borrow and Earn bootstrap requests were owned by independent hook-local lifecycles. Re-entering the view discarded last-valid display data, so markets, account identity, reserves, health factor, rewards, E-Mode, and protocol details entered separate loading states.

## Design Decisions
- Separate display readiness from execution authority: cached or loading data may stabilize layout, but Max and percentage actions remain disabled until authoritative metadata is ready.
- Persist only last-valid results and scope account-sensitive entries by network, provider, market, account, derivation type, and vault as applicable.
- Keep cached results visible during background revalidation and reject stale results whose scope no longer owns the current request.
- Avoid changing the shared image primitive; this PR only ensures the correct market/protocol image URI is available on the first frame.

## Changes Detail
- Render a disabled Max label alongside the balance skeleton and enable interaction only when an `onPress` owner exists.
- Keep the Stock price and 24-hour change rows mounted with matching placeholder geometry.
- Hydrate Borrow markets and owned reserves before paint, then silently refresh authoritative data.
- Add scoped SWR caching to Borrow health factor, rewards, E-Mode, Earn account, and protocol detail hooks.
- Add deterministic cache-key tests for the new Borrow/Earn namespaces.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop, Mobile, Web, Extension
- **Risk Areas**: Account/market cache ownership and stale display data during revalidation. Transaction actions remain gated by live authoritative state.

## Test plan
- [x] `yarn agent:check --profile pr`
- [x] 8 focused Jest suites, 147 tests
- [x] Electron: Limit -> Stock shows Max on the first frame and enables it only after authoritative balance readiness
- [x] Electron: Stock action button and price header remain stable during the transition
- [x] Electron: Borrow second entry shows market, health factor, and icon data without returning to the Net APY loading state
- [x] Electron: no target-flow console errors during the settled interaction runs
- [ ] Mobile runtime regression pass
