### PR TITLE
fix: filter unmatched perps results for short search queries (OK-60751)

### DIFF
--- a/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
@@ -80,4 +80,68 @@ describe('ServiceUniversalSearch perps asset capability', () => {
       }),
     ]);
   });
+  // Rows the endpoint returns for `usdc` because they are USDC settled, not
+  // because the query matches anything the row displays.
+  const searchAssets = [
+    { type: 'perps', name: 'BTC', subtitle: 'Bitcoin' },
+    { type: 'xyz', name: 'AMAT', subtitle: 'Applied Materials' },
+    { type: 'xyz', name: 'EWJ', subtitle: 'Japan ETF' },
+    { type: 'para', name: 'UNITREE', subtitle: 'Unitree' },
+  ].map((asset) => ({
+    ...asset,
+    logoUrl: 'https://example.com/logo.png',
+    maxLeverage: null,
+    midPx: '1',
+    dayNtlVlm: null,
+  }));
+
+  function buildSearchService() {
+    const backgroundApi = {
+      simpleDb: {
+        perp: {
+          getTradingUniverse: jest.fn().mockResolvedValue({
+            universesByDex: [
+              [{ name: 'BTC', maxLeverage: 40 }],
+              [
+                { name: 'xyz:AMAT', maxLeverage: 10 },
+                { name: 'xyz:EWJ', maxLeverage: 10 },
+              ],
+              [{ name: 'para:UNITREE', maxLeverage: 5 }],
+            ],
+            updatedAt: Date.now(),
+          }),
+        },
+      },
+      serviceHyperliquid: { refreshTradingMeta: jest.fn() },
+    };
+    const Ctor = ServiceUniversalSearch as unknown as new (args: {
+      backgroundApi: unknown;
+    }) => ServiceUniversalSearch;
+    const service = new Ctor({ backgroundApi });
+    (service as any).getClient = jest.fn().mockResolvedValue({
+      get: jest.fn().mockResolvedValue({ data: { data: searchAssets } }),
+    });
+    return service;
+  }
+
+  test.each<[string, string[]]>([
+    ['usdc', []],
+    ['btc', ['BTC']],
+    // An exact dex prefix browses that sub-dex, a fragment of one does not.
+    ['xyz', ['AMAT', 'EWJ']],
+    ['ar', []],
+    // Only the row's description carries this one.
+    ['etf', ['EWJ']],
+    // Longer and non-ASCII queries stay on the endpoint's own ranking.
+    ['japan', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
+    ['比特币', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
+  ])('keeps the rows a %p query can match', async (input, expected) => {
+    const service = buildSearchService();
+
+    const result = await service.universalSearchOfPerp({ input });
+
+    expect(
+      result.items.map((item) => (item.payload as { name: string }).name),
+    ).toEqual(expected);
+  });
 });

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
@@ -86,6 +86,7 @@ describe('ServiceUniversalSearch perps asset capability', () => {
     { type: 'perps', name: 'BTC', subtitle: 'Bitcoin' },
     { type: 'xyz', name: 'AMAT', subtitle: 'Applied Materials' },
     { type: 'xyz', name: 'EWJ', subtitle: 'Japan ETF' },
+    { type: 'xyz', name: 'NVDA', subtitle: 'NVIDIA' },
     { type: 'para', name: 'UNITREE', subtitle: 'Unitree' },
   ].map((asset) => ({
     ...asset,
@@ -105,6 +106,7 @@ describe('ServiceUniversalSearch perps asset capability', () => {
               [
                 { name: 'xyz:AMAT', maxLeverage: 10 },
                 { name: 'xyz:EWJ', maxLeverage: 10 },
+                { name: 'xyz:NVDA', maxLeverage: 10 },
               ],
               [{ name: 'para:UNITREE', maxLeverage: 5 }],
             ],
@@ -112,7 +114,18 @@ describe('ServiceUniversalSearch perps asset capability', () => {
           }),
         },
       },
-      serviceHyperliquid: { refreshTradingMeta: jest.fn() },
+      serviceHyperliquid: {
+        refreshTradingMeta: jest.fn(),
+        // Shaped like the server config: every market also carries its pair
+        // notations, which is what makes `usdc` match all of them upstream.
+        getTokenSearchAliases: jest.fn().mockResolvedValue({
+          BTC: { aliases: ['btc', 'bitcoin', 'digital gold', 'btc-usdc'] },
+          'xyz:AMAT': { aliases: ['amat', 'amat-usdc', 'amat/usd'] },
+          'xyz:EWJ': { aliases: ['ewj', 'ewj-usdc'] },
+          'xyz:NVDA': { aliases: ['nvda', 'nvda-usdc'] },
+          'para:UNITREE': { aliases: ['unitree', 'unitree-usdc'] },
+        }),
+      },
     };
     const Ctor = ServiceUniversalSearch as unknown as new (args: {
       backgroundApi: unknown;
@@ -125,16 +138,21 @@ describe('ServiceUniversalSearch perps asset capability', () => {
   }
 
   test.each<[string, string[]]>([
+    // Matched upstream only through the `*-usdc` pair aliases.
     ['usdc', []],
     ['btc', ['BTC']],
+    // Four characters, the threshold itself.
+    ['nvda', ['NVDA']],
+    // Reachable only through an alias: the row itself shows `BTC` / `Bitcoin`.
+    ['gold', ['BTC']],
     // An exact dex prefix browses that sub-dex, a fragment of one does not.
-    ['xyz', ['AMAT', 'EWJ']],
+    ['xyz', ['AMAT', 'EWJ', 'NVDA']],
     ['ar', []],
     // Only the row's description carries this one.
     ['etf', ['EWJ']],
     // Longer and non-ASCII queries stay on the endpoint's own ranking.
-    ['japan', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
-    ['比特币', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
+    ['japan', ['BTC', 'AMAT', 'EWJ', 'NVDA', 'UNITREE']],
+    ['比特币', ['BTC', 'AMAT', 'EWJ', 'NVDA', 'UNITREE']],
   ])('keeps the rows a %p query can match', async (input, expected) => {
     const service = buildSearchService();
 

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -21,6 +21,7 @@ import {
   buildTradablePerpMaxLeverageMap,
   isPerpsUniverseCacheComplete,
 } from '@onekeyhq/shared/src/utils/perpsDexUtils';
+import { matchesTokenSearchAlias } from '@onekeyhq/shared/src/utils/perpsUtils';
 import {
   PROMISE_CONCURRENCY_LIMIT,
   promiseAllSettledEnhanced,
@@ -56,10 +57,11 @@ const PERPS_UNIVERSE_SEARCH_MAX_AGE_MS = timerUtils.getTimeDurationMs({
   minute: 5,
 });
 const PERPS_ASSET_TYPE_VERSION = 2;
-// The search index also matches collateral text, so `usdc` returns every
-// USDC settled market. Only short ASCII tickers are held to a literal match:
-// a longer query is where the index's description hits such as `nasdaq` are
-// the point, and a non-ASCII one is where its localized aliases are.
+// Every market's search aliases include its pair notations (`btc-usdc`), so
+// `usdc` returns every USDC settled market. Only short ASCII tickers are held
+// to a literal match: a longer query is where the index's description hits
+// such as `nasdaq` are the point, and a non-ASCII one is where the localized
+// aliases the server may hold beyond our cached map are.
 const PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH = 4;
 
 @backgroundClass()
@@ -1301,10 +1303,19 @@ class ServiceUniversalSearch extends ServiceBase {
         const requiresLiteralMatch =
           /^[a-z0-9]+$/.test(normalizedQuery) &&
           normalizedQuery.length <= PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH;
+        // Read only when the filter can drop something: an alias is the only
+        // way a query reaches a market whose ticker and subtitle both miss it.
+        const tokenSearchAliases = requiresLiteralMatch
+          ? await this.backgroundApi.serviceHyperliquid.getTokenSearchAliases()
+          : undefined;
 
         const items: IUniversalSearchPerpResult['items'] =
           rawAssets
             ?.filter((asset) => {
+              const coin = buildCoinFromSearchAssetType({
+                assetType: asset.type,
+                name: asset.name,
+              });
               // `asset.type` is the dex prefix, so matching it exactly keeps
               // `xyz` browsing that sub-dex without a fragment such as `ar`
               // waving through every `para` row.
@@ -1313,7 +1324,13 @@ class ServiceUniversalSearch extends ServiceBase {
                 asset.type?.toLowerCase() !== normalizedQuery &&
                 ![asset.name, asset.subtitle].some((field) =>
                   field?.toLowerCase().includes(normalizedQuery),
-                )
+                ) &&
+                !matchesTokenSearchAlias({
+                  query: normalizedQuery,
+                  aliases: coin
+                    ? tokenSearchAliases?.[coin]?.aliases
+                    : undefined,
+                })
               ) {
                 return false;
               }
@@ -1323,10 +1340,6 @@ class ServiceUniversalSearch extends ServiceBase {
               if (!tradablePerpMaxLeverage) {
                 return true;
               }
-              const coin = buildCoinFromSearchAssetType({
-                assetType: asset.type,
-                name: asset.name,
-              });
               return Boolean(coin && tradablePerpMaxLeverage.has(coin));
             })
             .map((asset) => {

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -56,6 +56,11 @@ const PERPS_UNIVERSE_SEARCH_MAX_AGE_MS = timerUtils.getTimeDurationMs({
   minute: 5,
 });
 const PERPS_ASSET_TYPE_VERSION = 2;
+// The search index also matches collateral text, so `usdc` returns every
+// USDC settled market. Only short ASCII tickers are held to a literal match:
+// a longer query is where the index's description hits such as `nasdaq` are
+// the point, and a non-ASCII one is where its localized aliases are.
+const PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH = 4;
 
 @backgroundClass()
 class ServiceUniversalSearch extends ServiceBase {
@@ -1292,9 +1297,26 @@ class ServiceUniversalSearch extends ServiceBase {
             ? await this.readTradablePerpMaxLeverageMap()
             : cachedPerpMaxLeverage;
 
+        const normalizedQuery = input.trim().toLowerCase();
+        const requiresLiteralMatch =
+          /^[a-z0-9]+$/.test(normalizedQuery) &&
+          normalizedQuery.length <= PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH;
+
         const items: IUniversalSearchPerpResult['items'] =
           rawAssets
             ?.filter((asset) => {
+              // `asset.type` is the dex prefix, so matching it exactly keeps
+              // `xyz` browsing that sub-dex without a fragment such as `ar`
+              // waving through every `para` row.
+              if (
+                requiresLiteralMatch &&
+                asset.type?.toLowerCase() !== normalizedQuery &&
+                ![asset.name, asset.subtitle].some((field) =>
+                  field?.toLowerCase().includes(normalizedQuery),
+                )
+              ) {
+                return false;
+              }
               // The search index still carries delisted assets — `xyz:UNITREE`
               // survives there after moving to `para`, so the same ticker would
               // appear twice with one dead row.

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1685,6 +1685,34 @@ export interface ITokenSearchAliasItem {
 
 export type ITokenSearchAliases = Record<string, ITokenSearchAliasItem>;
 
+// Every market also carries its pair notations (`btc-usdc`, `btc/usd`) as
+// aliases, so matching those would let a quote currency query pull in every
+// market that settles in it.
+const TOKEN_SEARCH_PAIR_ALIAS_REGEX = /[-/]usdc?$/;
+
+// Mirrors findTokensByAlias for a single market, minus the pair notations.
+export function matchesTokenSearchAlias({
+  query,
+  aliases,
+}: {
+  query: string;
+  aliases: string[] | undefined;
+}): boolean {
+  if (!query || !aliases?.length) {
+    return false;
+  }
+  const shouldMatchAliasPrefix = /^[a-z0-9]{1,2}$/.test(query);
+  return aliases.some((alias) => {
+    const normalizedAlias = alias.toLowerCase();
+    if (TOKEN_SEARCH_PAIR_ALIAS_REGEX.test(normalizedAlias)) {
+      return false;
+    }
+    return shouldMatchAliasPrefix
+      ? normalizedAlias.startsWith(query)
+      : normalizedAlias.includes(query);
+  });
+}
+
 /**
  * Find token symbols by search alias
  * @param query - Search query (already lowercased)
@@ -2232,6 +2260,7 @@ export default {
   getHyperliquidTokenImageUrl,
   getHyperliquidTokenImageUris,
   findTokensByAlias,
+  matchesTokenSearchAlias,
   getTokenSubtitle,
   mapTriggerOrderType,
   inferTpsl,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60751](https://onekeyhq.atlassian.net/browse/OK-60751)

----------

<!-- github-pr-monitor:jira-links:end -->






## Summary

- Hold a short ASCII perps search query to a literal match on the row's `name` or `subtitle`, an exact dex prefix, or the market's server search aliases minus their pair notations — so `usdc` no longer lists 56 unrelated markets.
- Leave longer and non-ASCII queries to the endpoint's own ranking, so description hits (`nasdaq`, `bitcoin`) and localized aliases keep working.
- Additive change: nothing removed or restructured.

## Intent & Context

QA reported (OK-60751) that searching `usdc` in universal search fills the Perps section with markets that have nothing to do with the query — `CASHCAT`, `GRAM`, `AMAT`, `ARM`, `ASML` and so on — where the expected result is an empty Perps section.

The first suspicion was a regression from the HIP-3 work in 18e310d9 (OK-59307), which added `assetTypeVersion: 2` to this request. That turned out not to be the cause, so this PR adds an app side guard instead of reverting anything.

## Root Cause

Server side, and the mechanism is the per market alias list in `/utility/v1/perp-config` — the same map the perps token selector already searches with `findTokensByAlias`. Every market carries its pair notations as aliases:

```
"para:AAOI": { aliases: ["aaoi", "aaoi-usdc", "aaoi/usdc", "aaoi-usd", "aaoi/usd", "para:aaoi", ...] }
"BTC":       { aliases: ["btc", "bitcoin", "satoshi", "xbt", ...] }            <- no pair form
```

216 of the 3394 aliases in the live map are pair notations, and they sit exactly on the 54 stock rows. A `usdc` query matches all of them through text that never appears on screen, which is why the section fills with `AMAT` / `ARM` / `ASML`:

```
query=usdc&assetTypeVersion=2  -> 56 rows (perps 2 + xyz 38 + para 16)
query=usdc&assetTypeVersion=1  -> 40 rows (perps 2 + xyz 38)
query=usdc (no version param)  -> 40 rows
```

So the noise predates `assetTypeVersion: 2`; that param only widened the result set with the 16 `para` rows. Every substring of `USDC` returns the same set while non substrings return nothing, consistent with a substring match over that alias text:

```
usdc -> 56    usd -> 56    sd -> 56    dc -> 57
usc  -> 0     udc -> 0
nasdaq -> 12 stocks    stock -> 24    shares -> 13
```

The app simply rendered what the endpoint returned: `universalSearchOfPerp` only filtered *out* delisted assets, and the UI does no relevance filtering of its own.

## Design Decisions

- **Substring match, not fuzzy scoring.** The endpoint already ranks results; the client only needs to reject rows that match nothing a user can see. A scorer would be more code and a second, competing notion of relevance.
- **Match `name` / `subtitle` by substring, the dex by exact `asset.type`.** Matching against the dex prefixed coin (`xyz:AMAT`) instead would let a fragment such as `ar`, `pa` or `xy` wave through every row of that sub-dex — the exact noise this PR removes, on the most common short queries. An exact `asset.type` comparison still lets `xyz` or `para` browse a sub-dex.
- **Match the alias map too, minus the pair notations.** Part of the alias list is invisible on the row (`satoshi` and `digital gold` on BTC, `sandisk` on SNDK), so a ticker/subtitle-only rule silently killed those queries. Matching the list wholesale is not an option either: every stock row has an `*-usdc` alias, so `usdc` would go straight back to 56 rows. Skipping aliases that end in `-usd(c)` / `/usd(c)` holds both ends, and reuses the `findTokensByAlias` prefix rule for 1–2 character queries. The map is read only when the filter can drop something, and an absent or empty map degrades to the previous ticker/subtitle behaviour.
- **Only enforce it for ASCII queries of 4 characters or fewer.** Description search is a deliberate server feature and is valuable for longer queries: replaying live responses through an always-on literal filter would have dropped every result for `nasdaq` (12), `stock` (24) and `shares` (13), plus semantic hits such as `japan` -> `KIOXIA` / `SOFTBANK`. The ASCII guard matters because the endpoint answers localized aliases the cached map may not carry — on wallet.onekeytest.com the Chinese words for bitcoin, Japan and ethereum return BTC, EWJ and ETH — and those queries are 2–3 characters, so a length-only gate would have dropped all of them. Nothing in the client restricts the charset: the UI only trims the input and `universalSearch` passes it through verbatim.
- **Fix stays in the app.** The endpoint's relevance should still be fixed server side; this is a client side guard so 6.5.2 does not ship the broken list.

## Changes Detail

- `packages/shared/src/utils/perpsUtils.ts` — add `matchesTokenSearchAlias()`, a single market mirror of `findTokensByAlias` that skips the `*-usd(c)` pair notations.
- `packages/kit-bg/src/services/ServiceUniversalSearch.ts` — add `PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH`, read the cached alias map when the filter can drop rows, and add an early `return false` inside the existing filter in `universalSearchOfPerpCached`.
- `packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts` — one fixture plus a table of cases: `usdc` drops everything, `btc` / `nvda` keep their own row, `gold` survives on an alias alone, `xyz` browses the sub-dex, `ar` does not, `etf` survives on the subtitle alone, and `japan` / a Chinese alias stay on the endpoint's ranking. Both halves mutation checked: dropping the alias clause fails `gold`, dropping the pair-notation skip fails `usdc`.

## Trade-offs

Short queries still lose some genuinely semantic hits — `sol` -> `Bloom Energy` / `Nokia` survive only because their alias lists carry `sol...`, while rows outside the curated map are dropped. That is the price of removing the `usdc` / `usd` noise.

Replaying live endpoint responses through the final filter:

```
usdc  56 -> 0     usd  56 -> 1     sd  56 -> 0     dc  57 -> 4     ar  57 -> 22
btc    3 -> 3     eth   5 -> 5     sol  5 -> 5     ai  30 -> 21
sato   1 -> 1     xbt   2 -> 2     disk 3 -> 3     gold 1 -> 1     nvda 1 -> 1
etf   12 -> 12    xyz  46 -> 44    para 17 -> 17   japan 4 -> 4    bitcoin 6 -> 6
```

## Risk Assessment

- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (background runtime, all platforms)
- **Runtime scope**: bg runtime only — `ServiceUniversalSearch` runs in background and the filtered list is serialized to main; no shared native resource or persisted state is touched.
- **Risk Areas**: The 4 character threshold. A short ticker whose row carries no matching text in `name` / `subtitle` and no matching dex would be dropped; every ticker checked against live data (`btc`, `eth`, `sol`, `xrp`, `ada`, `bnb`, `sui`, `apt`, `arb`, `ena`, `ldo`, `trx`, `ton`, `nvda`, `tsla`, `aapl`, `amd`, `goog`, `meta`, `gold`) keeps its own row. Nothing outside perps search is touched.

## Test plan

- [ ] Universal search `usdc` — Perps section shows no results
- [ ] Universal search `usd` and `sd` — Perps section shows no results
- [ ] Universal search `btc`, `eth`, `sol`, `nvda`, `gold` — the matching market is still listed first
- [ ] Universal search `ar` — only markets whose ticker or name carries `ar`, no unrelated `para` rows
- [ ] Universal search `sato` and `xbt` — BTC is still listed (alias only match)
- [ ] Universal search `xyz` and `para` — sub-dex markets are still listed
- [ ] Universal search `nasdaq`, `japan`, `bitcoin`, `unitree` — description matches are unchanged
- [ ] Universal search with a Chinese alias (bitcoin / Japan) — results are unchanged
- [ ] Tap a perps result — it still opens the correct market, including sub-dex ones (`xyz:` / `para:`)
- [x] `yarn jest packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts` — 10 passed
- [x] `yarn agent:check --profile commit` — pass

[OK-60751]: https://onekeyhq.atlassian.net/browse/OK-60751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Rebase note
Re-applied onto `hotfix/v6.5.2` from `release/v6.5.0` (PR #12952, now closed). Both touched files are byte-identical between the two bases, so the PR patch applied cleanly and the resulting file contents are byte-identical to the original branch — verified by md5 per file. Net diff against 6.5.2 is exactly these two files, +86 lines.

Pre-existing on this base and unrelated to this PR: `yarn tsc:staged` reports `isInstallerPath` missing on `AppUpdater` in `DesktopApiAppUpdate.ts:832`, which also reproduces on a clean `hotfix/v6.5.2` worktree.
