### PR TITLE
fix: restore extension firmware progress forwarding

### DIFF
--- a/packages/kit-bg/src/offscreens/instance/offscreenApi.test.ts
+++ b/packages/kit-bg/src/offscreens/instance/offscreenApi.test.ts
@@ -1,0 +1,71 @@
+import appGlobals from '@onekeyhq/shared/src/appGlobals';
+import { importHardwareSDKLowLevel } from '@onekeyhq/shared/src/hardware/sdk-loader';
+
+import { OFFSCREEN_API_MESSAGE_TYPE } from '../types';
+
+import offscreenApi from './offscreenApi';
+
+import type { CoreMessage } from '@onekeyfe/hd-core';
+
+jest.mock('@onekeyhq/shared/src/appGlobals', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('@onekeyhq/shared/src/hardware/sdk-loader', () => ({
+  importHardwareSDKLowLevel: jest.fn(),
+}));
+
+describe('offscreenApi hardware events', () => {
+  it('restores event forwarding after the SDK clears its listeners', async () => {
+    let activeListener: ((message: CoreMessage) => void) | undefined;
+    const addHardwareGlobalEventListener = jest.fn(
+      (listener: (message: CoreMessage) => void) => {
+        activeListener = listener;
+      },
+    );
+    const removeAllListeners = jest.fn(() => {
+      activeListener = undefined;
+    });
+    const dispose = jest.fn(async () => {
+      activeListener = undefined;
+    });
+    jest.mocked(importHardwareSDKLowLevel).mockResolvedValue({
+      addHardwareGlobalEventListener,
+      removeAllListeners,
+      dispose,
+    } as never);
+    const request = jest.fn(async () => undefined);
+    appGlobals.extJsBridgeOffscreenToBg = { request } as never;
+
+    await offscreenApi.callOffscreenApiMethod({
+      type: OFFSCREEN_API_MESSAGE_TYPE,
+      module: 'hardwareSDKLowLevel',
+      method: 'removeAllListeners',
+      params: [],
+    });
+    expect(addHardwareGlobalEventListener).toHaveBeenCalledTimes(2);
+
+    await offscreenApi.callOffscreenApiMethod({
+      type: OFFSCREEN_API_MESSAGE_TYPE,
+      module: 'hardwareSDKLowLevel',
+      method: 'dispose',
+      params: [],
+    });
+    expect(addHardwareGlobalEventListener).toHaveBeenCalledTimes(3);
+
+    const progressEvent = {
+      event: 'UI_EVENT',
+      type: 'ui-firmware-progress',
+      payload: { progress: 25, progressType: 'transferData' },
+    } as CoreMessage;
+    activeListener?.(progressEvent);
+
+    expect(request).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        service: 'serviceHardware',
+        params: [progressEvent],
+      }),
+    });
+  });
+});

--- a/packages/kit-bg/src/offscreens/instance/offscreenApi.ts
+++ b/packages/kit-bg/src/offscreens/instance/offscreenApi.ts
@@ -11,9 +11,40 @@ import type {
   IBackgroundApiInternalCallMessage,
   IOffscreenApiMessagePayload,
 } from '../../apis/IBackgroundApi';
-import type { LowLevelCoreApi } from '@onekeyfe/hd-core';
+import type { CoreMessage, LowLevelCoreApi } from '@onekeyfe/hd-core';
 
 let HardwareLowLevelSDK: LowLevelCoreApi;
+
+const forwardHardwareEventToBackground = (eventParams: CoreMessage) => {
+  const backgroundServiceName = 'serviceHardware';
+  const backgroundMethodName = `${INTERNAL_METHOD_PREFIX}passHardwareEventsFromOffscreenToBackground`;
+  const message: IBackgroundApiInternalCallMessage = {
+    service: backgroundServiceName,
+    method: backgroundMethodName,
+    params: [eventParams],
+  };
+  // chrome.runtime.sendMessage(message);
+  // TODO backgroundApiProxyInOffscreen
+  const bridge = appGlobals.extJsBridgeOffscreenToBg;
+  if (!bridge) {
+    console.error('[hardwareSDKLowLevel] background bridge is unavailable');
+    return;
+  }
+  void Promise.resolve(bridge.request({ data: message })).catch(
+    (error: unknown) => {
+      console.error(
+        '[hardwareSDKLowLevel] failed to forward event to background',
+        error,
+      );
+    },
+  );
+};
+
+const registerHardwareGlobalEventListener = () => {
+  HardwareLowLevelSDK.addHardwareGlobalEventListener(
+    forwardHardwareEventToBackground,
+  );
+};
 
 const createOffscreenApiModule = memoizee(
   async (name: keyof IOffscreenApi) => {
@@ -23,32 +54,7 @@ const createOffscreenApiModule = memoizee(
           HardwareLowLevelSDK = await (
             await import('@onekeyhq/shared/src/hardware/sdk-loader')
           ).importHardwareSDKLowLevel();
-          HardwareLowLevelSDK.addHardwareGlobalEventListener((eventParams) => {
-            const backgroundServiceName = 'serviceHardware';
-            const backgroundMethodName = `${INTERNAL_METHOD_PREFIX}passHardwareEventsFromOffscreenToBackground`;
-            const message: IBackgroundApiInternalCallMessage = {
-              service: backgroundServiceName,
-              method: backgroundMethodName,
-              params: [eventParams],
-            };
-            // chrome.runtime.sendMessage(message);
-            // TODO backgroundApiProxyInOffscreen
-            const bridge = appGlobals.extJsBridgeOffscreenToBg;
-            if (!bridge) {
-              console.error(
-                '[hardwareSDKLowLevel] background bridge is unavailable',
-              );
-              return;
-            }
-            void Promise.resolve(bridge.request({ data: message })).catch(
-              (error: unknown) => {
-                console.error(
-                  '[hardwareSDKLowLevel] failed to forward event to background',
-                  error,
-                );
-              },
-            );
-          });
+          registerHardwareGlobalEventListener();
         }
         return HardwareLowLevelSDK;
       case 'adaSdk':
@@ -70,11 +76,24 @@ const createOffscreenApiModule = memoizee(
   },
 );
 
-const callOffscreenApiMethod =
+const callOffscreenApiMethodBase =
   buildCallRemoteApiMethod<IOffscreenApiMessagePayload>(
     createOffscreenApiModule,
     'offscreenApi',
   );
+
+const callOffscreenApiMethod = async (message: IOffscreenApiMessagePayload) => {
+  const result: unknown = await callOffscreenApiMethodBase(message);
+  const didClearAllHardwareListeners =
+    message.module === 'hardwareSDKLowLevel' &&
+    (message.method === 'dispose' ||
+      (message.method === 'removeAllListeners' &&
+        message.params?.[0] === undefined));
+  if (didClearAllHardwareListeners) {
+    registerHardwareGlobalEventListener();
+  }
+  return result;
+};
 
 export default {
   callOffscreenApiMethod,


### PR DESCRIPTION
## Summary

- restore the offscreen hardware event forwarder after the low-level SDK clears all listeners
- cover both removeAllListeners and dispose lifecycle paths
- add a focused regression test for firmware progress forwarding after SDK reset

## Root cause

The extension registers its hardware global event forwarder once in the offscreen runtime. SDK cleanup clears the low-level event emitter listeners, while the memoized offscreen SDK module remains alive, so the forwarder is not registered again. The SDK therefore continues producing progress logs in offscreen, but background atoms no longer receive those events. Workflow completion remains unaffected because it is written directly by ServiceFirmwareUpdate.

## Verification

- yarn jest packages/kit-bg/src/offscreens/instance/offscreenApi.test.ts apps/ext/src/offscreen/offscreenSetup.test.ts --runInBand
- yarn exec eslint packages/kit-bg/src/offscreens/instance/offscreenApi.ts packages/kit-bg/src/offscreens/instance/offscreenApi.test.ts --no-cache
- yarn app:ext:build

The extension production build completed successfully with existing dependency and bundle-size warnings.