### PR TITLE
fix: prevent iOS hardware dialog overlay conflicts

### DIFF
--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
@@ -48,6 +48,7 @@ import { useOnboardingDeviceScanErrorHandler } from '@onekeyhq/kit/src/hooks/use
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
+import { hardwareUiStateDialogLifecycle } from '@onekeyhq/kit/src/provider/Container/HardwareUiStateContainer/hardwareUiStateDialogLifecycle';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector/actions';
 import type { IDBCreateHwWalletParamsBase } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -1403,9 +1404,17 @@ export function ConnectYourDevicePage() {
     }) => {
       setIsChecking(true);
 
-      void backgroundApiProxy.serviceHardwareUI.showDeviceProcessLoadingDialog({
-        connectId: device.connectId ?? '',
-      });
+      const showDeviceProcessLoadingDialog = () =>
+        backgroundApiProxy.serviceHardwareUI.showDeviceProcessLoadingDialog({
+          connectId: device.connectId ?? '',
+        });
+      if (platformEnv.isNativeIOS) {
+        await hardwareUiStateDialogLifecycle.openAndWait(
+          showDeviceProcessLoadingDialog,
+        );
+      } else {
+        void showDeviceProcessLoadingDialog();
+      }
 
       let features: IOneKeyDeviceFeatures | undefined;
       let deviceState: IOneKeyDeviceState;

--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx
@@ -5,9 +5,9 @@ import { useIntl } from 'react-intl';
 import { Dialog, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { hardwareUiStateDialogLifecycle } from '@onekeyhq/kit/src/provider/Container/HardwareUiStateContainer/hardwareUiStateDialogLifecycle';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 export function SelectAddWalletTypeDialogContent({
   onAddStandardWalletPress,
@@ -84,24 +84,19 @@ export function useSelectAddWalletTypeDialog() {
   const showSelectAddWalletTypeDialog = useCallback(async (): Promise<
     'Standard' | 'Hidden' | undefined
   > => {
-    // iOS-only: dismiss the hardware-UI dialog before mounting this one.
-    // Both dialogs render into FULL_WINDOW_OVERLAY_PORTAL and share the same
-    // useOverlayZIndex stack. The hardware DialogContainer remounts on every
-    // atom action transition, so its Sheet.Overlay can end up above this
-    // dialog's Frame on iOS and intercept taps even though the wallet-type
-    // buttons appear visually on top. skipDeviceCancel:true keeps the BLE
-    // session alive; the hardware dialog naturally returns when the SDK
-    // emits its next UI event.
+    // iOS-only: wait until the hardware Sheet has left the main runtime's
+    // FullWindowOverlay before mounting another Sheet. The background atom
+    // write can finish before the main runtime commits the close, so a fixed
+    // delay can still leave the old overlay intercepting touches.
     if (platformEnv.isNativeIOS) {
-      await backgroundApiProxy.serviceHardwareUI.closeHardwareUiStateDialog({
-        connectId: undefined,
-        skipDeviceCancel: true,
-        skipDelayClose: true,
-        reason: 'open SelectAddWalletTypeDialog',
-      });
-      // Let the hardware DialogContainer unmount and its useOverlayZIndex
-      // cleanup drop from the stack before we mount.
-      await timerUtils.wait(300);
+      await hardwareUiStateDialogLifecycle.closeAndWait(() =>
+        backgroundApiProxy.serviceHardwareUI.closeHardwareUiStateDialog({
+          connectId: undefined,
+          skipDeviceCancel: true,
+          skipDelayClose: true,
+          reason: 'open SelectAddWalletTypeDialog',
+        }),
+      );
     }
 
     return new Promise((resolve) => {

--- a/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
@@ -1037,9 +1037,17 @@ export function useDeviceConnect({
         connectProtocol: resolvedConnectProtocol,
       });
       const currentDevice = getActiveDevice() ?? device;
-      void backgroundApiProxy.serviceHardwareUI.showDeviceProcessLoadingDialog({
-        connectId: currentDevice.connectId ?? '',
-      });
+      const showDeviceProcessLoadingDialog = () =>
+        backgroundApiProxy.serviceHardwareUI.showDeviceProcessLoadingDialog({
+          connectId: currentDevice.connectId ?? '',
+        });
+      if (platformEnv.isNativeIOS) {
+        await hardwareUiStateDialogLifecycle.openAndWait(
+          showDeviceProcessLoadingDialog,
+        );
+      } else {
+        void showDeviceProcessLoadingDialog();
+      }
 
       let features: IOneKeyDeviceFeatures | undefined;
       let deviceState: IOneKeyDeviceState;


### PR DESCRIPTION
## Summary

- serialize the iOS hardware loading Sheet mount before wallet creation state checks
- wait for the main-runtime close acknowledgement and native Sheet exit before opening the wallet-type dialog
- keep the hardware/BLE session active and leave non-iOS behavior unchanged

## Root cause

On iOS, the background runtime can finish clearing the hardware UI atom before the main runtime commits the React close and the native `FullWindowOverlay` Sheet finishes exiting. Mounting the wallet-type dialog during that window can leave the previous `Sheet.Overlay` above it and intercept touches.

## Side effects

- adds the existing 150 ms loading animation wait plus up to roughly 300 ms for a stable native Sheet exit on iOS
- fails through the existing error/retry path after a 5-second UI acknowledgement timeout instead of stacking another non-interactive overlay
- preserves the hardware loading UI, its delayed close action, and `skipDeviceCancel: true`

## Testing

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn jest packages/kit/src/provider/Container/HardwareUiStateContainer/hardwareUiStateDialogLifecycle.test.ts --runInBand` (8 tests passed)
- `git diff --check`

## Device verification

- [ ] confirm the Standard/Hidden wallet-type options remain tappable on iOS 18.7.5
- [ ] confirm the subsequent PIN/passphrase dialogs render correctly
- [ ] confirm the BLE session remains connected throughout the flow
