### PR TITLE
docs: strengthen i18n skill workflow

### DIFF
--- a/.skillshare/skills/1k-i18n/SKILL.md
+++ b/.skillshare/skills/1k-i18n/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: 1k-i18n
-description: Internationalization — translations (ETranslations, useIntl, formatMessage) and locale management. NEVER modify auto-generated translation files.
-allowed-tools: Read, Grep, Glob
+description: OneKey i18n and Lokalise workflow for searching, adding, updating, pulling, and using translation keys. Verify the target project and full locale coverage; never edit generated translation files.
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
 # Internationalization (i18n)
@@ -32,13 +32,20 @@ intl.formatMessage({ id: ETranslations.global__confirm })
 
 ## Existing Keys First
 
-When updating an existing translation:
+Search locally and remotely before creating a key. Reuse a key only when its
+meaning, placeholders, and UI context match.
 
-- Do not edit generated locale files directly.
-- Update the source translation in Lokalise:
-  - Use the `lokalise` MCP if it is available in the current environment.
-  - Otherwise use Lokalise Web.
-- After the source change, sync locally with `yarn i18n:pull` or `yarn i18n:pull:keychain`.
+For any Lokalise create or update:
+
+- Verify the actual target project name and ID before mutating it.
+- Fetch that project's configured languages; do not infer them from an
+  environment-variable name.
+- Prefer repository scripts and credential wrappers. `yarn op` is the default;
+  `keychain` and `oenv` variants are supported alternatives.
+- A configured Lokalise MCP or Lokalise Web may be used for an existing
+  translation, but the same project and language checks still apply.
+- After the remote change, sync locally with `yarn i18n:pull`,
+  `yarn i18n:pull:keychain`, or `yarn i18n:pull:oenv`.
 
 ## Key Shape Mapping
 
@@ -63,6 +70,39 @@ Query guidance:
 - Lokalise / MCP: prefer the exact source key. Legacy namespaced keys often use `::`.
 - Local `yarn i18n:search`: searches pulled `en_US.json`, so legacy keys should be queried with `.`, while newer suffix-style keys should be queried with `__`.
 - Code usage: refer to the generated `ETranslations` member with `_`.
+
+## End-to-End Delivery Requirements
+
+For any task that creates or updates a translation:
+
+1. Check the current branch and worktree before pulling generated files.
+2. Resolve credentials without printing tokens.
+3. Retrieve `GET /projects/{project_id}` and confirm the returned project name
+   and ID match the intended target.
+4. Retrieve `GET /projects/{project_id}/languages` and record its exact
+   `lang_iso` values.
+5. Search for the exact key in that verified project before creating it.
+6. Use `yarn i18n:add` for a missing key. It only creates `en_US` and optional
+   `zh_CN` source translations; it does not complete the remaining locales.
+7. Ensure the key has valid translations for every checked-in locale. The
+   repository currently has 19 locale JSON files.
+8. Pull generated files, verify the enum and all locale JSON files, and inspect
+   the full generated diff for unrelated remote updates.
+9. Wire the generated `ETranslations` member in code and validate placeholder
+   consistency.
+
+Do not silently skip a repository locale because the target project uses a
+different code format. Map repository locale names to the project's configured
+`lang_iso` values. If the project genuinely lacks a required language, stop
+before upload and report the mismatch.
+
+The completion report must state the verified project name/ID, covered locale
+set, pull command used, generated-file scope, and any unrelated keys brought in
+by the pull. Review code changes separately from generated locale changes.
+
+Read [i18n.md](references/rules/i18n.md) before performing any remote Lokalise
+mutation or `i18n:pull`. It contains the project preflight, current 19-locale
+set, translation-record update flow, and generated-diff verification.
 
 ## Quick Reference
 
@@ -96,10 +136,13 @@ const message = appLocale.intl.formatMessage({
 
 1. **Search first**
    - Local search: `yarn i18n:search "global.contact_us"` or `yarn i18n:search "address_book__action"`
-   - Lokalise / MCP: try the exact source key, such as `global::contact_us`
-2. **If the key already exists, update it in Lokalise** and then run `yarn i18n:pull`
-3. **If it is a new key, add it via `yarn i18n:add`** using the suffix-style underscore format
-4. **Use in code**:
+2. **Verify the target** — confirm project name/ID and fetch exact project languages
+3. **Search remotely** — query the exact source key, such as `global::contact_us`, in that verified project
+4. **If the key already exists, update it in Lokalise** by translation record
+5. **If it is a new key, add it via `yarn i18n:add`** using the suffix-style underscore format
+6. **Complete every repository locale** — do not stop after `en_US`/`zh_CN`
+7. **Pull and inspect** — verify the key everywhere and call out unrelated generated changes
+8. **Use in code**:
    ```tsx
    {intl.formatMessage({ id: ETranslations.global_contact_us })}
    ```
@@ -118,15 +161,19 @@ Examples:
 
 ## Detailed Guide
 
-For comprehensive i18n guidelines and examples, see [i18n.md](references/rules/i18n.md).
+For comprehensive i18n guidelines and the end-to-end Lokalise workflow, see
+[i18n.md](references/rules/i18n.md).
 
 Topics covered:
 - Translation management restrictions
 - Using translations in components
 - Translation key naming conventions
+- Target project and language verification
+- Full 19-locale coverage
+- Safe Lokalise create/update and pull flow
+- Generated-diff inspection
 - Locale handling and fallbacks
 - Code examples
-- Workflow summary
 
 ## Key Files
 
@@ -136,6 +183,8 @@ Topics covered:
 | Locale JSON (auto-generated) | `packages/shared/src/locale/json/` |
 | App locale | `packages/shared/src/locale/appLocale.ts` |
 | Default locale | `packages/shared/src/locale/getDefaultLocale.ts` |
+| Lokalise add script | `development/scripts/i18n/i18n-add.js` |
+| Lokalise pull script | `development/scripts/i18n/i18n-pull.js` |
 
 ## Related Skills
 

--- a/.skillshare/skills/1k-i18n/references/rules/i18n.md
+++ b/.skillshare/skills/1k-i18n/references/rules/i18n.md
@@ -23,13 +23,16 @@ Updating an existing translation and adding a new translation are different work
 For an existing key:
 
 1. Search locally first.
-2. Update the source translation in Lokalise.
-3. Sync locally with `yarn i18n:pull` or `yarn i18n:pull:keychain`.
+2. Verify the intended Lokalise project name, ID, and configured languages.
+3. Query the exact remote key from that verified project.
+4. Update the relevant translation records and complete every repository locale.
+5. Sync locally and inspect the full generated diff.
 
 Do not patch generated locale JSON files directly.
 
-If the current machine has a `lokalise` MCP configured, you can update Lokalise from Codex.
-If not, use Lokalise Web and then pull locally.
+Prefer the repository scripts and credential wrappers. A configured `lokalise`
+MCP or Lokalise Web may be used, but it does not remove the project-identity,
+language-coverage, pull, or diff-verification requirements.
 
 ## Key Shape Mapping
 
@@ -111,56 +114,254 @@ Based on [Apple Human Interface Guidelines](https://developer.apple.com/design/h
 4. **Functional grouping** - Same feature keys sort adjacent alphabetically
 5. **Track usage** - Suffixes enable filtering by type (e.g., apply Title Case to all `*__title` keys)
 
-## CLI Workflow
+## End-to-End Lokalise Workflow
 
-### Search Before Adding
+Use this workflow for any remote create/update or local `i18n:pull`.
+
+### 0. Protect the Worktree
+
+Check the current branch and pending changes before pulling:
 
 ```bash
-# Always search first to avoid duplicates
-yarn i18n:search "send"
-
-# Output shows grouped results with type tags:
-# [send]
-#   send__title [title]
-#     → "Send"
-#   confirm_send__action [action]
-#     → "Confirm Send"
-#
-# Total: 12 keys (3 typed, 9 legacy)
+git branch --show-current
+git status --short
 ```
 
-Examples for existing keys:
+`yarn i18n:pull` rewrites generated locale files. If the worktree already has
+unrelated locale changes, isolate the i18n work or agree on a staging strategy
+before continuing.
+
+### 1. Search Locally
+
+Search before any remote mutation:
 
 ```bash
-# Legacy namespaced key, searched locally in pulled JSON form
+yarn i18n:search "send"
+
+# Legacy namespaced key, searched in pulled JSON form
 yarn i18n:search "global.contact_us"
 
 # New suffix-style key
 yarn i18n:search "address_book__action"
 ```
 
-### Add New Keys
+Reuse an existing key only when the meaning, placeholders, capitalization, and
+UI role are compatible. Similar wording alone is insufficient.
+
+### 2. Resolve Credentials
+
+The root scripts support these wrappers:
 
 ```bash
-# Secrets injected from 1Password via `yarn op`
+# Default: OneKey 1Password vault
+yarn op <command>
+
+# Configured macOS Keychain
+yarn keychain <command>
+
+# Configured oenv environment
+yarn oenv <command>
+```
+
+Use one wrapper consistently for project verification, mutation, and pull.
+Never print `LOKALISE_TOKEN` or include it in logs, scripts, commits, or review
+notes.
+
+### 3. Verify the Target Project
+
+Before every create or update, retrieve the project object and its languages
+using the same credential context that will perform the write:
+
+```bash
+yarn op bash -lc '
+  set -euo pipefail
+  curl -fsS \
+    -H "X-Api-Token: $LOKALISE_TOKEN" \
+    "https://api.lokalise.com/api2/projects/$LOKALISE_PROJECT_ID" |
+    jq "{project_id, name}"
+
+  curl -fsS \
+    -H "X-Api-Token: $LOKALISE_TOKEN" \
+    "https://api.lokalise.com/api2/projects/$LOKALISE_PROJECT_ID/languages?limit=5000" |
+    jq -r ".languages[] | [.lang_iso, .lang_name] | @tsv"
+'
+```
+
+Replace `yarn op` with the selected wrapper when necessary. For a non-default
+target, deliberately bind the request to the requested project ID first.
+Environment-variable names such as `LOKALISE_PROJECT_ID_PORTAL` or
+`LOKALISE_PROJECT_ID_EXPLORE` are hints, not proof; the returned project name
+and ID are the proof.
+
+Stop before mutation if the returned project does not match the user's intended
+target.
+
+### 4. Verify Required Locale Coverage
+
+The source of truth for repository coverage is the checked-in locale set:
+
+```bash
+rg --files packages/shared/src/locale/json | sort
+```
+
+The current set has 19 locales:
+
+```text
+bn
+de
+en_US
+es
+fr_FR
+hi_IN
+id
+it_IT
+ja_JP
+ko_KR
+pt
+pt_BR
+ru
+th_TH
+uk_UA
+vi
+zh_CN
+zh_HK
+zh_TW
+```
+
+Compare this set with the verified project's exact `lang_iso` values. Projects
+may use underscore codes, lowercase hyphenated codes, or collapsed regional
+codes. Map repository locales to the configured project codes without dropping
+translation content.
+
+If a required repository locale has no valid project mapping, stop and report
+the mismatch before upload. Do not silently skip it or create project languages
+without explicit authorization.
+
+### 5. Query the Exact Remote Key
+
+Query the verified project with the Lokalise source-key shape:
+
+```bash
+TASK_I18N_KEY="address_book__action" yarn op bash -lc '
+  curl -fsS -G \
+    -H "X-Api-Token: $LOKALISE_TOKEN" \
+    --data-urlencode "filter_keys=$TASK_I18N_KEY" \
+    --data-urlencode "include_translations=1" \
+    "https://api.lokalise.com/api2/projects/$LOKALISE_PROJECT_ID/keys"
+'
+```
+
+Legacy source keys often use `::`; newer suffix-style keys usually use `__`.
+Confirm the returned key is an exact semantic match before reusing or changing
+it.
+
+### 6. Add a Missing Key
+
+For the default monorepo project, use the repository script:
+
+```bash
 yarn i18n:add send__title "Send"
 yarn i18n:add enter_send_amount__desc "Enter the amount you want to send"
 yarn i18n:add transaction_failed__msg "Transaction failed." "交易失败。"
+
+# Supported alternatives when configured:
+yarn i18n:add:keychain send__title "Send"
+yarn i18n:add:oenv send__title "Send"
 ```
 
-`yarn i18n:add` only accepts lowercase letters, numbers, and underscores in the key name.
-It is for new suffix-style keys such as `send__title`, not legacy `::` or `.` forms.
+The script validates key format and source-language placeholder consistency.
+It creates only `en_US` and optional `zh_CN` translations. It does not populate
+`zh_TW`, `zh_HK`, or the other repository locales.
 
-### Sync to Local
+`yarn i18n:add` only accepts lowercase letters, numbers, and underscores in the
+key name. It is for new suffix-style keys such as `send__title`, not legacy
+`::` or `.` forms.
+
+Do not run the default add command against a non-default project until the
+command's project ID is explicitly bound to the already verified target.
+
+### 7. Complete All Locale Translations
+
+After creating or finding the key:
+
+1. Re-query it with `include_translations=1`.
+2. Map every repository locale to the verified project's `lang_iso`.
+3. Validate that every value is intentional and non-empty.
+4. Validate ICU placeholders across all languages.
+5. Update non-source languages by translation record:
+   `PUT /projects/{project_id}/translations/{translation_id}`.
+6. Re-query the exact key and confirm all required languages are present.
+
+When using a custom upload script, run a dry-run first. The preflight should
+show the verified project name/ID, exact key, mapped language codes, and which
+records would change, without showing credentials. Do not use an unverified
+key-scoped path for translation-record updates.
+
+### 8. Pull Generated Files
 
 ```bash
-# After adding keys to Lokalise, sync to local
 yarn i18n:pull
 
-# This updates:
-# - packages/shared/src/locale/enum/translations.ts
-# - packages/shared/src/locale/json/*.json
+# Supported alternatives when configured:
+yarn i18n:pull:keychain
+yarn i18n:pull:oenv
 ```
+
+Pull after remote coverage is complete. If remote translations change after an
+earlier pull, pull again.
+
+The pull updates:
+
+- `packages/shared/src/locale/enum/translations.ts`
+- `packages/shared/src/locale/json/*.json`
+
+### 9. Verify Generated Output
+
+Verify the generated enum and every locale file:
+
+```bash
+rg -n "<key_name>" \
+  packages/shared/src/locale/enum/translations.ts \
+  packages/shared/src/locale/json
+
+rg -l '"<key_name>"' packages/shared/src/locale/json/*.json | sort
+rg --files packages/shared/src/locale/json | sort
+```
+
+The two locale-file lists must cover the same set. Inspect the generated diff:
+
+```bash
+git status --short
+git diff --stat
+git diff -- \
+  packages/shared/src/locale/enum/translations.ts \
+  packages/shared/src/locale/json
+```
+
+`i18n:pull` may bring unrelated remote updates. Do not hand-edit generated
+files or selectively discard generated hunks to hide them. Identify and report
+unrelated keys before commit, and treat the reviewed generated pull as one
+coherent change set.
+
+Review the application-code diff separately from the generated-locale diff so
+remote changes cannot be mistaken for intentional code changes.
+
+### 10. Integrate in Code
+
+Only after the enum member exists, replace hardcoded copy with
+`ETranslations.<key_name>`. Verify the code uses the correct generated member
+shape and supplies every required ICU variable.
+
+The final report should include the verified Lokalise project name/ID, covered
+locale set, pull command used, generated files changed, and any unrelated keys
+included by the pull.
+
+### Official Lokalise API References
+
+- [Retrieve a project](https://developers.lokalise.com/reference/retrieve-a-project)
+- [List project languages](https://developers.lokalise.com/reference/list-project-languages)
+- [List all keys](https://developers.lokalise.com/reference/list-all-keys)
+- [Update a translation](https://developers.lokalise.com/reference/update-a-translation)
 
 ## Using Translations
 
@@ -241,11 +442,15 @@ New keys should follow the `semantic__type` suffix convention.
 | Default locale | `packages/shared/src/locale/getDefaultLocale.ts` |
 | i18n search script | `development/scripts/i18n/i18n-search.js` |
 | i18n add script | `development/scripts/i18n/i18n-add.js` |
+| i18n pull script | `development/scripts/i18n/i18n-pull.js` |
+| Root credential wrappers | `package.json` |
 
 ## Workflow Summary
 
-1. **Search locally** - `yarn i18n:search "global.contact_us"` or `yarn i18n:search "address_book__action"`
-2. **If the key exists, update it in Lokalise** - via MCP when available, otherwise via Lokalise Web
-3. **If the key is new, add it** - `yarn i18n:add key__type "value"`
-4. **Sync** - `yarn i18n:pull` or `yarn i18n:pull:keychain`
-5. **Use in code** - `ETranslations.global_contact_us` or `ETranslations.address_book__action`
+1. **Protect the worktree** before generated-file changes.
+2. **Search locally**, then verify the target Lokalise project and languages.
+3. **Query the exact remote key** in that verified project.
+4. **Reuse/update or create** the key with the correct naming and placeholders.
+5. **Complete all repository locales**, currently 19.
+6. **Pull and verify** the enum, every locale JSON, and the full generated diff.
+7. **Use in code** with the correct `ETranslations` member and ICU variables.


### PR DESCRIPTION
## Summary

- require Lokalise project name, project ID, and configured-language verification before writes
- require complete coverage for all 19 repository locales, including dry-run and translation-record update guidance
- document generated pull verification and unrelated-remote-change reporting while preserving the existing key-shape and naming guidance

## Verification

- yarn agent:check --profile commit
- yarn agent:check --profile pr
- walked through a real key create, 19-locale completion, pull, and generated-diff inspection against the verified Monorepo v5 project