### PR TITLE
fix: restore android async storage size limit

### DIFF
--- a/apps/mobile/android/gradle.properties
+++ b/apps/mobile/android/gradle.properties
@@ -62,9 +62,4 @@ FRESCO_VERSION=2.5.0
 OKHTTP_VERSION=4.9.2
 ANDROIDX_APPCOMPAT_VERSION=1.6.8
 
-# see https://react-native-async-storage.github.io/async-storage/docs/advanced/db_size/
-# see https://www.sqlite.org/limits.html
-# Increase limit, Max limit is 2GB, default is 6MB
-AsyncStorage_db_size_in_MB=1024
-
 Pbkdf2_compileSdkVersion=android-31

--- a/patches/@react-native-async-storage+async-storage+3.0.78.patch
+++ b/patches/@react-native-async-storage+async-storage+3.0.78.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/asyncstorage/ReactDatabaseSupplier.java b/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/asyncstorage/ReactDatabaseSupplier.java
+index 6e6032c..172b917 100644
+--- a/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/asyncstorage/ReactDatabaseSupplier.java
++++ b/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/asyncstorage/ReactDatabaseSupplier.java
+@@ -39,7 +39,8 @@ public class ReactDatabaseSupplier extends SQLiteOpenHelper {
+ 
+     private Context mContext;
+     private @Nullable SQLiteDatabase mDb;
+-    private long mMaximumDatabaseSize = 6L * 1024L * 1024L;
++    // OneKey patch: Keep the Android AsyncStorage limit at 1 GB after BuildConfig support was removed.
++    private long mMaximumDatabaseSize = 1024L * 1024L * 1024L;
+ 
+     private ReactDatabaseSupplier(Context context) {
+         super(context, DATABASE_NAME, null, DATABASE_VERSION);


### PR DESCRIPTION
## Summary

- hardcode the Android AsyncStorage maximum database size to 1 GB
- restore the previous OneKey behavior after the fork removed BuildConfig-based configuration
- prevent the 6 MB limit from causing `database or disk is full` and `cannot rollback` errors

Slack context: https://onekeygroup.slack.com/archives/C01SZCKLJ0P/p1787380501933549

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- patch applies cleanly to the pristine `@onekeyfe/react-native-async-storage@3.0.78` archive and contains no Android build artifacts
- Android prod debug APK built successfully
- Pixel 6 Android simulator A/B test: old APK reproduced the SQLite full/rollback error; patched APK saved and read back 10.00 MB, crossing the former 6 MB limit, with no relevant SQLite errors
- verified the installed APK contains `mMaximumDatabaseSize = 1073741824L`

## QA notes

- Complete the business acceptance test on Android with OneKey Classic firmware 3.12.0 by sending a small BTC transaction and confirming broadcast/history without SQLite errors.
- Do not use the current dev tool to append 10 MB to one key ten times: Android has a separate 20 MB per-row CursorWindow limit. A 100 MB storage stress test should use multiple keys/chunks.