### PR TITLE
fix: refine perps desktop table layout OK-59954

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -35,6 +35,10 @@ import {
   getColumnStyle,
   getOrderAssetDisplayName,
 } from '../utils';
+import {
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT,
+  PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT,
+} from '../utils/tableLayout';
 
 import type { IColumnConfig, IRenderMode } from '../List/CommonTableListView';
 
@@ -410,8 +414,8 @@ const OpenOrdersRow = memo(
       <XStack
         flex={1}
         py="$1.5"
-        pl="$5"
-        pr="$3"
+        pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+        pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
         alignItems="center"
         backgroundColor={bgColor}
         onHoverIn={() => onHoverChange?.(index)}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -44,6 +44,10 @@ import { showClosePositionDialog } from '../ClosePositionModal';
 import { showSetTpslDialog } from '../SetTpslModal';
 import { calcCellAlign, getColumnStyle } from '../utils';
 import { MOBILE_POSITION_ACTION_TEXT_SIZE } from '../utils/positionActionPresentation';
+import {
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT,
+  PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT,
+} from '../utils/tableLayout';
 
 import { DesktopActionIconButton } from './DesktopActionIconButton';
 
@@ -708,8 +712,8 @@ const PositionRowDesktop = memo(
         <XStack
           minWidth={renderMode === 'full' ? cellMinWidth : undefined}
           py="$1.5"
-          pl="22px"
-          pr="$3"
+          pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+          pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
           display="flex"
           flex={1}
           alignItems="center"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -31,6 +31,10 @@ import {
   getColumnStyle,
   getFillDirectionDisplayInfo,
 } from '../utils';
+import {
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT,
+  PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT,
+} from '../utils/tableLayout';
 
 import {
   getTradeFillClosePnlBN,
@@ -345,8 +349,8 @@ const TradesHistoryRow = memo(
       <XStack
         flex={1}
         py="$1.5"
-        pl="$5"
-        pr="$3"
+        pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+        pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
         alignItems="center"
         backgroundColor={bgColor}
         onHoverIn={() => onHoverChange?.(index)}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -55,6 +55,11 @@ import {
 } from '../../../utils/mobileLayoutTrace';
 import { PullToRefresh } from '../../PullToRefresh';
 import { calcCellAlign, getColumnStyle } from '../utils';
+import {
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT,
+  PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT,
+  getPerpDesktopTableFixedSectionWidth,
+} from '../utils/tableLayout';
 
 import type {
   LayoutChangeEvent,
@@ -483,6 +488,10 @@ export function CommonTableListView<T>({
       ),
     [fixedColumns],
   );
+  const fixedSectionWidth = useMemo(
+    () => getPerpDesktopTableFixedSectionWidth(fixedMinWidth),
+    [fixedMinWidth],
+  );
 
   const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null);
 
@@ -904,14 +913,27 @@ export function CommonTableListView<T>({
           flexGrow: 1,
         }}
       >
-        <XStack flex={1} py="$2" pl="$5" pr="$3" minWidth={scrollableMinWidth}>
+        <XStack
+          flex={1}
+          py="$2"
+          pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+          pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
+          minWidth={scrollableMinWidth}
+        >
           {scrollableColumns.map((column, index) =>
             renderHeaderCell(column, index),
           )}
         </XStack>
       </ScrollView>
       {hasFixedColumns ? (
-        <XStack py="$2" px="$3" minWidth={fixedMinWidth}>
+        <XStack
+          py="$2"
+          pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+          pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
+          width={fixedSectionWidth}
+          minWidth={fixedSectionWidth}
+          flexShrink={0}
+        >
           {fixedColumns.map((column, index) => renderHeaderCell(column, index))}
         </XStack>
       ) : null}
@@ -967,7 +989,9 @@ export function CommonTableListView<T>({
       {/* Fixed columns */}
       {hasFixedColumns ? (
         <YStack
-          minWidth={fixedMinWidth}
+          width={fixedSectionWidth}
+          minWidth={fixedSectionWidth}
+          flexShrink={0}
           cursor="default"
           bg="$bgApp"
           $platform-web={{

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -189,7 +189,7 @@ function useOpenOrdersColumnsConfig({
         }),
         minWidth: 140,
         flex: 1,
-        align: 'center',
+        align: 'left',
       },
       {
         key: 'cancel',

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
@@ -175,7 +175,7 @@ function PerpPositionsList({
           id: ETranslations.perp_position_tp_sl,
         }),
         minWidth: 140,
-        align: 'center',
+        align: 'left',
         flex: 1,
       },
       {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -66,6 +66,10 @@ import {
   getTwapHistoryEventTimeMs,
   normalizeEpochMs,
 } from '../utils';
+import {
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT,
+  PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT,
+} from '../utils/tableLayout';
 
 import {
   CommonTableListView,
@@ -492,8 +496,8 @@ function TwapActiveRow({
     <XStack
       flex={1}
       py="$1.5"
-      pl="$5"
-      pr="$3"
+      pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+      pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
       alignItems="center"
       backgroundColor={bgColor}
       onHoverIn={() => onHoverChange?.(index)}
@@ -787,8 +791,8 @@ function TwapHistoryRow({
     <XStack
       flex={1}
       py="$1.5"
-      pl="$5"
-      pr="$3"
+      pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+      pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
       alignItems="center"
       backgroundColor={bgColor}
       onHoverIn={() => onHoverChange?.(index)}
@@ -1110,8 +1114,8 @@ function TwapFillRow({
     <XStack
       flex={1}
       py="$1.5"
-      pl="$5"
-      pr="$3"
+      pl={PERP_DESKTOP_TABLE_ROW_PADDING_LEFT}
+      pr={PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT}
       alignItems="center"
       backgroundColor={bgColor}
       onHoverIn={() => onHoverChange?.(index)}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/tableLayout.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/tableLayout.test.ts
@@ -1,0 +1,19 @@
+import {
+  PERP_DESKTOP_TABLE_ROW_HORIZONTAL_PADDING,
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT,
+  PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT,
+  getPerpDesktopTableFixedSectionWidth,
+} from './tableLayout';
+
+describe('Perp desktop table layout', () => {
+  it('uses the same horizontal padding for table headers and rows', () => {
+    expect(PERP_DESKTOP_TABLE_ROW_PADDING_LEFT).toBe(20);
+    expect(PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT).toBe(12);
+    expect(PERP_DESKTOP_TABLE_ROW_HORIZONTAL_PADDING).toBe(32);
+  });
+
+  it('includes row padding in the fixed section width', () => {
+    expect(getPerpDesktopTableFixedSectionWidth(160)).toBe(192);
+    expect(getPerpDesktopTableFixedSectionWidth(80)).toBe(112);
+  });
+});

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/tableLayout.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/tableLayout.ts
@@ -1,0 +1,11 @@
+export const PERP_DESKTOP_TABLE_ROW_PADDING_LEFT = 20;
+export const PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT = 12;
+
+export const PERP_DESKTOP_TABLE_ROW_HORIZONTAL_PADDING =
+  PERP_DESKTOP_TABLE_ROW_PADDING_LEFT + PERP_DESKTOP_TABLE_ROW_PADDING_RIGHT;
+
+export function getPerpDesktopTableFixedSectionWidth(
+  fixedColumnsMinWidth: number,
+) {
+  return fixedColumnsMinWidth + PERP_DESKTOP_TABLE_ROW_HORIZONTAL_PADDING;
+}

--- a/packages/kit/src/views/Perp/layouts/perpLayoutUtils.ts
+++ b/packages/kit/src/views/Perp/layouts/perpLayoutUtils.ts
@@ -3,7 +3,7 @@ import { PERP_LAYOUT_CONFIG } from '@onekeyhq/shared/types/hyperliquid/perp.cons
 export const ORDER_BOOK_SIDE_RATIO_RESERVED_HEIGHT = 36;
 export const ORDER_BOOK_SIDE_RATIO_GAP = 4;
 export const PERP_DESKTOP_CHART_MIN_HEIGHT = 360;
-export const PERP_DESKTOP_INFO_MIN_HEIGHT = 240;
+export const PERP_DESKTOP_INFO_MIN_HEIGHT = 300;
 
 const ORDER_BOOK_VERTICAL_PADDING = 2;
 const ORDER_BOOK_VERTICAL_HEADER_HEIGHT = 24;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59954](https://onekeyhq.atlassian.net/browse/OK-59954)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Keep the Perps desktop order/info pane at least 300px high.
- Align desktop table header and row padding, including fixed-section widths, across positions, open orders, trade history, and TWAP tabs.
- Left-align TP/SL columns in positions and open orders.

## Issue

https://onekeyhq.atlassian.net/browse/OK-59954

## Test Plan

- yarn jest packages/kit/src/views/Perp/components/OrderInfoPanel/utils/tableLayout.test.ts packages/kit/src/views/Perp/layouts/perpLayoutUtils.test.ts packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.test.tsx --runInBand
- yarn agent:check --profile commit
- yarn agent:check --profile pr

[OK-59954]: https://onekeyhq.atlassian.net/browse/OK-59954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ