### PR TITLE
fix: localize native chart indicator settings

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewIndicatorContent.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewIndicatorContent.tsx
@@ -121,7 +121,7 @@ function OkxIndicatorContent({
           <OkxIndicatorOpacitySlider
             value={indicator.opacity}
             label={intl.formatMessage({
-              id: ETranslations.market_chart_settings__color_preferences,
+              id: ETranslations.market_chart_indicator_transparency__label,
             })}
             upColor={indicator.opacityColors?.upColor ?? OKX_CHART_UP}
             downColor={indicator.opacityColors?.downColor ?? OKX_CHART_DOWN}

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewIndicatorFields.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewIndicatorFields.tsx
@@ -406,7 +406,7 @@ export function OkxIndicatorLineRow({
     id: ETranslations.market_chart_settings__solid_line,
   });
   const dashedLineLabel = intl.formatMessage({
-    id: ETranslations.market_chart_settings__dotted_line,
+    id: ETranslations.market_chart_indicator_dashed_line__label,
   });
   const secondaryStyleOptions = [solidLineLabel, dashedLineLabel];
 

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
@@ -144,6 +144,7 @@ export const TradingViewNativeChartControlsContainer = memo(
     const showIndicatorsDialog = useCallback(() => {
       if (layoutMode === 'desktop') {
         showTradingViewNativeIndicatorSettingsDialog({
+          intl,
           onConfirm: onIndicatorSettingsConfirm,
           value: indicatorSettingsValue,
         });
@@ -169,6 +170,7 @@ export const TradingViewNativeChartControlsContainer = memo(
       indicatorSettingsValue,
       indicators,
       indicatorsTitle,
+      intl,
       layoutMode,
       maxSelectableSubIndicatorCount,
       onIndicatorSettingsConfirm,

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -32,6 +32,7 @@ import {
   reconcileTradingViewNativeIndicatorActiveState,
   updateTradingViewNativeIndicatorActiveState,
 } from './indicatorSettingsAdapter';
+import { localizeTradingViewNativeIndicatorSettingsValue } from './indicatorSettingsLocalization';
 import { TradingViewNativeChart } from './TradingViewNativeChart';
 import { TradingViewNativeChartControlsContainer } from './TradingViewNativeChartControlsContainer';
 import { TradingViewNativeFullscreenButton } from './TradingViewNativeFullscreenButton';
@@ -196,8 +197,13 @@ export const TradingViewNativeContainer = memo(
     );
     const indicatorSettingsValue = useMemo(
       () =>
-        getTradingViewNativeIndicatorSettingsValue(normalizedIndicatorSettings),
-      [normalizedIndicatorSettings],
+        localizeTradingViewNativeIndicatorSettingsValue(
+          getTradingViewNativeIndicatorSettingsValue(
+            normalizedIndicatorSettings,
+          ),
+          intl,
+        ),
+      [intl, normalizedIndicatorSettings],
     );
     const mainIndicatorSettingsSnapshot = useMemo(
       () => ({

--- a/packages/kit/src/components/TradingView/TradingViewNative/indicatorSettingsLocalization.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/indicatorSettingsLocalization.test.ts
@@ -1,0 +1,123 @@
+// cspell:ignore macd trix
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { createTradingViewNativeIndicatorSettingsValue } from './indicatorSettingsAdapter';
+import { localizeTradingViewNativeIndicatorSettingsValue } from './indicatorSettingsLocalization';
+
+import type { IIndicatorSettingsIntl } from './indicatorSettingsLocalization';
+
+const EXPECTED_TRANSLATION_IDS = [
+  ETranslations.market_chart_indicator_adx_smoothing__label,
+  ETranslations.market_chart_indicator_cci__title,
+  ETranslations.market_chart_indicator_di_length__label,
+  ETranslations.market_chart_indicator_divisor__label,
+  ETranslations.market_chart_indicator_dmi__title,
+  ETranslations.market_chart_indicator_emv__title,
+  ETranslations.market_chart_indicator_fast_length__label,
+  ETranslations.market_chart_indicator_histogram__label,
+  ETranslations.market_chart_indicator_increment__label,
+  ETranslations.market_chart_indicator_length__label,
+  ETranslations.market_chart_indicator_lower_limit__label,
+  ETranslations.market_chart_indicator_ma_length__label,
+  ETranslations.market_chart_indicator_macd__desc,
+  ETranslations.market_chart_indicator_maximum__label,
+  ETranslations.market_chart_indicator_mfi__title,
+  ETranslations.market_chart_indicator_middle_limit__label,
+  ETranslations.market_chart_indicator_mtm__title,
+  ETranslations.market_chart_indicator_obv__title,
+  ETranslations.market_chart_indicator_roc__title,
+  ETranslations.market_chart_indicator_rsi__title,
+  ETranslations.market_chart_indicator_rsi_length__label,
+  ETranslations.market_chart_indicator_signal__label,
+  ETranslations.market_chart_indicator_signal_length__label,
+  ETranslations.market_chart_indicator_slow_length__label,
+  ETranslations.market_chart_indicator_smoothed_ma__label,
+  ETranslations.market_chart_indicator_smoothing_length__label,
+  ETranslations.market_chart_indicator_start__label,
+  ETranslations.market_chart_indicator_stddev__label,
+  ETranslations.market_chart_indicator_stoch_rsi__title,
+  ETranslations.market_chart_indicator_stochastic_length__label,
+  ETranslations.market_chart_indicator_upper_limit__label,
+  ETranslations.market_chart_indicator_vol__title,
+  ETranslations.market_chart_indicator_volume_ma__label,
+  ETranslations.market_chart_indicator_wr__title,
+  ETranslations.market_chart_indicator_zero__label,
+  ETranslations.market_chart_indicator_zero_line__label,
+  ETranslations.market_chart_settings__background,
+] as const;
+
+function getLocalizedValue() {
+  const intl: IIndicatorSettingsIntl = {
+    formatMessage: ({ id }) => id,
+  };
+  return localizeTradingViewNativeIndicatorSettingsValue(
+    createTradingViewNativeIndicatorSettingsValue(),
+    intl,
+  );
+}
+
+describe('indicatorSettingsLocalization', () => {
+  it('uses every existing production indicator-settings translation', () => {
+    const value = getLocalizedValue();
+    const renderedTexts = new Set(
+      value.indicators.flatMap((indicator) => [
+        indicator.description,
+        indicator.title,
+        ...(indicator.parameters?.map((parameter) => parameter.label) ?? []),
+        ...indicator.lines.map((line) => line.label),
+      ]),
+    );
+
+    expect(
+      EXPECTED_TRANSLATION_IDS.filter(
+        (translationId) => !renderedTexts.has(translationId),
+      ),
+    ).toEqual([]);
+  });
+
+  it('keeps technical identifiers while localizing user-facing names', () => {
+    const value = getLocalizedValue();
+    const volume = value.indicators.find((indicator) => indicator.id === 'VOL');
+    const macd = value.indicators.find((indicator) => indicator.id === 'MACD');
+    const rsi = value.indicators.find((indicator) => indicator.id === 'RSI');
+    const trix = value.indicators.find((indicator) => indicator.id === 'TRIX');
+
+    expect(volume).toMatchObject({
+      description: ETranslations.market_chart_indicator_vol__title,
+      label: 'VOL',
+      title: `VOL (${ETranslations.market_chart_indicator_vol__title})`,
+    });
+    expect(macd).toMatchObject({
+      description: ETranslations.market_chart_indicator_macd__desc,
+      label: 'MACD',
+      title: 'MACD',
+    });
+    expect(rsi).toMatchObject({
+      description: ETranslations.market_chart_indicator_rsi__title,
+      label: 'RSI',
+      title: `RSI (${ETranslations.market_chart_indicator_rsi__title})`,
+    });
+    expect(trix).toMatchObject({
+      description: 'TRIX',
+      label: 'TRIX',
+      title: 'TRIX',
+    });
+  });
+
+  it('keeps background, zero, and zero-line labels distinct', () => {
+    const value = getLocalizedValue();
+    const rsi = value.indicators.find((indicator) => indicator.id === 'RSI');
+    const trix = value.indicators.find((indicator) => indicator.id === 'TRIX');
+    const roc = value.indicators.find((indicator) => indicator.id === 'ROC');
+
+    expect(
+      rsi?.lines.find((line) => line.id === 'fill:background')?.label,
+    ).toBe(ETranslations.market_chart_settings__background);
+    expect(trix?.lines.find((line) => line.id === 'band:zero')?.label).toBe(
+      ETranslations.market_chart_indicator_zero__label,
+    );
+    expect(roc?.lines.find((line) => line.id === 'band:zero')?.label).toBe(
+      ETranslations.market_chart_indicator_zero_line__label,
+    );
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/indicatorSettingsLocalization.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/indicatorSettingsLocalization.ts
@@ -1,0 +1,222 @@
+// cspell:ignore MACD Stoch TRIX
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { isTradingViewNativeAnyIndicator } from './utils/chartIndicators';
+
+import type { ITradingViewNativeAnyIndicator } from './utils/chartIndicators';
+import type { ITradingViewIndicatorSettingsValue } from '../TradingViewChartControls/chartSettings';
+
+export type IIndicatorSettingsIntl = {
+  formatMessage: (descriptor: { id: ETranslations }) => string;
+};
+
+type IIndicatorSettingsTranslationConfig = {
+  description?: ETranslations;
+  labels?: Readonly<Record<string, ETranslations>>;
+  name?: ETranslations;
+};
+
+const INDICATOR_SETTINGS_TRANSLATIONS: Partial<
+  Record<ITradingViewNativeAnyIndicator, IIndicatorSettingsTranslationConfig>
+> = {
+  BOLL: {
+    labels: {
+      deviation: ETranslations.market_chart_indicator_stddev__label,
+      period: ETranslations.market_chart_indicator_length__label,
+    },
+  },
+  SAR: {
+    labels: {
+      accelerationMax: ETranslations.market_chart_indicator_maximum__label,
+      accelerationStart: ETranslations.market_chart_indicator_start__label,
+      accelerationStep: ETranslations.market_chart_indicator_increment__label,
+    },
+  },
+  VOL: {
+    labels: {
+      movingAveragePeriod:
+        ETranslations.market_chart_indicator_ma_length__label,
+      'plot:movingAverage':
+        ETranslations.market_chart_indicator_volume_ma__label,
+      'plot:smoothedMovingAverage':
+        ETranslations.market_chart_indicator_smoothed_ma__label,
+      'plot:volume': ETranslations.market_chart_indicator_vol__title,
+      smoothingPeriod:
+        ETranslations.market_chart_indicator_smoothing_length__label,
+    },
+    name: ETranslations.market_chart_indicator_vol__title,
+  },
+  MACD: {
+    description: ETranslations.market_chart_indicator_macd__desc,
+    labels: {
+      fastPeriod: ETranslations.market_chart_indicator_fast_length__label,
+      'plot:histogram': ETranslations.market_chart_indicator_histogram__label,
+      'plot:signal': ETranslations.market_chart_indicator_signal__label,
+      signalPeriod: ETranslations.market_chart_indicator_signal_length__label,
+      slowPeriod: ETranslations.market_chart_indicator_slow_length__label,
+    },
+  },
+  RSI: {
+    labels: {
+      'band:lower': ETranslations.market_chart_indicator_lower_limit__label,
+      'band:middle': ETranslations.market_chart_indicator_middle_limit__label,
+      'band:upper': ETranslations.market_chart_indicator_upper_limit__label,
+      'fill:background': ETranslations.market_chart_settings__background,
+      movingAveragePeriod:
+        ETranslations.market_chart_indicator_smoothing_length__label,
+      period: ETranslations.market_chart_indicator_length__label,
+      'plot:movingAverage':
+        ETranslations.market_chart_indicator_smoothed_ma__label,
+    },
+    name: ETranslations.market_chart_indicator_rsi__title,
+  },
+  StochRSI: {
+    labels: {
+      'band:lower': ETranslations.market_chart_indicator_lower_limit__label,
+      'band:upper': ETranslations.market_chart_indicator_upper_limit__label,
+      'fill:background': ETranslations.market_chart_settings__background,
+      rsiPeriod: ETranslations.market_chart_indicator_rsi_length__label,
+      stochasticPeriod:
+        ETranslations.market_chart_indicator_stochastic_length__label,
+    },
+    name: ETranslations.market_chart_indicator_stoch_rsi__title,
+  },
+  OBV: {
+    labels: {
+      movingAveragePeriod:
+        ETranslations.market_chart_indicator_smoothing_length__label,
+      'plot:movingAverage':
+        ETranslations.market_chart_indicator_smoothed_ma__label,
+    },
+    name: ETranslations.market_chart_indicator_obv__title,
+  },
+  MFI: {
+    labels: {
+      'band:lower': ETranslations.market_chart_indicator_lower_limit__label,
+      'band:upper': ETranslations.market_chart_indicator_upper_limit__label,
+      'fill:background': ETranslations.market_chart_settings__background,
+      period: ETranslations.market_chart_indicator_length__label,
+    },
+    name: ETranslations.market_chart_indicator_mfi__title,
+  },
+  TRIX: {
+    labels: {
+      'band:zero': ETranslations.market_chart_indicator_zero__label,
+      period: ETranslations.market_chart_indicator_length__label,
+    },
+  },
+  EMV: {
+    labels: {
+      divisor: ETranslations.market_chart_indicator_divisor__label,
+      period: ETranslations.market_chart_indicator_length__label,
+    },
+    name: ETranslations.market_chart_indicator_emv__title,
+  },
+  WR: {
+    labels: {
+      'band:lower': ETranslations.market_chart_indicator_lower_limit__label,
+      'band:upper': ETranslations.market_chart_indicator_upper_limit__label,
+      'fill:background': ETranslations.market_chart_settings__background,
+      period: ETranslations.market_chart_indicator_length__label,
+    },
+    name: ETranslations.market_chart_indicator_wr__title,
+  },
+  ROC: {
+    labels: {
+      'band:zero': ETranslations.market_chart_indicator_zero_line__label,
+      period: ETranslations.market_chart_indicator_length__label,
+    },
+    name: ETranslations.market_chart_indicator_roc__title,
+  },
+  MTM: {
+    labels: {
+      'band:zero': ETranslations.market_chart_indicator_zero__label,
+      period: ETranslations.market_chart_indicator_length__label,
+      'plot:momentum': ETranslations.market_chart_indicator_mtm__title,
+    },
+    name: ETranslations.market_chart_indicator_mtm__title,
+  },
+  DMI: {
+    labels: {
+      adxSmoothingPeriod:
+        ETranslations.market_chart_indicator_adx_smoothing__label,
+      diPeriod: ETranslations.market_chart_indicator_di_length__label,
+    },
+    name: ETranslations.market_chart_indicator_dmi__title,
+  },
+  CCI: {
+    labels: {
+      'band:lower': ETranslations.market_chart_indicator_lower_limit__label,
+      'band:upper': ETranslations.market_chart_indicator_upper_limit__label,
+      'fill:background': ETranslations.market_chart_settings__background,
+      movingAveragePeriod:
+        ETranslations.market_chart_indicator_smoothing_length__label,
+      period: ETranslations.market_chart_indicator_length__label,
+      'plot:movingAverage':
+        ETranslations.market_chart_indicator_smoothed_ma__label,
+    },
+    name: ETranslations.market_chart_indicator_cci__title,
+  },
+};
+
+type ILabelledSettingsItem = {
+  id: string;
+  label: string;
+};
+
+function localizeLabels<T extends ILabelledSettingsItem>(
+  items: T[],
+  translationIds: Readonly<Record<string, ETranslations>>,
+  intl: IIndicatorSettingsIntl,
+) {
+  return items.map((item) => {
+    const translationId = translationIds[item.id];
+    return translationId
+      ? { ...item, label: intl.formatMessage({ id: translationId }) }
+      : item;
+  });
+}
+
+export function localizeTradingViewNativeIndicatorSettingsValue(
+  value: ITradingViewIndicatorSettingsValue,
+  intl: IIndicatorSettingsIntl,
+): ITradingViewIndicatorSettingsValue {
+  return {
+    ...value,
+    indicators: value.indicators.map((indicator) => {
+      if (!isTradingViewNativeAnyIndicator(indicator.id)) {
+        return indicator;
+      }
+
+      const translationConfig = INDICATOR_SETTINGS_TRANSLATIONS[indicator.id];
+      if (!translationConfig) {
+        return indicator;
+      }
+
+      const descriptionId =
+        translationConfig.description ?? translationConfig.name;
+      const translatedName = translationConfig.name
+        ? intl.formatMessage({ id: translationConfig.name })
+        : undefined;
+      const labels = translationConfig.labels;
+
+      return {
+        ...indicator,
+        ...(descriptionId
+          ? { description: intl.formatMessage({ id: descriptionId }) }
+          : {}),
+        ...(translatedName
+          ? { title: `${indicator.label} (${translatedName})` }
+          : {}),
+        ...(labels && indicator.parameters
+          ? {
+              parameters: localizeLabels(indicator.parameters, labels, intl),
+            }
+          : {}),
+        lines: labels
+          ? localizeLabels(indicator.lines, labels, intl)
+          : indicator.lines,
+      };
+    }),
+  };
+}

--- a/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.test.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from 'react';
 
 import { showTradingViewNativeIndicatorSettingsDialog } from './showTradingViewNativeIndicatorSettingsDialog';
 
+import type { IIndicatorSettingsIntl } from './indicatorSettingsLocalization';
 import type {
   ITradingViewIndicatorSettingsProps,
   ITradingViewIndicatorSettingsValue,
@@ -41,8 +42,11 @@ describe('showTradingViewNativeIndicatorSettingsDialog', () => {
       schemaVersion: 1,
     };
     const onConfirm = jest.fn(() => Promise.resolve());
+    const intl: IIndicatorSettingsIntl = {
+      formatMessage: ({ id }) => id,
+    };
 
-    showTradingViewNativeIndicatorSettingsDialog({ onConfirm, value });
+    showTradingViewNativeIndicatorSettingsDialog({ intl, onConfirm, value });
     const props = mockShowDialog.mock.calls[0][0].renderContent.props;
     expect(props.maxActiveSubIndicatorCount).toBeNull();
 

--- a/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.tsx
@@ -10,13 +10,18 @@ import {
   createTradingViewNativeIndicatorSettingsValue,
   getTradingViewNativeIndicatorSettings,
 } from './indicatorSettingsAdapter';
+import { localizeTradingViewNativeIndicatorSettingsValue } from './indicatorSettingsLocalization';
+
+import type { IIndicatorSettingsIntl } from './indicatorSettingsLocalization';
 
 const TRADING_VIEW_NATIVE_INDICATOR_SETTINGS_DIALOG_WIDTH = 690;
 
 export function showTradingViewNativeIndicatorSettingsDialog({
+  intl,
   onConfirm,
   value,
 }: {
+  intl: IIndicatorSettingsIntl;
   onConfirm: (
     value: ITradingViewNativeIndicatorSettings,
   ) => void | Promise<void>;
@@ -47,7 +52,12 @@ export function showTradingViewNativeIndicatorSettingsDialog({
     renderContent: (
       <TradingViewIndicatorSettings
         value={value}
-        createDefaultValue={createTradingViewNativeIndicatorSettingsValue}
+        createDefaultValue={() =>
+          localizeTradingViewNativeIndicatorSettingsValue(
+            createTradingViewNativeIndicatorSettingsValue(),
+            intl,
+          )
+        }
         maxActiveSubIndicatorCount={null}
         onClose={() => {
           void closeDialog();


### PR DESCRIPTION
## Summary

- localize Native TradingView indicator titles, descriptions, parameters, bands, and plots with the 38 existing production Lokalise keys
- correct the dashed-line and transparency labels without repurposing dotted-line or color-preferences translations
- keep the indicator adapter focused on data conversion by applying translations at the Native settings UI boundary, including Reset
- preserve technical indicator identifiers and leave generated locale files unchanged

## Validation

- targeted Jest: 6 suites and 48 tests passed
- `yarn agent:check --profile commit`
- thermo-nuclear maintainability review: no blockers

## Lokalise

- verified the project and all 19 repository locales using `.env`
- reused existing keys only; no new Lokalise keys or generated translation edits
