### PR TITLE
fix: Katana swap pair and slippage editor (OK-60584, OK-61086)

### DIFF
--- a/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
@@ -255,7 +255,7 @@ const PreSwapInfoGroup = ({
         placement="bottom-end"
         floatingPanelProps={{ width: 400 }}
         renderTrigger={trigger}
-        renderContent={() => (
+        renderContent={
           <Stack p="$4" width={400}>
             <SwapReviewSlippageEditor
               initialValue={slippage}
@@ -264,7 +264,7 @@ const PreSwapInfoGroup = ({
               onSave={slippageEditor.onSave}
             />
           </Stack>
-        )}
+        }
       />
     );
   }, [intl, slippage, slippageEditor]);

--- a/packages/shared/types/swap/SwapProvider.constants.ts
+++ b/packages/shared/types/swap/SwapProvider.constants.ts
@@ -882,6 +882,32 @@ export const swapDefaultSetTokens: Record<
       'networkLogoURI': 'https://uni.onekey-asset.com/static/chain/linea.png',
     },
   },
+  'evm--747474': {
+    fromToken: {
+      'networkId': 'evm--747474',
+      'contractAddress': '',
+      'name': 'Katana',
+      'symbol': 'ETH',
+      'decimals': 18,
+      'logoURI':
+        'https://uni-test.onekey-asset.com/dashboard/logo/upload_1784281571805.0.8864057938722496.0.webp',
+      'isNative': true,
+      'networkLogoURI':
+        'https://uni-test.onekey-asset.com/dashboard/logo/upload_1784281571805.0.8864057938722496.0.webp',
+    },
+    toToken: {
+      'networkId': 'evm--747474',
+      'contractAddress': '0x7f1f4b4b29f5058fa32cc7a97141b8d7e5abdc2d',
+      'name': 'Katana Network Token',
+      'symbol': 'KAT',
+      'decimals': 18,
+      'logoURI':
+        'https://coin-images.coingecko.com/coins/images/70225/large/katana-social-icon.png?1761121098',
+      'isNative': false,
+      'networkLogoURI':
+        'https://uni-test.onekey-asset.com/dashboard/logo/upload_1784281571805.0.8864057938722496.0.webp',
+    },
+  },
   'evm--196': {
     fromToken: {
       'networkId': 'evm--196',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60584](https://onekeyhq.atlassian.net/browse/OK-60584) [OK-61086](https://onekeyhq.atlassian.net/browse/OK-61086)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Configure the Katana wallet Home Swap entry to preselect native ETH and KAT using the current token API metadata.
- Keep the Market Swap review slippage editor mounted while the quote rebuilds, so the newly entered value does not revert during saving.

## Issues

- Fixes OK-60584
- Fixes OK-61086

## Root cause

The slippage Popover received a new inline render function when the saving state changed. React treated it as a new component type, remounted the editor, and reset its local input from the previous slippage value.

## Test plan

- `yarn agent:check --profile commit`
- `yarn jest packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx --runInBand`
- Desktop Market PUMP flow: changed slippage from 1% to 0%, selected **This order**, and verified the disabled/loading input remained at 0%.
- Verified both configured Katana image URLs return HTTP 200.

## Risk

- Changes are scoped to Katana default token metadata and the desktop/web slippage Popover content identity.
- No transaction was signed or broadcast during runtime verification.

[OK-60584]: https://onekeyhq.atlassian.net/browse/OK-60584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61086]: https://onekeyhq.atlassian.net/browse/OK-61086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ