### PR TITLE
fix: improve perps tab overflow (OK-61160)

### DIFF
--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -49,7 +49,8 @@ type IReadonlySharedValue<T> = { readonly value: T };
 
 const TAB_HOVER_STYLE = { bg: '$bgHover' } as const;
 const TAB_PRESS_STYLE = { bg: '$bgActive' } as const;
-const TAB_LIST_VIEW_STYLE = { flexShrink: 1 } as const;
+// Fill the space before the toolbar so the tab list scrolls only on overflow.
+const TAB_LIST_VIEW_STYLE = { flexGrow: 1, flexShrink: 1 } as const;
 const TAB_CONTENT_CONTAINER_STYLE = { pr: 16 } as const;
 const PILL_SCROLL_CONTENT_STYLE = {
   px: '$pagePadding',

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -49,8 +49,11 @@ type IReadonlySharedValue<T> = { readonly value: T };
 
 const TAB_HOVER_STYLE = { bg: '$bgHover' } as const;
 const TAB_PRESS_STYLE = { bg: '$bgActive' } as const;
-// Fill the space before the toolbar so the tab list scrolls only on overflow.
-const TAB_LIST_VIEW_STYLE = { flexGrow: 1, flexShrink: 1 } as const;
+const TAB_LIST_VIEW_STYLE = { flexShrink: 1 } as const;
+const TAB_LIST_FILL_AVAILABLE_SPACE_STYLE = {
+  flexGrow: 1,
+  flexShrink: 1,
+} as const;
 const TAB_CONTENT_CONTAINER_STYLE = { pr: 16 } as const;
 const PILL_SCROLL_CONTENT_STYLE = {
   px: '$pagePadding',
@@ -633,6 +636,8 @@ export interface ITabBarProps extends TabBarProps<string> {
   /** Aligns the selected item within a horizontal scrollable tab bar. */
   keepFocusedTabVisible?: boolean;
   showsHorizontalScrollIndicator?: boolean;
+  /** Fills the row space before an optional toolbar. */
+  fillAvailableSpace?: boolean;
 }
 
 export interface ITabBarItemProps {
@@ -761,6 +766,7 @@ export function TabBar({
   directTabPressAnimationMode = 'timing',
   keepFocusedTabVisible = false,
   showsHorizontalScrollIndicator = false,
+  fillAvailableSpace = false,
 }: Omit<Partial<ITabBarProps>, 'focusedTab' | 'tabNames'> & {
   focusedTab: SharedValue<string>;
   tabNames: string[];
@@ -1371,7 +1377,11 @@ export function TabBar({
     >
       <XStack alignItems="center" gap="$2" justifyContent="space-between">
         <ListView
-          style={TAB_LIST_VIEW_STYLE}
+          style={
+            fillAvailableSpace
+              ? TAB_LIST_FILL_AVAILABLE_SPACE_STYLE
+              : TAB_LIST_VIEW_STYLE
+          }
           useFlashList
           data={tabNames}
           ref={listViewRef}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -275,6 +275,7 @@ function PerpOrderInfoPanel() {
         <Tabs.TabBar
           {...props}
           scrollable
+          fillAvailableSpace
           keepFocusedTabVisible
           showsHorizontalScrollIndicator
           renderItem={({ name, isFocused, onPress }) => (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61160](https://onekeyhq.atlassian.net/browse/OK-61160)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Add an opt-in TabBar layout that lets the Perps order-info tab list fill the remaining space before its toolbar.
- Keep every other TabBar consumer on the existing layout while preserving horizontal scrolling when the Perps tabs overflow.

## Testing

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` (local checks passed; human review remains required)

## Issue

https://onekeyhq.atlassian.net/browse/OK-61160

[OK-61160]: https://onekeyhq.atlassian.net/browse/OK-61160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ