### PR TITLE
fix: clip price extrema markers to main chart

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
@@ -813,4 +813,47 @@ describe('TradingViewNative shared chart scene', () => {
       );
     }
   });
+
+  it('clips price extrema markers at the sub-indicator boundary', () => {
+    const subIndicatorPanes =
+      createTradingViewNativeSubIndicatorRenderSnapshots({
+        configs: [{ id: 'RSI', indicator: 'RSI' }],
+        points: POINTS,
+      }).map(({ pane }) => pane);
+    const scene = buildTradingViewNativeChartScene({
+      candleIntervalSeconds: 3600,
+      chartType: 'candlestick',
+      crosshair: { visible: false, x: 0, y: 0 },
+      hasVolume: false,
+      height: 240,
+      measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
+      points: POINTS,
+      priceRangeScale: 0.9,
+      subIndicatorPanes,
+      viewport: { offset: 0, zoomScale: 1 },
+      watermarkOpacity: 0.08,
+      width: 320,
+    });
+    const lowMarkerIndex = scene.commands.findIndex(
+      (command) =>
+        command.kind === 'text' &&
+        command.font === 'legend' &&
+        command.text === '97.00',
+    );
+    const lowMarker = scene.commands[lowMarkerIndex];
+    const extremaClip = scene.commands
+      .slice(0, lowMarkerIndex)
+      .findLast((command) => command.kind === 'clip');
+
+    expect(lowMarker).toMatchObject({ kind: 'text', text: '97.00' });
+    expect(extremaClip).toEqual({
+      kind: 'clip',
+      rect: { height: 160, width: 320, x: 0, y: 0 },
+    });
+    if (lowMarker?.kind === 'text' && extremaClip?.kind === 'clip') {
+      expect(lowMarker.y).toBeGreaterThan(extremaClip.rect.height);
+    }
+    expect(scene.commands[lowMarkerIndex + 1]).toEqual({ kind: 'restore' });
+  });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
@@ -772,6 +772,12 @@ export function buildTradingViewNativeChartScene({
     x: CHART_HORIZONTAL_PADDING,
     y: 0,
   };
+  const mainChartClip = {
+    height: mainChartBottom,
+    width,
+    x: 0,
+    y: 0,
+  };
 
   commands.push({
     kind: 'line',
@@ -1031,6 +1037,7 @@ export function buildTradingViewNativeChartScene({
         })
       : null;
   if (visiblePriceExtrema) {
+    commands.push({ kind: 'clip', rect: mainChartClip });
     const extrema = visiblePriceExtrema.low
       ? [visiblePriceExtrema.high, visiblePriceExtrema.low]
       : [visiblePriceExtrema.high];
@@ -1069,6 +1076,7 @@ export function buildTradingViewNativeChartScene({
         );
       }
     }
+    commands.push({ kind: 'restore' });
   }
 
   const crosshairPointIndex =


### PR DESCRIPTION
## Summary

- clip TradingViewNative price extrema markers to the main chart bounds
- prevent minimum and maximum price labels from drawing over sub-indicator panes after Y-axis scaling
- add regression coverage for a scaled chart with an RSI sub-indicator

## Tests

- yarn jest packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts --runInBand
- yarn jest packages/kit/src/components/TradingView/TradingViewNative/web/chartCanvasRenderer.test.ts packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts --runInBand
- yarn agent:check --profile commit

## UI verification

- Not run: no desktop app session or connected Android device was available.