### PR TITLE
chore: run unit tests in five shards

### DIFF
--- a/.github/scripts/ciFailureIssue.js
+++ b/.github/scripts/ciFailureIssue.js
@@ -5,6 +5,8 @@ const DEFAULT_CONSTRAINTS = [
   'Validate with the listed focused command, then run yarn agent:check --profile commit for changed TypeScript files.',
 ];
 
+const jestShardTotal = process.env.JEST_SHARD_TOTAL || '3';
+
 const RUNTIME_NOTES = {
   ciOnly:
     'Scope: CI-only diagnostics. This helper does not change app runtime behavior, native resources, or per-runtime JS heap state.',
@@ -77,7 +79,8 @@ const ciFailureConfigs = {
     commands: [
       'yarn install --immutable',
       'FAILED_SHARD=1',
-      `yarn test --coverage --shard="\${FAILED_SHARD}/3" --coverageDirectory="coverage/shard-\${FAILED_SHARD}" --coverageReporters=text --coverageReporters=lcov --coverageReporters=json-summary --coverageReporters=json --coverageThreshold={}`,
+      `JEST_SHARD_TOTAL=${jestShardTotal}`,
+      `yarn test --coverage --shard="\${FAILED_SHARD}/\${JEST_SHARD_TOTAL}" --coverageDirectory="coverage/shard-\${FAILED_SHARD}" --coverageReporters=text --coverageReporters=lcov --coverageReporters=json-summary --coverageReporters=json --coverageThreshold={}`,
       'yarn agent:check --profile commit',
     ],
     constraints: [

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   YARN_ENABLE_GLOBAL_CACHE: true
-  JEST_SHARD_TOTAL: 3
+  JEST_SHARD_TOTAL: 5
   JEST_COVERAGE_THRESHOLD_JSON: '{"statements":10,"branches":35,"functions":10}'
 
 permissions:
@@ -30,14 +30,14 @@ permissions:
 
 jobs:
   unittest:
-    name: Unit Tests (${{ matrix.shard }}/3)
+    name: Unit Tests (${{ matrix.shard }}/5)
     runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
       matrix:
         node-version: [24.x]
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Increase the Jest shard matrix from 3 to 5 parallel jobs.
- Keep coverage artifact validation and merging aligned with the five-shard total.

## Validation

- Parsed the workflow YAML and verified the shard matrix is 1 through 5.
- Confirmed Jest accepts the 1/5 shard configuration and enumerates tests.
- Ran yarn agent:check --profile commit.