### PR TITLE
fix: improve Market review and slippage UI (OK-61157, OK-60997, OK-61152)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
@@ -562,6 +562,25 @@ describe('marketDirectSendTx', () => {
     expect(highFeeResult.preparedUnsignedTx).toBe(preparedUnsignedTx);
   });
 
+  it('reuses a prepared unsigned transaction for fee estimation', async () => {
+    const preparedUnsignedTx = createUnsignedTx();
+
+    const result = await estimateMarketDirectGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        isInternalSwap: true,
+      },
+      preparedUnsignedTx,
+    });
+
+    expect(mockPrepareSendConfirmUnsignedTx).not.toHaveBeenCalled();
+    expect(result.preparedUnsignedTx).toBe(preparedUnsignedTx);
+  });
+
   it('converts a custom EVM legacy priority fee from Gwei to fee unit', async () => {
     mockPrepareSendConfirmUnsignedTx.mockResolvedValue(createUnsignedTx());
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -86,7 +86,9 @@ type IMarketDirectSendParams = {
 type IEstimateMarketDirectGasInfosParams = Omit<
   IMarketDirectSendParams,
   'gasInfos'
->;
+> & {
+  preparedUnsignedTx?: IUnsignedTxPro;
+};
 
 export type IMarketPresetFeeEstimateFakeTxToken = Pick<
   ISwapTokenBase,
@@ -924,6 +926,31 @@ export function buildMarketGasInfoFeeInfo(gasInfo: ISwapGasInfo): IFeeInfoUnit {
   };
 }
 
+export async function prepareMarketDirectUnsignedTx({
+  accountId,
+  networkId,
+  buildUnsignedParams,
+  approveUnsignedTxArr,
+}: Pick<
+  IEstimateMarketDirectGasInfosParams,
+  'accountId' | 'networkId' | 'buildUnsignedParams' | 'approveUnsignedTxArr'
+>) {
+  if (!accountId || !networkId) {
+    throw new OneKeyError('account error');
+  }
+
+  const buildUnsignedParamsCheckNonce = { ...buildUnsignedParams };
+  if (approveUnsignedTxArr?.length) {
+    buildUnsignedParamsCheckNonce.prevNonce =
+      approveUnsignedTxArr[approveUnsignedTxArr.length - 1].nonce;
+  }
+
+  return backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
+    ...buildUnsignedParamsCheckNonce,
+    isInternalSwap: true,
+  });
+}
+
 export async function estimateMarketDirectGasInfos({
   accountAddress,
   accountId,
@@ -933,6 +960,7 @@ export async function estimateMarketDirectGasInfos({
   networkFeeLevel,
   customPriorityFee,
   gasAccountAnalytics,
+  preparedUnsignedTx,
 }: IEstimateMarketDirectGasInfosParams): Promise<{
   gasInfos: IMarketGasInfoEntry[];
   gasFeeFiatValue?: string;
@@ -944,17 +972,14 @@ export async function estimateMarketDirectGasInfos({
     throw new OneKeyError('account error');
   }
 
-  const buildUnsignedParamsCheckNonce = { ...buildUnsignedParams };
-  if (approveUnsignedTxArr?.length) {
-    buildUnsignedParamsCheckNonce.prevNonce =
-      approveUnsignedTxArr[approveUnsignedTxArr.length - 1].nonce;
-  }
-
   const unsignedTx =
-    await backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
-      ...buildUnsignedParamsCheckNonce,
-      isInternalSwap: true,
-    });
+    preparedUnsignedTx ??
+    (await prepareMarketDirectUnsignedTx({
+      accountId,
+      networkId,
+      buildUnsignedParams,
+      approveUnsignedTxArr,
+    }));
 
   const gasInfos = await resolveMarketGasInfos({
     accountAddress,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
@@ -11,6 +11,7 @@ import {
   swapStepsAtom,
   useSwapStepsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import { ESwapReviewRebuildPhase } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewRebuildStateMachine';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
   IFetchQuoteResult,
@@ -115,6 +116,14 @@ function createAdapter(): jest.Mocked<IMarketSwapReviewAdapter> {
     sendSignMessage: jest.fn(),
     buildApproveInfos: jest.fn(),
   };
+}
+
+function createDeferred() {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 type ISendMarketSwapParams = Parameters<
@@ -355,11 +364,13 @@ describe('useMarketSwapReviewActions', () => {
         }),
       );
     });
-    expect(rebuildReview).toHaveBeenCalledWith({
-      slippagePercentage: 1,
-      networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
-      customPriorityFee: undefined,
-    });
+    expect(rebuildReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slippagePercentage: 1,
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+        customPriorityFee: undefined,
+      }),
+    );
     expect(onConfirmStart).toHaveBeenCalledTimes(1);
     expect(onConfirmStart.mock.invocationCallOrder[0]).toBeLessThan(
       adapter.sendSwapTx.mock.invocationCallOrder[0],
@@ -423,6 +434,111 @@ describe('useMarketSwapReviewActions', () => {
     expect(result.current.actions.preSwapStepsStart).toBe(
       initialPreSwapStepsStart,
     );
+  });
+
+  it('releases editing after execution rebuild and blocks confirm until fee is ready', async () => {
+    const adapter = createAdapter();
+    const feeEstimate = createDeferred();
+    const onExecutionReady = jest.fn();
+    const coreReviewState = createReviewState({
+      steps: [
+        {
+          type: ESwapStepType.SEND_TX,
+          status: ESwapStepStatus.READY,
+        },
+      ],
+      quoteResult: createQuoteResult({
+        toAmount: '2600',
+        slippage: 2,
+      }),
+      preSwapData: {
+        slippage: 2,
+      },
+    });
+    const finalReviewState = createReviewState({
+      steps: coreReviewState.steps,
+      quoteResult: coreReviewState.quoteResult,
+      preSwapData: {
+        slippage: 2,
+        netWorkFee: {
+          gasFeeFiatValue: '0.01',
+        },
+      },
+    });
+    adapter.rebuildReview = jest.fn(async (params) => {
+      expect(params.isCurrent()).toBe(true);
+      params.onPhaseChange(ESwapReviewRebuildPhase.BuildingTransaction);
+      params.onPhaseChange(ESwapReviewRebuildPhase.PreparingExecution);
+      params.onExecutionReady(coreReviewState);
+      await feeEstimate.promise;
+      return finalReviewState;
+    });
+    adapter.sendSwapTx.mockResolvedValue();
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return { actions, swapSteps };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+          }),
+        ),
+      },
+    );
+
+    let rebuildPromise: Promise<void> | undefined;
+    act(() => {
+      rebuildPromise = result.current.actions.rebuildReviewWithSlippage(2, {
+        onExecutionReady,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.actions.reviewRebuildState.phase).toBe(
+        ESwapReviewRebuildPhase.EstimatingFee,
+      );
+      expect(onExecutionReady).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.swapSteps.preSwapData.toTokenAmount).toBe('2600');
+    expect(result.current.swapSteps.preSwapData.estimateNetworkFeeLoading).toBe(
+      true,
+    );
+
+    act(() => {
+      result.current.actions.onConfirm();
+    });
+    expect(adapter.sendSwapTx).not.toHaveBeenCalled();
+
+    await act(async () => {
+      feeEstimate.resolve();
+      await rebuildPromise;
+    });
+
+    expect(result.current.actions.reviewRebuildState.phase).toBe(
+      ESwapReviewRebuildPhase.Ready,
+    );
+    expect(result.current.swapSteps.preSwapData.estimateNetworkFeeLoading).toBe(
+      false,
+    );
+    expect(
+      result.current.swapSteps.preSwapData.netWorkFee?.gasFeeFiatValue,
+    ).toBe('0.01');
+
+    act(() => {
+      result.current.actions.onConfirm();
+    });
+    await waitFor(() => {
+      expect(adapter.sendSwapTx).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('uses the review store fee level when refreshing prebuild data', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -738,6 +738,9 @@ describe('useSpeedSwapActions', () => {
     await act(async () => {
       reviewState = await result.current.rebuildMarketSwapReview({
         slippagePercentage: 1,
+        isCurrent: () => true,
+        onPhaseChange: jest.fn(),
+        onExecutionReady: jest.fn(),
       });
     });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -49,6 +49,7 @@ import {
   checkSwapLatestBalanceSufficient,
   getSwapRequiredNativeBalanceAmount,
 } from '@onekeyhq/kit/src/views/Swap/utils/swapBalanceUtils';
+import { ESwapReviewRebuildPhase } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewRebuildStateMachine';
 import type {
   ISwapReviewAdapter,
   ISwapReviewApproveBroadcastResult,
@@ -140,6 +141,7 @@ import {
   estimateMarketApproveGasInfos,
   estimateMarketDirectGasInfos,
   estimateMarketPresetGasFeeFiatValues,
+  prepareMarketDirectUnsignedTx,
   resolveMarketPresetNativeTokenPrice,
   sendMarketDirectUnsignedTxs,
 } from './marketDirectSendTx';
@@ -1462,7 +1464,10 @@ export function useSpeedSwapActions(props: {
       snapshot: IMarketReviewExecutionSnapshot,
       networkFeeLevel: ESwapNetworkFeeLevel = ESwapNetworkFeeLevel.MEDIUM,
       customPriorityFee?: ISwapReviewCustomPriorityFee,
-      options?: { throwOnEstimateError?: boolean },
+      options?: {
+        throwOnEstimateError?: boolean;
+        onExecutionReady?: (reviewState: ISwapReviewState) => void;
+      },
     ) => {
       const nextReviewState = buildMarketReviewState({
         accountId: snapshot.accountId,
@@ -1485,6 +1490,28 @@ export function useSpeedSwapActions(props: {
         texts: buildReviewStepTexts(snapshot.quoteResult.info.providerName),
       });
 
+      const buildReviewStateWithFee = ({
+        netWorkFee,
+        estimateNetworkFeeLoading,
+      }: {
+        netWorkFee: ISwapReviewState['preSwapData']['netWorkFee'];
+        estimateNetworkFeeLoading: boolean;
+      }): ISwapReviewState => ({
+        steps: nextReviewState.steps,
+        preSwapData: {
+          ...nextReviewState.preSwapData,
+          swapBuildLoading: false,
+          estimateNetworkFeeLoading,
+          swapBuildResultData: {
+            swapInfo: snapshot.swapInfo,
+            encodedTx: snapshot.buildUnsignedParams.encodedTx,
+            transferInfo: snapshot.buildUnsignedParams.transfersInfo?.[0],
+          },
+          netWorkFee,
+        },
+        quoteResult: snapshot.quoteResult,
+      });
+
       let netWorkFee: ISwapReviewState['preSwapData']['netWorkFee'];
       try {
         const approveUnsignedTxArr = await buildMarketApproveUnsignedTxArr({
@@ -1495,15 +1522,47 @@ export function useSpeedSwapActions(props: {
           accountId: snapshot.accountId,
           networkId: snapshot.networkId,
         });
-        if (
+        const shouldEstimateApproveOnly = Boolean(
           snapshot.quoteResult.swapShouldSignedData &&
-          approveUnsignedTxArr?.length
+          approveUnsignedTxArr?.length,
+        );
+        const shouldSkipSignedPrebuild = shouldSkipMarketSignedPrebuild({
+          quoteResult: snapshot.quoteResult,
+          approveUnsignedTxCount: approveUnsignedTxArr?.length,
+        });
+        const preparedUnsignedTx =
+          !shouldEstimateApproveOnly && !shouldSkipSignedPrebuild
+            ? await prepareMarketDirectUnsignedTx({
+                accountId: snapshot.accountId,
+                networkId: snapshot.networkId,
+                buildUnsignedParams: snapshot.buildUnsignedParams,
+                approveUnsignedTxArr,
+              })
+            : undefined;
+
+        if (
+          !snapshot.buildUnsignedParams.encodedTx &&
+          preparedUnsignedTx?.encodedTx
         ) {
+          snapshot.buildUnsignedParams = {
+            ...snapshot.buildUnsignedParams,
+            encodedTx: preparedUnsignedTx.encodedTx,
+          };
+        }
+
+        options?.onExecutionReady?.(
+          buildReviewStateWithFee({
+            netWorkFee: undefined,
+            estimateNetworkFeeLoading: true,
+          }),
+        );
+
+        if (shouldEstimateApproveOnly) {
           const feeState = await estimateMarketApproveGasInfos({
             accountAddress: snapshot.accountAddress,
             accountId: snapshot.accountId,
             networkId: snapshot.networkId,
-            approveUnsignedTxArr,
+            approveUnsignedTxArr: approveUnsignedTxArr ?? [],
             networkFeeLevel,
             customPriorityFee,
           });
@@ -1512,12 +1571,7 @@ export function useSpeedSwapActions(props: {
             gasInfos: feeState.gasInfos,
             gasFeeFiatValue: feeState.gasFeeFiatValue,
           };
-        } else if (
-          shouldSkipMarketSignedPrebuild({
-            quoteResult: snapshot.quoteResult,
-            approveUnsignedTxCount: approveUnsignedTxArr?.length,
-          })
-        ) {
+        } else if (shouldSkipSignedPrebuild) {
           netWorkFee = undefined;
         } else {
           const feeState = await estimateMarketDirectGasInfos({
@@ -1528,6 +1582,7 @@ export function useSpeedSwapActions(props: {
             approveUnsignedTxArr,
             networkFeeLevel,
             customPriorityFee,
+            preparedUnsignedTx,
             gasAccountAnalytics:
               snapshot.kind === 'swap'
                 ? {
@@ -1576,19 +1631,10 @@ export function useSpeedSwapActions(props: {
         });
       }
 
-      return {
-        steps: nextReviewState.steps,
-        preSwapData: {
-          ...nextReviewState.preSwapData,
-          swapBuildResultData: {
-            swapInfo: snapshot.swapInfo,
-            encodedTx: snapshot.buildUnsignedParams.encodedTx,
-            transferInfo: snapshot.buildUnsignedParams.transfersInfo?.[0],
-          },
-          netWorkFee,
-        },
-        quoteResult: snapshot.quoteResult,
-      };
+      return buildReviewStateWithFee({
+        netWorkFee,
+        estimateNetworkFeeLoading: false,
+      });
     },
     [
       assertLatestWrappedExecutionBalancesSufficient,
@@ -1817,6 +1863,9 @@ export function useSpeedSwapActions(props: {
       slippagePercentage,
       networkFeeLevel = ESwapNetworkFeeLevel.MEDIUM,
       customPriorityFee,
+      isCurrent,
+      onPhaseChange,
+      onExecutionReady,
     }) => {
       const snapshot = reviewExecutionSnapshotRef.current;
       if (snapshot?.kind !== 'swap') {
@@ -1835,6 +1884,12 @@ export function useSpeedSwapActions(props: {
         accountAddress: snapshot.accountAddress,
         accountId: snapshot.accountId,
       });
+      if (!isCurrent()) {
+        throw new OneKeyLocalError(
+          'Market swap review changed while rebuilding.',
+        );
+      }
+      onPhaseChange(ESwapReviewRebuildPhase.BuildingTransaction);
 
       const buildRes = await backgroundApiProxy.serviceSwap.fetchBuildTx({
         fromToken: fromTokenFinal,
@@ -1857,6 +1912,12 @@ export function useSpeedSwapActions(props: {
       if (!buildRes) {
         throw new OneKeyLocalError('Market swap review rebuild failed.');
       }
+      if (!isCurrent()) {
+        throw new OneKeyLocalError(
+          'Market swap review changed while rebuilding.',
+        );
+      }
+      onPhaseChange(ESwapReviewRebuildPhase.PreparingExecution);
 
       const mergedBuildRes = mergeMarketBuildResultWithQuote({
         buildRes,
@@ -1903,14 +1964,27 @@ export function useSpeedSwapActions(props: {
         nextSnapshot,
         networkFeeLevel,
         customPriorityFee,
-        { throwOnEstimateError: true },
+        {
+          throwOnEstimateError: true,
+          onExecutionReady: (reviewState) => {
+            if (
+              !isCurrent() ||
+              reviewExecutionSnapshotRef.current !== snapshot
+            ) {
+              throw new OneKeyLocalError(
+                'Market swap review changed while rebuilding.',
+              );
+            }
+            onExecutionReady(reviewState);
+            reviewExecutionSnapshotRef.current = nextSnapshot;
+          },
+        },
       );
-      if (reviewExecutionSnapshotRef.current !== snapshot) {
+      if (!isCurrent() || reviewExecutionSnapshotRef.current !== nextSnapshot) {
         throw new OneKeyLocalError(
           'Market swap review changed while rebuilding.',
         );
       }
-      reviewExecutionSnapshotRef.current = nextSnapshot;
       return nextReviewState;
     },
     [

--- a/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
@@ -341,10 +341,11 @@ const PreSwapInfoGroup = ({
         onOpenChange={slippageEditor.onOpenChange}
         showHeader={false}
         placement="bottom-end"
+        offset={{ mainAxis: 8, crossAxis: 20 }}
         floatingPanelProps={{ width: 400 }}
         renderTrigger={trigger}
         renderContent={
-          <Stack p="$4" width={400}>
+          <Stack p="$5" width={400}>
             <SwapReviewSlippageEditor
               disableSaveSlippageForFutureOrders={
                 slippageEditor.disableSaveSlippageForFutureOrders

--- a/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
@@ -254,7 +254,8 @@ const PreSwapInfoGroup = ({
           value={activeNetworkFeeSelectValue}
           items={networkFeeLevelArray}
         />
-        {preSwapData.stepBeforeActionsLoading ? (
+        {preSwapData.stepBeforeActionsLoading ||
+        preSwapData.estimateNetworkFeeLoading ? (
           <Skeleton width="$10" height="$4" />
         ) : (
           <NumberSizeableText
@@ -277,6 +278,7 @@ const PreSwapInfoGroup = ({
     onSelectNetworkFeeLevel,
     preSwapData.netWorkFee?.gasFeeFiatValue,
     settings.currencyInfo.symbol,
+    preSwapData.estimateNetworkFeeLoading,
     preSwapData.stepBeforeActionsLoading,
   ]);
 

--- a/packages/kit/src/views/Swap/components/SwapReviewSlippageEditor.tsx
+++ b/packages/kit/src/views/Swap/components/SwapReviewSlippageEditor.tsx
@@ -114,36 +114,40 @@ export function SwapReviewSlippageEditor({
   );
   const actionButtons = (
     <XStack gap="$2">
-      <Button
-        testID="swap-review-slippage-all-future-orders"
-        flex={1}
-        flexBasis={0}
-        minWidth={0}
-        size={controlSize}
-        borderRadius={platformEnv.isNative ? '$3' : '$2'}
-        variant="secondary"
-        disabled={isSaveDisabled || disableSaveSlippageForFutureOrders}
-        loading={savingScope === 'future'}
-        onPress={() => handleSave('future')}
-      >
-        {intl.formatMessage({
-          id: ETranslations.trade_silp_all_future_orders,
-        })}
-      </Button>
+      {disableSaveSlippageForFutureOrders ? null : (
+        <Button
+          testID="swap-review-slippage-all-future-orders"
+          flex={1}
+          flexBasis={0}
+          minWidth={0}
+          size={controlSize}
+          borderRadius={platformEnv.isNative ? '$3' : '$full'}
+          variant="secondary"
+          disabled={isSaveDisabled}
+          loading={savingScope === 'future'}
+          onPress={() => handleSave('future')}
+        >
+          {intl.formatMessage({
+            id: ETranslations.trade_silp_all_future_orders,
+          })}
+        </Button>
+      )}
       <Button
         testID="swap-review-slippage-this-order"
         flex={1}
         flexBasis={0}
         minWidth={0}
         size={controlSize}
-        borderRadius={platformEnv.isNative ? '$3' : '$2'}
+        borderRadius={platformEnv.isNative ? '$3' : '$full'}
         variant="primary"
         disabled={isSaveDisabled}
         loading={savingScope === 'current'}
         onPress={() => handleSave('current')}
       >
         {intl.formatMessage({
-          id: ETranslations.trade_silp_this_order,
+          id: disableSaveSlippageForFutureOrders
+            ? ETranslations.global_confirm
+            : ETranslations.trade_silp_this_order,
         })}
       </Button>
     </XStack>

--- a/packages/kit/src/views/Swap/hooks/useSwapReviewActions.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapReviewActions.ts
@@ -22,14 +22,24 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  ESwapReviewRebuildPhase,
+  isSwapReviewConfirmBlocked,
+} from '../utils/swapReviewRebuildStateMachine';
+import {
   ESwapReviewApproveTransactionSource,
   getSwapReviewApproveTransaction,
 } from '../utils/swapReviewState';
+
+import { useSwapReviewRebuildStateMachine } from './useSwapReviewRebuildStateMachine';
 
 import type {
   ISwapReviewAdapter,
   ISwapReviewState,
 } from '../utils/swapReviewState';
+
+export type ISwapReviewRebuildOptions = {
+  onExecutionReady?: () => void;
+};
 
 function mergeReviewStateSteps(prevSteps: ISwapStep[], nextSteps: ISwapStep[]) {
   return nextSteps.map((nextStep, index) => {
@@ -135,7 +145,6 @@ export function useSwapReviewActions({
   const [inAppNotificationAtom] = useInAppNotificationAtom();
   const handledApproveStatusRef = useRef<string>('');
   const latestApproveTxIdRef = useRef<string>('');
-  const rebuildReviewRequestIdRef = useRef(0);
   const adapterRef = useRef(adapter);
   const intlRef = useRef(intl);
   const networkFeeLevelRef = useRef(swapStepNetFeeLevel.networkFeeLevel);
@@ -143,18 +152,18 @@ export function useSwapReviewActions({
   const swapStepsStateRef = useRef(swapStepsState);
   const { replaceReviewState, setBeforeActionsLoading, updateStep } =
     useReviewStepStateActions();
+  const {
+    state: reviewRebuildState,
+    stateRef: reviewRebuildStateRef,
+    begin: beginReviewRebuild,
+    resetUncommittedError: resetUncommittedReviewRebuildError,
+  } = useSwapReviewRebuildStateMachine();
 
   adapterRef.current = adapter;
   intlRef.current = intl;
   networkFeeLevelRef.current = swapStepNetFeeLevel.networkFeeLevel;
   customPriorityFeeRef.current = swapStepNetFeeLevel.customPriorityFee;
   swapStepsStateRef.current = swapStepsState;
-
-  useEffect(() => {
-    return () => {
-      rebuildReviewRequestIdRef.current += 1;
-    };
-  }, []);
 
   const clearPreSwapGasInfos = useCallback(
     (preSwapData: ISwapPreSwapData) => {
@@ -243,18 +252,48 @@ export function useSwapReviewActions({
     ],
   );
 
-  const rebuildReviewStateWithSlippage = useCallback(
-    async (slippagePercentage: number) => {
-      const frozenQuoteResult = swapStepsStateRef.current.quoteResult;
+  const rebuildReviewWithSlippage = useCallback(
+    async (slippagePercentage: number, options?: ISwapReviewRebuildOptions) => {
+      let expectedQuoteResult = swapStepsStateRef.current.quoteResult;
       const rebuildReview = adapterRef.current.rebuildReview;
-      if (!frozenQuoteResult || !rebuildReview) {
+      if (!expectedQuoteResult || !rebuildReview) {
         throw new OneKeyLocalError(
           'Current swap quote does not support rebuilding',
         );
       }
 
-      const requestId = rebuildReviewRequestIdRef.current + 1;
-      rebuildReviewRequestIdRef.current = requestId;
+      const operation = beginReviewRebuild(slippagePercentage);
+      let executionReady = false;
+      const isCurrentReview = () =>
+        operation.isCurrent() &&
+        swapStepsStateRef.current.quoteResult === expectedQuoteResult;
+      const assertCurrentReview = () => {
+        if (!isCurrentReview()) {
+          throw new OneKeyLocalError('Swap review changed while rebuilding');
+        }
+      };
+      const commitExecutionReview = (reviewState: ISwapReviewState) => {
+        if (executionReady) {
+          return;
+        }
+        assertCurrentReview();
+        executionReady = true;
+        expectedQuoteResult = reviewState.quoteResult;
+        operation.advance(ESwapReviewRebuildPhase.EstimatingFee);
+        const coreReviewState = {
+          ...reviewState,
+          preSwapData: {
+            ...reviewState.preSwapData,
+            swapBuildLoading: false,
+            estimateNetworkFeeLoading: true,
+            stepBeforeActionsError: undefined,
+          },
+        };
+        swapStepsStateRef.current = coreReviewState;
+        replaceReviewState(coreReviewState);
+        options?.onExecutionReady?.();
+      };
+
       setSwapSteps((prev) => ({
         ...prev,
         preSwapData: {
@@ -270,20 +309,31 @@ export function useSwapReviewActions({
           slippagePercentage,
           networkFeeLevel: networkFeeLevelRef.current,
           customPriorityFee: customPriorityFeeRef.current,
+          isCurrent: isCurrentReview,
+          onPhaseChange: (phase) => {
+            assertCurrentReview();
+            operation.advance(phase);
+          },
+          onExecutionReady: commitExecutionReview,
         });
-        if (
-          requestId !== rebuildReviewRequestIdRef.current ||
-          swapStepsStateRef.current.quoteResult !== frozenQuoteResult
-        ) {
-          throw new OneKeyLocalError('Swap review changed while rebuilding');
+        assertCurrentReview();
+        if (!executionReady) {
+          commitExecutionReview(reviewState);
         }
-        replaceReviewState(reviewState);
-        return reviewState;
+        const finalReviewState = {
+          ...reviewState,
+          preSwapData: {
+            ...reviewState.preSwapData,
+            swapBuildLoading: false,
+            estimateNetworkFeeLoading: false,
+            stepBeforeActionsError: undefined,
+          },
+        };
+        swapStepsStateRef.current = finalReviewState;
+        replaceReviewState(finalReviewState);
+        operation.resolve();
       } catch (error) {
-        if (
-          requestId === rebuildReviewRequestIdRef.current &&
-          swapStepsStateRef.current.quoteResult === frozenQuoteResult
-        ) {
+        if (isCurrentReview()) {
           setSwapSteps((prev) => ({
             ...prev,
             preSwapData: {
@@ -292,18 +342,12 @@ export function useSwapReviewActions({
               estimateNetworkFeeLoading: false,
             },
           }));
+          operation.reject();
         }
         throw error;
       }
     },
-    [replaceReviewState, setSwapSteps],
-  );
-
-  const rebuildReviewWithSlippage = useCallback(
-    async (slippagePercentage: number) => {
-      await rebuildReviewStateWithSlippage(slippagePercentage);
-    },
-    [rebuildReviewStateWithSlippage],
+    [beginReviewRebuild, replaceReviewState, setSwapSteps],
   );
 
   const preSwapStepsStart = useCallback(
@@ -547,6 +591,10 @@ export function useSwapReviewActions({
 
   const onConfirm = useCallback(
     (onConfirmStart?: () => void) => {
+      if (isSwapReviewConfirmBlocked(reviewRebuildStateRef.current.phase)) {
+        return;
+      }
+
       const confirm = async () => {
         const currentReviewState = swapStepsStateRef.current;
         if (currentReviewState.preSwapData.requiresSlippageRebuildOnConfirm) {
@@ -556,11 +604,7 @@ export function useSwapReviewActions({
               'Invalidated swap review is missing slippage',
             );
           }
-          const rebuiltReviewState =
-            await rebuildReviewStateWithSlippage(slippagePercentage);
-          onConfirmStart?.();
-          await preSwapStepsStart(rebuiltReviewState);
-          return;
+          await rebuildReviewWithSlippage(slippagePercentage);
         }
 
         onConfirmStart?.();
@@ -572,7 +616,7 @@ export function useSwapReviewActions({
         errorToastUtils.showToastOfError(error);
       });
     },
-    [preSwapStepsStart, rebuildReviewStateWithSlippage],
+    [preSwapStepsStart, rebuildReviewWithSlippage, reviewRebuildStateRef],
   );
 
   return {
@@ -580,5 +624,7 @@ export function useSwapReviewActions({
     preSwapBeforeStepActions,
     preSwapStepsStart,
     rebuildReviewWithSlippage,
+    reviewRebuildState,
+    resetUncommittedReviewRebuildError,
   };
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapReviewRebuildStateMachine.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapReviewRebuildStateMachine.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  initialSwapReviewRebuildState,
+  reduceSwapReviewRebuildState,
+} from '../utils/swapReviewRebuildStateMachine';
+
+import type {
+  ESwapReviewRebuildPhase,
+  ISwapReviewRebuildState,
+  ISwapReviewRebuildStateEvent,
+} from '../utils/swapReviewRebuildStateMachine';
+
+export type ISwapReviewRebuildOperation = {
+  requestId: number;
+  isCurrent: () => boolean;
+  advance: (
+    phase:
+      | ESwapReviewRebuildPhase.BuildingTransaction
+      | ESwapReviewRebuildPhase.PreparingExecution
+      | ESwapReviewRebuildPhase.EstimatingFee,
+  ) => void;
+  resolve: () => void;
+  reject: () => void;
+};
+
+export function useSwapReviewRebuildStateMachine() {
+  const [state, setState] = useState<ISwapReviewRebuildState>(
+    initialSwapReviewRebuildState,
+  );
+  const stateRef = useRef(state);
+  const requestIdRef = useRef(0);
+
+  const dispatch = useCallback((event: ISwapReviewRebuildStateEvent) => {
+    const nextState = reduceSwapReviewRebuildState(stateRef.current, event);
+    if (nextState !== stateRef.current) {
+      stateRef.current = nextState;
+      setState(nextState);
+    }
+  }, []);
+
+  const begin = useCallback(
+    (slippagePercentage: number): ISwapReviewRebuildOperation => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      dispatch({
+        type: 'start',
+        requestId,
+        slippagePercentage,
+      });
+
+      const isCurrent = () => requestIdRef.current === requestId;
+
+      return {
+        requestId,
+        isCurrent,
+        advance: (phase) => {
+          if (!isCurrent()) {
+            return;
+          }
+          dispatch({ type: 'advance', requestId, phase });
+        },
+        resolve: () => {
+          if (!isCurrent()) {
+            return;
+          }
+          dispatch({ type: 'resolve', requestId });
+        },
+        reject: () => {
+          if (!isCurrent()) {
+            return;
+          }
+          dispatch({ type: 'reject', requestId });
+        },
+      };
+    },
+    [dispatch],
+  );
+
+  const resetUncommittedError = useCallback(() => {
+    dispatch({
+      type: 'resetUncommittedError',
+      requestId: requestIdRef.current,
+    });
+  }, [dispatch]);
+
+  useEffect(() => {
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, []);
+
+  return {
+    state,
+    stateRef,
+    begin,
+    resetUncommittedError,
+  };
+}

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -76,12 +76,19 @@ import {
 } from '../../components/SwapReviewSlippageEditor';
 import { resolveQuoteShowTip } from '../../utils/quoteShowTipUtils';
 import {
+  isSwapReviewConfirmBlocked,
+  isSwapReviewRebuildInProgress,
+} from '../../utils/swapReviewRebuildStateMachine';
+import {
   NATIVE_BTC_MIN_SLIPPAGE_PERCENTAGE,
   invalidateSwapReviewForSlippageChange,
   shouldShowSwapReviewToAmountSkeleton,
 } from '../../utils/swapReviewState';
 import { reconcileSwapStepWithHistory } from '../../utils/swapStepHistory';
 import { getSwapExecutionTypeFromQuoteResult } from '../../utils/swapTypeUtils';
+
+import type { ISwapReviewRebuildOptions } from '../../hooks/useSwapReviewActions';
+import type { ISwapReviewRebuildState } from '../../utils/swapReviewRebuildStateMachine';
 
 interface IPreSwapDialogContentProps {
   onConfirm: () => void;
@@ -101,7 +108,12 @@ interface IPreSwapDialogContentProps {
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
   showCustomNetworkFeeOption?: boolean;
   isSwapPro?: boolean;
-  rebuildReviewWithSlippage?: (slippagePercentage: number) => Promise<void>;
+  rebuildReviewWithSlippage?: (
+    slippagePercentage: number,
+    options?: ISwapReviewRebuildOptions,
+  ) => Promise<void>;
+  reviewRebuildState?: ISwapReviewRebuildState;
+  resetUncommittedReviewRebuildError?: () => void;
   saveSlippageForFutureOrders?: (
     slippagePercentage: number,
   ) => Promise<void> | void;
@@ -119,6 +131,8 @@ const PreSwapDialogContent = ({
   showCustomNetworkFeeOption,
   isSwapPro,
   rebuildReviewWithSlippage,
+  reviewRebuildState,
+  resetUncommittedReviewRebuildError,
   saveSlippageForFutureOrders,
   disableSaveSlippageForFutureOrders,
 }: IPreSwapDialogContentProps) => {
@@ -177,6 +191,7 @@ const PreSwapDialogContent = ({
     customNetworkFeeOptionKey,
   );
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
     };
@@ -331,23 +346,35 @@ const PreSwapDialogContent = ({
         preSwapData?.estimateNetworkFeeLoading ||
         preSwapData?.swapBuildLoading ||
         preSwapData?.stepBeforeActionsLoading ||
-        preSwapData?.stepBeforeActionsError,
+        preSwapData?.stepBeforeActionsError ||
+        isSwapReviewConfirmBlocked(reviewRebuildState?.phase),
       ),
     [
       preSwapData?.estimateNetworkFeeLoading,
       preSwapData?.stepBeforeActionsError,
       preSwapData?.stepBeforeActionsLoading,
       preSwapData?.swapBuildLoading,
+      reviewRebuildState?.phase,
     ],
   );
 
   const handleSlippageEditorOpenChange = useCallback(
     (open: boolean) => {
-      if (!slippageSavingScope) {
+      if (
+        !slippageSavingScope &&
+        !isSwapReviewRebuildInProgress(reviewRebuildState?.phase)
+      ) {
+        if (!open) {
+          resetUncommittedReviewRebuildError?.();
+        }
         setSlippageEditorOpen(open);
       }
     },
-    [slippageSavingScope],
+    [
+      resetUncommittedReviewRebuildError,
+      reviewRebuildState?.phase,
+      slippageSavingScope,
+    ],
   );
   const handleSaveSlippage = useCallback(
     async (scope: ISwapReviewSlippageSaveScope, slippagePercentage: number) => {
@@ -356,23 +383,38 @@ const PreSwapDialogContent = ({
       }
 
       setSlippageSavingScope(scope);
-      try {
-        await rebuildReviewWithSlippage(slippagePercentage);
-        if (!isMountedRef.current) {
+      let editorReleased = false;
+      const releaseEditor = () => {
+        if (editorReleased || !isMountedRef.current) {
           return;
         }
-        if (scope === 'future') {
-          if (saveSlippageForFutureOrders) {
-            await saveSlippageForFutureOrders(slippagePercentage);
-          } else {
-            setSettings((prev) => ({
-              ...prev,
-              swapSlippagePercentageMode: ESwapSlippageSegmentKey.CUSTOM,
-              swapSlippagePercentageCustomValue: slippagePercentage,
-            }));
-          }
-        }
+        editorReleased = true;
         setSlippageEditorOpen(false);
+        setSlippageSavingScope(undefined);
+
+        if (scope !== 'future') {
+          return;
+        }
+        if (saveSlippageForFutureOrders) {
+          void Promise.resolve(
+            saveSlippageForFutureOrders(slippagePercentage),
+          ).catch((error: unknown) => {
+            errorToastUtils.toastIfError(error);
+            errorToastUtils.showToastOfError(error);
+          });
+        } else {
+          setSettings((prev) => ({
+            ...prev,
+            swapSlippagePercentageMode: ESwapSlippageSegmentKey.CUSTOM,
+            swapSlippagePercentageCustomValue: slippagePercentage,
+          }));
+        }
+      };
+      try {
+        await rebuildReviewWithSlippage(slippagePercentage, {
+          onExecutionReady: releaseEditor,
+        });
+        releaseEditor();
       } catch (error) {
         errorToastUtils.toastIfError(error);
         errorToastUtils.showToastOfError(error);

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
+import { initialSwapReviewRebuildState } from '../../utils/swapReviewRebuildStateMachine';
 import { ESwapReviewApproveTransactionSource } from '../../utils/swapReviewState';
 
 import { SwapReviewDialog } from './SwapReviewDialog';
@@ -123,6 +124,9 @@ describe('SwapReviewDialog', () => {
       onConfirm: reviewConfirmMock,
       preSwapBeforeStepActions: jest.fn(),
       preSwapStepsStart: jest.fn(),
+      rebuildReviewWithSlippage: jest.fn(),
+      reviewRebuildState: initialSwapReviewRebuildState,
+      resetUncommittedReviewRebuildError: jest.fn(),
     });
   });
 

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
@@ -8,6 +8,7 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
 
 import { useSwapReviewActions } from '../../hooks/useSwapReviewActions';
+import { isSwapReviewConfirmBlocked } from '../../utils/swapReviewRebuildStateMachine';
 import {
   ESwapReviewApproveTransactionSource,
   type ISwapReviewAdapter,
@@ -65,6 +66,8 @@ function SwapReviewDialogContent({
     preSwapBeforeStepActions,
     preSwapStepsStart,
     rebuildReviewWithSlippage,
+    reviewRebuildState,
+    resetUncommittedReviewRebuildError,
   } = useSwapReviewActions({
     adapter,
     approveTransactionSource,
@@ -75,12 +78,17 @@ function SwapReviewDialogContent({
       disableGlobalApproveSync={disableGlobalApproveSync}
       disableSaveSlippageForFutureOrders={disableSaveSlippageForFutureOrders}
       onConfirm={() => {
+        if (isSwapReviewConfirmBlocked(reviewRebuildState.phase)) {
+          return;
+        }
         onConfirm(onConfirmStart);
       }}
       onDone={onDone}
       preSwapBeforeStepActions={preSwapBeforeStepActions}
       preSwapStepsStart={preSwapStepsStart}
       rebuildReviewWithSlippage={rebuildReviewWithSlippage}
+      reviewRebuildState={reviewRebuildState}
+      resetUncommittedReviewRebuildError={resetUncommittedReviewRebuildError}
       saveSlippageForFutureOrders={adapter.saveSlippageForFutureOrders}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}
       defaultCustomPriorityFee={defaultCustomPriorityFee}

--- a/packages/kit/src/views/Swap/utils/swapReviewRebuildStateMachine.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewRebuildStateMachine.test.ts
@@ -1,0 +1,125 @@
+import {
+  ESwapReviewRebuildPhase,
+  initialSwapReviewRebuildState,
+  isSwapReviewConfirmBlocked,
+  isSwapReviewExecutionRebuildPending,
+  reduceSwapReviewRebuildState,
+} from './swapReviewRebuildStateMachine';
+
+describe('swapReviewRebuildStateMachine', () => {
+  it('advances through execution and fee phases before becoming ready', () => {
+    const validating = reduceSwapReviewRebuildState(
+      initialSwapReviewRebuildState,
+      {
+        type: 'start',
+        requestId: 1,
+        slippagePercentage: 2,
+      },
+    );
+    const building = reduceSwapReviewRebuildState(validating, {
+      type: 'advance',
+      requestId: 1,
+      phase: ESwapReviewRebuildPhase.BuildingTransaction,
+    });
+    const preparing = reduceSwapReviewRebuildState(building, {
+      type: 'advance',
+      requestId: 1,
+      phase: ESwapReviewRebuildPhase.PreparingExecution,
+    });
+    const estimating = reduceSwapReviewRebuildState(preparing, {
+      type: 'advance',
+      requestId: 1,
+      phase: ESwapReviewRebuildPhase.EstimatingFee,
+    });
+    const ready = reduceSwapReviewRebuildState(estimating, {
+      type: 'resolve',
+      requestId: 1,
+    });
+
+    expect(isSwapReviewExecutionRebuildPending(preparing.phase)).toBe(true);
+    expect(estimating.executionReady).toBe(true);
+    expect(isSwapReviewConfirmBlocked(estimating.phase)).toBe(true);
+    expect(ready.phase).toBe(ESwapReviewRebuildPhase.Ready);
+    expect(isSwapReviewConfirmBlocked(ready.phase)).toBe(false);
+  });
+
+  it('ignores stale requests and regressive phases', () => {
+    const validating = reduceSwapReviewRebuildState(
+      initialSwapReviewRebuildState,
+      {
+        type: 'start',
+        requestId: 2,
+        slippagePercentage: 3,
+      },
+    );
+    const building = reduceSwapReviewRebuildState(validating, {
+      type: 'advance',
+      requestId: 2,
+      phase: ESwapReviewRebuildPhase.BuildingTransaction,
+    });
+    const estimating = reduceSwapReviewRebuildState(building, {
+      type: 'advance',
+      requestId: 2,
+      phase: ESwapReviewRebuildPhase.EstimatingFee,
+    });
+
+    expect(
+      reduceSwapReviewRebuildState(building, {
+        type: 'advance',
+        requestId: 1,
+        phase: ESwapReviewRebuildPhase.EstimatingFee,
+      }),
+    ).toBe(building);
+    expect(
+      reduceSwapReviewRebuildState(estimating, {
+        type: 'advance',
+        requestId: 2,
+        phase: ESwapReviewRebuildPhase.BuildingTransaction,
+      }),
+    ).toBe(estimating);
+  });
+
+  it('only resets an error when no rebuilt execution was committed', () => {
+    const validating = reduceSwapReviewRebuildState(
+      initialSwapReviewRebuildState,
+      {
+        type: 'start',
+        requestId: 1,
+        slippagePercentage: 2,
+      },
+    );
+    const validationError = reduceSwapReviewRebuildState(validating, {
+      type: 'reject',
+      requestId: 1,
+    });
+    const reset = reduceSwapReviewRebuildState(validationError, {
+      type: 'resetUncommittedError',
+      requestId: 1,
+    });
+
+    expect(reset.phase).toBe(ESwapReviewRebuildPhase.Idle);
+
+    const estimating = reduceSwapReviewRebuildState(
+      reduceSwapReviewRebuildState(
+        reduceSwapReviewRebuildState(validating, {
+          type: 'advance',
+          requestId: 1,
+          phase: ESwapReviewRebuildPhase.PreparingExecution,
+        }),
+        {
+          type: 'advance',
+          requestId: 1,
+          phase: ESwapReviewRebuildPhase.EstimatingFee,
+        },
+      ),
+      { type: 'reject', requestId: 1 },
+    );
+
+    expect(
+      reduceSwapReviewRebuildState(estimating, {
+        type: 'resetUncommittedError',
+        requestId: 1,
+      }),
+    ).toBe(estimating);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapReviewRebuildStateMachine.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewRebuildStateMachine.ts
@@ -1,0 +1,166 @@
+export enum ESwapReviewRebuildPhase {
+  Idle = 'idle',
+  ValidatingBalance = 'validatingBalance',
+  BuildingTransaction = 'buildingTransaction',
+  PreparingExecution = 'preparingExecution',
+  EstimatingFee = 'estimatingFee',
+  Ready = 'ready',
+  Error = 'error',
+}
+
+export type ISwapReviewRebuildState = {
+  requestId: number;
+  phase: ESwapReviewRebuildPhase;
+  slippagePercentage?: number;
+  executionReady: boolean;
+  failedPhase?: ESwapReviewRebuildPhase;
+};
+
+export type ISwapReviewRebuildStateEvent =
+  | {
+      type: 'start';
+      requestId: number;
+      slippagePercentage: number;
+    }
+  | {
+      type: 'advance';
+      requestId: number;
+      phase:
+        | ESwapReviewRebuildPhase.BuildingTransaction
+        | ESwapReviewRebuildPhase.PreparingExecution
+        | ESwapReviewRebuildPhase.EstimatingFee;
+    }
+  | {
+      type: 'resolve';
+      requestId: number;
+    }
+  | {
+      type: 'reject';
+      requestId: number;
+    }
+  | {
+      type: 'resetUncommittedError';
+      requestId: number;
+    };
+
+export const initialSwapReviewRebuildState: ISwapReviewRebuildState = {
+  requestId: 0,
+  phase: ESwapReviewRebuildPhase.Idle,
+  executionReady: false,
+};
+
+const activePhaseOrder = {
+  [ESwapReviewRebuildPhase.ValidatingBalance]: 0,
+  [ESwapReviewRebuildPhase.BuildingTransaction]: 1,
+  [ESwapReviewRebuildPhase.PreparingExecution]: 2,
+  [ESwapReviewRebuildPhase.EstimatingFee]: 3,
+} as const;
+
+function getActivePhaseOrder(phase: ESwapReviewRebuildPhase) {
+  if (phase in activePhaseOrder) {
+    return activePhaseOrder[phase as keyof typeof activePhaseOrder];
+  }
+  return undefined;
+}
+
+export function reduceSwapReviewRebuildState(
+  state: ISwapReviewRebuildState,
+  event: ISwapReviewRebuildStateEvent,
+): ISwapReviewRebuildState {
+  if (event.type === 'start') {
+    if (event.requestId <= state.requestId) {
+      return state;
+    }
+    return {
+      requestId: event.requestId,
+      phase: ESwapReviewRebuildPhase.ValidatingBalance,
+      slippagePercentage: event.slippagePercentage,
+      executionReady: false,
+    };
+  }
+
+  if (event.requestId !== state.requestId) {
+    return state;
+  }
+
+  if (event.type === 'advance') {
+    const currentOrder = getActivePhaseOrder(state.phase);
+    const nextOrder = getActivePhaseOrder(event.phase);
+    if (
+      currentOrder === undefined ||
+      nextOrder === undefined ||
+      nextOrder <= currentOrder
+    ) {
+      return state;
+    }
+    return {
+      ...state,
+      phase: event.phase,
+      executionReady:
+        state.executionReady ||
+        event.phase === ESwapReviewRebuildPhase.EstimatingFee,
+    };
+  }
+
+  if (event.type === 'resolve') {
+    if (state.phase !== ESwapReviewRebuildPhase.EstimatingFee) {
+      return state;
+    }
+    return {
+      ...state,
+      phase: ESwapReviewRebuildPhase.Ready,
+      executionReady: true,
+    };
+  }
+
+  if (event.type === 'reject') {
+    if (getActivePhaseOrder(state.phase) === undefined) {
+      return state;
+    }
+    return {
+      ...state,
+      failedPhase: state.phase,
+      phase: ESwapReviewRebuildPhase.Error,
+    };
+  }
+
+  if (
+    event.type === 'resetUncommittedError' &&
+    state.phase === ESwapReviewRebuildPhase.Error &&
+    !state.executionReady
+  ) {
+    return {
+      ...initialSwapReviewRebuildState,
+      requestId: state.requestId,
+    };
+  }
+
+  return state;
+}
+
+export function isSwapReviewRebuildInProgress(phase?: ESwapReviewRebuildPhase) {
+  if (!phase) {
+    return false;
+  }
+  return getActivePhaseOrder(phase) !== undefined;
+}
+
+export function isSwapReviewExecutionRebuildPending(
+  phase?: ESwapReviewRebuildPhase,
+) {
+  return (
+    phase === ESwapReviewRebuildPhase.ValidatingBalance ||
+    phase === ESwapReviewRebuildPhase.BuildingTransaction ||
+    phase === ESwapReviewRebuildPhase.PreparingExecution
+  );
+}
+
+export function isSwapReviewConfirmBlocked(phase?: ESwapReviewRebuildPhase) {
+  if (!phase) {
+    return false;
+  }
+  return (
+    phase !== ESwapReviewRebuildPhase.Idle &&
+    phase !== ESwapReviewRebuildPhase.Ready
+  );
+}

--- a/packages/kit/src/views/Swap/utils/swapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.ts
@@ -139,6 +139,8 @@ export function invalidateSwapReviewForSlippageChange({
   };
 }
 
+import type { ESwapReviewRebuildPhase } from './swapReviewRebuildStateMachine';
+
 export type ISwapReviewGasInfoEntry = {
   encodeTx: IEncodedTx;
   gasInfo: ISwapGasInfo;
@@ -275,6 +277,13 @@ export type ISwapReviewAdapter = {
     slippagePercentage: number;
     networkFeeLevel?: ESwapNetworkFeeLevel;
     customPriorityFee?: ISwapReviewCustomPriorityFee;
+    isCurrent: () => boolean;
+    onPhaseChange: (
+      phase:
+        | ESwapReviewRebuildPhase.BuildingTransaction
+        | ESwapReviewRebuildPhase.PreparingExecution,
+    ) => void;
+    onExecutionReady: (reviewState: ISwapReviewState) => void;
   }) => Promise<ISwapReviewState>;
   saveSlippageForFutureOrders?: (
     slippagePercentage: number,

--- a/packages/kit/src/views/Swap/utils/swapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.ts
@@ -18,6 +18,8 @@ import {
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
+import type { ESwapReviewRebuildPhase } from './swapReviewRebuildStateMachine';
+
 export const NATIVE_BTC_MIN_SLIPPAGE_PERCENTAGE = 1;
 
 type INativeBtcSwapTokenIdentity = Pick<ISwapToken, 'isNative' | 'networkId'>;
@@ -138,8 +140,6 @@ export function invalidateSwapReviewForSlippageChange({
     },
   };
 }
-
-import type { ESwapReviewRebuildPhase } from './swapReviewRebuildStateMachine';
 
 export type ISwapReviewGasInfoEntry = {
   encodeTx: IEncodedTx;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61157](https://onekeyhq.atlassian.net/browse/OK-61157) [OK-60997](https://onekeyhq.atlassian.net/browse/OK-60997) [OK-61152](https://onekeyhq.atlassian.net/browse/OK-61152)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues

- Fixes OK-61157
- Fixes OK-60997
- Fixes OK-61152

## Summary

- model Market review rebuilds with explicit balance, transaction-build, execution-preparation, and fee-estimation phases
- publish the executable review state as soon as the unsigned transaction is ready while keeping Confirm blocked until fee estimation completes
- decouple future-order slippage persistence from the current review rebuild and reuse the prepared unsigned transaction for fee estimation
- preserve the existing invalidated-review fallback used by the Native BTC slippage flow
- align the review slippage popover with the preview dialog using 20px padding and matching rounded action buttons
- show one full-width Confirm button when future-order slippage persistence is unavailable while preserving the two-button flow for other presets

## Validation

- `yarn jest packages/kit/src/views/Swap/utils/swapReviewRebuildStateMachine.test.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx --runInBand` (6 suites, 77 tests)
- `yarn tsc --noEmit --pretty false`
- `yarn lint`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- Desktop Slow 4G PUMP/OKX DEX: editor close improved from 7.396s to 4.598s; Confirm ready improved from 7.403s to 5.922s
- Desktop review dialog and slippage popover: left edge and width aligned, 20px popover padding, matching rounded buttons, and Auto mode rendered one full-width Confirm action

## Risk

- scoped to reusable Swap review orchestration and the Market adapter; Confirm remains blocked until the rebuilt execution and fee state are ready

[OK-61157]: https://onekeyhq.atlassian.net/browse/OK-61157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-60997]: https://onekeyhq.atlassian.net/browse/OK-60997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61152]: https://onekeyhq.atlassian.net/browse/OK-61152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ