### PR TITLE
fix: refine mobile Perps chart layout OK-59954

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -1090,7 +1090,7 @@ export const {
     skipOrderConfirm: false,
     showTradeMarks: true,
     showChartLines: true,
-    chartPosition: 'bottom',
+    chartPosition: 'top',
     hideSmallSpotHoldings: true,
     lastTriggerOrderType: ETriggerOrderType.TRIGGER_MARKET,
     lastAdvancedOrderType: ETriggerOrderType.TRIGGER_MARKET,

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.test.tsx
@@ -99,18 +99,27 @@ jest.mock('@onekeyhq/components', () => ({
   ),
   XStack: ({
     accessibilityLabel,
+    alignSelf,
     children,
+    flex,
     onPress,
+    pr,
     testID,
   }: {
     accessibilityLabel?: string;
+    alignSelf?: string;
     children?: ReactNode;
+    flex?: number;
     onPress?: (event: unknown) => void;
+    pr?: string;
     testID?: string;
   }) =>
     onPress ? (
       <button
         aria-label={accessibilityLabel}
+        data-align-self={alignSelf}
+        data-flex={flex}
+        data-pr={pr}
         data-testid={testID}
         onClick={onPress}
         type="button"
@@ -118,7 +127,13 @@ jest.mock('@onekeyhq/components', () => ({
         {children}
       </button>
     ) : (
-      <div aria-label={accessibilityLabel} data-testid={testID}>
+      <div
+        aria-label={accessibilityLabel}
+        data-align-self={alignSelf}
+        data-flex={flex}
+        data-pr={pr}
+        data-testid={testID}
+      >
         {children}
       </div>
     ),
@@ -366,6 +381,7 @@ describe('TradingView chart controls', () => {
     const { getByTestId } = render(
       <TradingViewChartControls
         {...BASE_PROPS}
+        compactMobileLayout
         rightControl={<span>Chevron</span>}
         rightControlLabel="Close chart"
         onRightControlPress={handleClose}
@@ -374,9 +390,15 @@ describe('TradingView chart controls', () => {
 
     fireEvent.click(getByTestId('interval-selector'));
     expect(handleClose).not.toHaveBeenCalled();
+    expect(
+      getByTestId('interval-selector').parentElement?.getAttribute('data-flex'),
+    ).toBeNull();
 
     const closeArea = getByTestId('trading-view-native-chart-close');
     expect(closeArea.getAttribute('aria-label')).toBe('Close chart');
+    expect(closeArea.getAttribute('data-flex')).toBe('1');
+    expect(closeArea.getAttribute('data-align-self')).toBe('stretch');
+    expect(closeArea.getAttribute('data-pr')).toBe('$2');
     fireEvent.click(closeArea);
     expect(handleClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
@@ -541,7 +541,11 @@ export const TradingViewChartControls = memo(
             opacity={isControlsReady ? 1 : 0}
             pointerEvents={isControlsReady ? 'auto' : 'none'}
           >
-            <XStack flex={1} minWidth={0} alignItems="center">
+            <XStack
+              flex={onRightControlPress ? undefined : 1}
+              minWidth={0}
+              alignItems="center"
+            >
               {intervalSelector}
             </XStack>
 
@@ -571,6 +575,7 @@ export const TradingViewChartControls = memo(
             gap="$2"
             alignItems="center"
             justifyContent="flex-end"
+            pr={compactMobileLayout && onRightControlPress ? '$2' : undefined}
             accessibilityRole={onRightControlPress ? 'button' : undefined}
             accessibilityLabel={rightControlLabel}
             cursor={onRightControlPress ? 'pointer' : undefined}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -33,10 +33,7 @@ import {
   YStack,
   useIsKeyboardShown,
 } from '@onekeyhq/components';
-import {
-  FixedColumnShadowOverlay,
-  SimpleEdgeShadowOverlay,
-} from '@onekeyhq/kit/src/components/FixedColumnShadowOverlay';
+import { FixedColumnShadowOverlay } from '@onekeyhq/kit/src/components/FixedColumnShadowOverlay';
 import {
   SHADOW_CONSTANTS,
   getWebClipPath,
@@ -813,10 +810,9 @@ export function CommonTableListView<T>({
       <Stack
         flex={1}
         position="relative"
-        onLayout={(event) => handleMobileTraceLayout('listWithShadow', event)}
+        onLayout={(event) => handleMobileTraceLayout('listContainer', event)}
       >
         {ListContent}
-        <SimpleEdgeShadowOverlay isDark={isDark} position="right" />
       </Stack>
     );
 

--- a/packages/kit/src/views/Perp/components/PerpLayoutSettings.test.tsx
+++ b/packages/kit/src/views/Perp/components/PerpLayoutSettings.test.tsx
@@ -188,6 +188,17 @@ describe('PerpLayoutSettings', () => {
     expect(view.getByText('不展示')).toBeTruthy();
   });
 
+  it('defaults to the top position without a saved preference', () => {
+    mockChartPosition = undefined;
+    const view = render(<PerpLayoutSettingsContent />);
+    const top = view.getByTestId('perp-mobile-chart-position-option-top');
+    const bottom = view.getByTestId('perp-mobile-chart-position-option-bottom');
+
+    expect(top.getAttribute('aria-checked')).toBe('true');
+    expect(top.getAttribute('data-border-color')).toBe('$borderActive');
+    expect(bottom.getAttribute('aria-checked')).toBe('false');
+  });
+
   it('persists the selected chart position', () => {
     const view = render(<PerpLayoutSettingsContent />);
 

--- a/packages/kit/src/views/Perp/components/PerpLayoutSettings.tsx
+++ b/packages/kit/src/views/Perp/components/PerpLayoutSettings.tsx
@@ -251,7 +251,7 @@ export function PerpLayoutSettingsContent() {
   const copy = useLayoutSettingsCopy();
   const [perpsCustomSettings, setPerpsCustomSettings] =
     usePerpsCustomSettingsAtom();
-  const selectedPosition = perpsCustomSettings.chartPosition ?? 'bottom';
+  const selectedPosition = perpsCustomSettings.chartPosition ?? 'top';
 
   const handleSelect = useCallback(
     (chartPosition: IPerpsChartPosition) => {

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -175,7 +175,7 @@ export function PerpMobileLayout() {
   const tabBarHeight = useScrollContentTabBarOffset();
   const isSplitMainActive = useIsSplitMainActive();
   const [perpsCustomSettings] = usePerpsCustomSettingsAtom();
-  const chartPosition = perpsCustomSettings.chartPosition ?? 'bottom';
+  const chartPosition = perpsCustomSettings.chartPosition ?? 'top';
   const shouldShowTopChart = chartPosition === 'top' && !isSplitMainActive;
   const shouldShowBottomChart =
     chartPosition === 'bottom' && !isSplitMainActive;


### PR DESCRIPTION
## Summary

- remove the unintended right-edge shadow from mobile Perps lists
- restore the full expanded-chart header close area and align the Chevron with the collapsed state
- change the unsaved/default mobile chart position from bottom to top while preserving existing saved preferences

## Validation

- targeted Jest: 3 suites, 22 tests passed
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- Desktop renderer and Electron startup verified

[OK-59954](https://onekeyhq.atlassian.net/browse/OK-59954)

[OK-59954]: https://onekeyhq.atlassian.net/browse/OK-59954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ