### PR TITLE
feat: add native TradingView chart types

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewChartControls/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/types.ts
@@ -1,3 +1,5 @@
+import type { ITradingViewNativeChartType } from '@onekeyhq/shared/types/tradingViewNative';
+
 export interface ITradingViewIntervalOption {
   label: string;
   value: string;
@@ -23,6 +25,7 @@ export interface ITradingViewNativeIndicatorSelection {
 }
 
 export interface ITradingViewChartTypeOption {
+  id?: ITradingViewNativeChartType;
   label: string;
   value: number;
 }

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
@@ -1,4 +1,6 @@
+// cspell:words heikin ashi
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { ITradingViewNativeChartType } from '@onekeyhq/shared/types/tradingViewNative';
 
 import type {
   IChartSettingsSegmentValue,
@@ -30,6 +32,22 @@ export const HEADER_ICON_BUTTON_STYLE_PROPS = {
   },
 } as const;
 
+const CHART_TYPE_TRANSLATIONS = {
+  area: ETranslations.market_area,
+  bars: ETranslations.market_bars,
+  candlestick: ETranslations.market_candle,
+  heikinAshi: ETranslations.market_heikin_ashi,
+  line: ETranslations.market_line,
+} as const satisfies Record<ITradingViewNativeChartType, ETranslations>;
+
+const CHART_TYPE_ICONS = {
+  area: 'ChartTrending2Outline',
+  bars: 'TradingViewCandlesHlcOutline',
+  candlestick: 'TradingViewCandlesOutline',
+  heikinAshi: 'TradingViewBarsOutline',
+  line: 'TradingViewLineOutline',
+} as const satisfies Record<ITradingViewNativeChartType, string>;
+
 export function buildSettingsItemTestID(
   section: string,
   value: IChartSettingsSegmentValue,
@@ -59,8 +77,10 @@ export function findChartTypeOption(
   chartTypes: ITradingViewChartTypeOption[],
   keyword: string,
 ) {
-  return chartTypes.find((chartType) =>
-    chartType.label.trim().toLowerCase().includes(keyword),
+  return chartTypes.find(
+    (chartType) =>
+      chartType.id?.toLowerCase().includes(keyword) ||
+      chartType.label.trim().toLowerCase().includes(keyword),
   );
 }
 
@@ -69,6 +89,9 @@ export function formatChartTypeOptionLabel(
   chartType: ITradingViewChartTypeOption,
 ) {
   const label = chartType.label.trim();
+  if (chartType.id) {
+    return intl.formatMessage({ id: CHART_TYPE_TRANSLATIONS[chartType.id] });
+  }
   const normalizedLabel = label.toLowerCase();
   if (normalizedLabel === 'candle' || normalizedLabel === 'candles') {
     return intl.formatMessage({ id: ETranslations.market_candle });
@@ -90,6 +113,9 @@ export function formatChartTypeOptionLabel(
 }
 
 export function getChartTypeIconName(chartType?: ITradingViewChartTypeOption) {
+  if (chartType?.id) {
+    return CHART_TYPE_ICONS[chartType.id];
+  }
   const normalizedLabel = chartType?.label.trim().toLowerCase() ?? '';
   if (normalizedLabel.includes('heikin')) {
     return 'TradingViewBarsOutline';

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
@@ -31,6 +31,8 @@ const mockTradingViewChartControls = jest.fn<null, [unknown]>(() => null);
 const mockPushModal = jest.fn();
 const mockDialogShow = jest.fn<void, [IMockDialogConfig]>();
 const defaultIndicatorSettingsProps = {
+  activeChartType: 'candlestick' as const,
+  onChartTypeChange: jest.fn(),
   onIndicatorSettingsPress: jest.fn(),
   onIndicatorSelectionConfirm: jest.fn(),
 };
@@ -103,9 +105,45 @@ describe('TradingViewNative chart controls', () => {
         hasVisibleIntervalSelector: true,
         settingsEnabled: false,
         showIndicatorPopover: false,
+        showChartTypeSelect: true,
         showChartTypeToggle: false,
+        activeChartType: 1,
+        chartTypes: [
+          { id: 'candlestick', label: 'Candles', value: 1 },
+          { id: 'heikinAshi', label: 'Heikin Ashi', value: 8 },
+          { id: 'bars', label: 'Bars', value: 0 },
+          { id: 'line', label: 'Line', value: 2 },
+          { id: 'area', label: 'Area', value: 3 },
+        ],
       }),
     );
+  });
+
+  it('maps shared menu values back to native chart types', () => {
+    const handleChartTypeChange = jest.fn();
+    render(
+      <TradingViewNativeChartControlsContainer
+        {...defaultIndicatorSettingsProps}
+        activeChartType="line"
+        activeIndicatorValues={new Set(['MA'])}
+        intervalConfig={{ activeInterval: '60', intervals: [] }}
+        onChartTypeChange={handleChartTypeChange}
+        onIndicatorChange={jest.fn()}
+        onIntervalChange={jest.fn()}
+      />,
+    );
+
+    const controlsProps = mockTradingViewChartControls.mock.calls[0][0] as {
+      activeChartType: number;
+      onChartTypeChange: (chartType: number) => void;
+    };
+    expect(controlsProps.activeChartType).toBe(2);
+
+    controlsProps.onChartTypeChange(8);
+    controlsProps.onChartTypeChange(21);
+
+    expect(handleChartTypeChange).toHaveBeenCalledTimes(1);
+    expect(handleChartTypeChange).toHaveBeenCalledWith('heikinAshi');
   });
 
   it('keeps chart settings hidden in desktop layout without an opt-in', () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
@@ -25,8 +25,16 @@ import {
   TRADING_VIEW_NATIVE_INDICATOR_CATALOG,
   isTradingViewNativeAnyIndicator,
 } from './utils/chartIndicators/indicatorCatalog';
+import {
+  TRADING_VIEW_NATIVE_CHART_TYPE_OPTIONS,
+  getTradingViewNativeChartTypeFromValue,
+  getTradingViewNativeChartTypeValue,
+} from './utils/chartType';
+
+import type { ITradingViewNativeChartType } from './types';
 
 interface ITradingViewNativeChartControlsContainerProps {
+  activeChartType: ITradingViewNativeChartType;
   activeIndicatorValues: Set<string>;
   calendarAvailableTimeRange?: ITradingViewChartControlsProps['calendarAvailableTimeRange'];
   enableNativeChartSettings?: boolean;
@@ -37,6 +45,7 @@ interface ITradingViewNativeChartControlsContainerProps {
   fullscreenHeader?: ReactNode;
   isChartSwitchDisabled?: ITradingViewChartControlsProps['isChartSwitchDisabled'];
   onChartSwitch?: ITradingViewChartControlsProps['onChartSwitch'];
+  onChartTypeChange: (chartType: ITradingViewNativeChartType) => void;
   onIntervalChange: ITradingViewChartControlsProps['onIntervalChange'];
   onIndicatorChange: (
     indicator: ITradingViewNativeAnyIndicator,
@@ -53,6 +62,7 @@ interface ITradingViewNativeChartControlsContainerProps {
 
 export const TradingViewNativeChartControlsContainer = memo(
   ({
+    activeChartType,
     activeIndicatorValues,
     calendarAvailableTimeRange,
     enableNativeChartSettings = false,
@@ -63,6 +73,7 @@ export const TradingViewNativeChartControlsContainer = memo(
     fullscreenHeader,
     isChartSwitchDisabled,
     onChartSwitch,
+    onChartTypeChange,
     onIntervalChange,
     onIndicatorChange,
     onIndicatorSettingsPress,
@@ -76,6 +87,8 @@ export const TradingViewNativeChartControlsContainer = memo(
     const chartStyleTitle = intl.formatMessage({
       id: ETranslations.market_chart_style,
     });
+    const activeChartTypeValue =
+      getTradingViewNativeChartTypeValue(activeChartType);
     const settingsEnabled = enableNativeChartSettings;
     const indicators = useMemo<ITradingViewIndicatorOption[]>(
       () =>
@@ -114,6 +127,16 @@ export const TradingViewNativeChartControlsContainer = memo(
     const handleFullscreenToggle = useCallback(() => {
       onFullscreenChange?.(!isFullscreen);
     }, [isFullscreen, onFullscreenChange]);
+    const handleChartTypeChange = useCallback(
+      (chartTypeValue: number) => {
+        const nextChartType =
+          getTradingViewNativeChartTypeFromValue(chartTypeValue);
+        if (nextChartType && nextChartType !== activeChartType) {
+          onChartTypeChange(nextChartType);
+        }
+      },
+      [activeChartType, onChartTypeChange],
+    );
     const handleIndicatorPress = useCallback(
       (indicator: ITradingViewIndicatorOption) => {
         if (!isTradingViewNativeAnyIndicator(indicator.value)) {
@@ -169,14 +192,14 @@ export const TradingViewNativeChartControlsContainer = memo(
         backgroundColor="$transparent"
         calendarAvailableTimeRange={calendarAvailableTimeRange}
         intervalConfig={intervalConfig}
-        activeChartType={undefined}
+        activeChartType={activeChartTypeValue}
         activeIndicatorValues={activeIndicatorValues}
         chartSettingsTitle={intl.formatMessage({
           id: ETranslations.market_chart_settings,
         })}
         chartStyleTitle={chartStyleTitle}
         chartTypeToggleIcon="TradingViewCandlesOutline"
-        chartTypes={[]}
+        chartTypes={TRADING_VIEW_NATIVE_CHART_TYPE_OPTIONS}
         hasVisibleControls
         hasVisibleIndicators
         hasVisibleIntervalSelector
@@ -186,7 +209,7 @@ export const TradingViewNativeChartControlsContainer = memo(
         nextChartTypeLabel={chartStyleTitle}
         priceMarketCap={undefined}
         settingsEnabled={settingsEnabled}
-        showChartTypeSelect={false}
+        showChartTypeSelect
         showChartTypeToggle={false}
         showIndicatorPopover={false}
         showPriceMarketCapSelect={false}
@@ -202,7 +225,7 @@ export const TradingViewNativeChartControlsContainer = memo(
         onIntervalChange={onIntervalChange}
         onIndicatorPress={handleIndicatorPress}
         onShowIndicatorsDialog={showIndicatorsDialog}
-        onChartTypeChange={noop}
+        onChartTypeChange={handleChartTypeChange}
         onChartTypeToggle={noop}
         onPriceMarketCapModeChange={noop}
         onCalendarPanelOpen={onCalendarPanelOpen}

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
@@ -7,7 +7,10 @@ import type { ReactNode, SetStateAction } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import type { IMarketTokenKLineDataPoint } from '@onekeyhq/shared/types/marketV2';
-import type { ITradingViewNativeIndicatorSettings } from '@onekeyhq/shared/types/tradingViewNative';
+import type {
+  ITradingViewNativeChartSettings,
+  ITradingViewNativeIndicatorSettings,
+} from '@onekeyhq/shared/types/tradingViewNative';
 
 import {
   createTradingViewNativeIndicatorSettingsValue,
@@ -19,7 +22,10 @@ import {
 } from './TradingViewNativeContainer';
 import { TRADING_VIEW_NATIVE_SUB_INDICATORS } from './utils/chartIndicators';
 
-import type { ITradingViewNativeDataState } from './types';
+import type {
+  ITradingViewNativeChartType,
+  ITradingViewNativeDataState,
+} from './types';
 import type { ITradingViewNativeSubIndicatorInstanceConfig } from './utils/subIndicatorRender/types';
 
 const mockHandleRetry = jest.fn();
@@ -54,6 +60,8 @@ let mockActiveInterval = '60';
 let mockPoints: IMarketTokenKLineDataPoint[];
 let mockVisibleTimeRange: { from: number; to: number } | undefined;
 let mockViewportRequest: unknown;
+let mockInitialChartSettings: ITradingViewNativeChartSettings | undefined;
+let mockPersistedChartSettings: ITradingViewNativeChartSettings | undefined;
 let mockInitialIndicatorSettings:
   | ITradingViewNativeIndicatorSettings
   | undefined;
@@ -148,8 +156,27 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => {
   >('@onekeyhq/shared/types/tradingViewNative');
 
   return {
-    useMarketTradingViewChartSettingsPersistAtom: () =>
-      React.useState(tradingViewNative.createTradingViewNativeChartSettings),
+    useMarketTradingViewChartSettingsPersistAtom: () => {
+      const [settings, setSettings] = React.useState(
+        () =>
+          mockInitialChartSettings ??
+          tradingViewNative.createTradingViewNativeChartSettings(),
+      );
+      const setTrackedSettings = React.useCallback(
+        (nextSettings: SetStateAction<ITradingViewNativeChartSettings>) => {
+          setSettings((currentSettings) => {
+            const resolvedSettings =
+              typeof nextSettings === 'function'
+                ? nextSettings(currentSettings)
+                : nextSettings;
+            mockPersistedChartSettings = resolvedSettings;
+            return resolvedSettings;
+          });
+        },
+        [],
+      );
+      return [settings, setTrackedSettings] as const;
+    },
     useMarketTradingViewIndicatorSettingsPersistAtom: () => {
       const [settings, setSettings] = React.useState(
         () =>
@@ -212,6 +239,8 @@ describe('TradingViewNativeContainer', () => {
     mockVisibleTimeRange = undefined;
     mockRealtimePointListener = undefined;
     mockViewportRequest = null;
+    mockInitialChartSettings = undefined;
+    mockPersistedChartSettings = undefined;
     mockInitialIndicatorSettings = undefined;
     mockPersistedIndicatorSettings = undefined;
   });
@@ -260,6 +289,46 @@ describe('TradingViewNativeContainer', () => {
           low: 'market.low_abbr',
           open: 'market.open_abbr',
         },
+      }),
+    );
+  });
+
+  it('persists menu chart type changes and renders Heikin Ashi points', () => {
+    mockDataState = { status: 'live' };
+    mockPoints = [
+      { c: 106, h: 110, l: 90, o: 100, t: 1, v: 10 },
+      { c: 108, h: 112, l: 100, o: 106, t: 2, v: 20 },
+    ];
+
+    render(
+      <TradingViewNativeContainer
+        source={{
+          kind: 'market',
+          networkId: 'evm--1',
+          tokenAddress: '0xabc',
+          symbol: 'TOKEN',
+          realtime: 'disabled',
+        }}
+      />,
+    );
+
+    const controlsProps = mockTradingViewNativeChartControlsContainer.mock
+      .calls[0][0] as {
+      activeChartType: ITradingViewNativeChartType;
+      onChartTypeChange: (chartType: ITradingViewNativeChartType) => void;
+    };
+    expect(controlsProps.activeChartType).toBe('candlestick');
+
+    act(() => controlsProps.onChartTypeChange('heikinAshi'));
+
+    expect(mockPersistedChartSettings?.chartType).toBe('heikinAshi');
+    expect(mockTradingViewNativeChart).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        chartType: 'heikinAshi',
+        points: [
+          { c: 101.5, h: 110, l: 90, o: 103, t: 1, v: 10 },
+          { c: 106.5, h: 112, l: 100, o: 102.25, t: 2, v: 20 },
+        ],
       }),
     );
   });

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -52,6 +52,10 @@ import {
   resolveTradingViewNativeSubIndicatorThemeColors,
 } from './utils/chartThemeColors';
 import {
+  getTradingViewNativePrimarySeriesPoints,
+  resolveTradingViewNativeChartType,
+} from './utils/chartType';
+import {
   buildTradingViewNativeSubIndicatorRenderPanes,
   calculateTradingViewNativeSubIndicatorsWithCache,
   createTradingViewNativeSubIndicatorCalculationCache,
@@ -60,6 +64,7 @@ import {
 
 import type { ITradingViewNativeChartInterval } from './data/tradingViewNativeIntervals';
 import type {
+  ITradingViewNativeChartType,
   ITradingViewNativeDataState,
   ITradingViewNativeProps,
 } from './types';
@@ -165,7 +170,7 @@ export const TradingViewNativeContainer = memo(
   }: ITradingViewNativeProps) => {
     const intl = useIntl();
     const themeColors = useTradingViewSettingsThemeColors();
-    const [storedChartSettings] =
+    const [storedChartSettings, setStoredChartSettings] =
       useMarketTradingViewChartSettingsPersistAtom();
     const [indicatorSettings, setIndicatorSettings] =
       useMarketTradingViewIndicatorSettingsPersistAtom();
@@ -302,7 +307,7 @@ export const TradingViewNativeContainer = memo(
     const {
       calendarAvailableTimeRange,
       candleIntervalSeconds,
-      chartType,
+      chartType: automaticChartType,
       chartPictureVersion,
       dataProviderKey,
       dataState,
@@ -321,14 +326,26 @@ export const TradingViewNativeContainer = memo(
       onRealtimePoint: handleRealtimePoint,
       source,
     });
+    const chartType = useMemo(
+      () =>
+        resolveTradingViewNativeChartType({
+          automaticChartType,
+          preference: normalizedChartSettings.chartType,
+        }),
+      [automaticChartType, normalizedChartSettings.chartType],
+    );
+    const primarySeriesPoints = useMemo(
+      () => getTradingViewNativePrimarySeriesPoints({ chartType, points }),
+      [chartType, points],
+    );
     const indicatorSeries = useMemo(
       () =>
         buildTradingViewNativeIndicatorSeries({
           activeIndicatorValues: activeMainIndicatorValues,
           indicatorSettings: mainIndicatorSettings,
-          points,
+          points: primarySeriesPoints,
         }),
-      [activeMainIndicatorValues, mainIndicatorSettings, points],
+      [activeMainIndicatorValues, mainIndicatorSettings, primarySeriesPoints],
     );
     const visibleSubIndicatorInstances = useMemo(
       () =>
@@ -342,9 +359,13 @@ export const TradingViewNativeContainer = memo(
         calculateTradingViewNativeSubIndicatorsWithCache({
           cache: subIndicatorCalculationCache,
           instances: visibleSubIndicatorInstances,
-          points,
+          points: primarySeriesPoints,
         }),
-      [points, subIndicatorCalculationCache, visibleSubIndicatorInstances],
+      [
+        primarySeriesPoints,
+        subIndicatorCalculationCache,
+        visibleSubIndicatorInstances,
+      ],
     );
     const subIndicatorPanes = useMemo(
       () =>
@@ -384,8 +405,8 @@ export const TradingViewNativeContainer = memo(
     const sourceTokenAddress =
       source.kind === 'market' ? source.tokenAddress : undefined;
     const currentPriceLabel = useMemo(
-      () => getTradingViewNativeCurrentPriceLabel(points),
-      [points],
+      () => getTradingViewNativeCurrentPriceLabel(primarySeriesPoints),
+      [primarySeriesPoints],
     );
     const chartComponentRenderNodes = useTradingViewNativeChartComponents({
       chartComponents,
@@ -520,6 +541,23 @@ export const TradingViewNativeContainer = memo(
         changeChartInterval(interval);
       },
       [changeChartInterval],
+    );
+
+    const handleChartTypeChange = useCallback(
+      (nextChartType: ITradingViewNativeChartType) => {
+        void setStoredChartSettings((currentSettings) => {
+          const normalizedCurrentSettings =
+            normalizeTradingViewNativeChartSettings(currentSettings);
+          if (normalizedCurrentSettings.chartType === nextChartType) {
+            return currentSettings;
+          }
+          return {
+            ...normalizedCurrentSettings,
+            chartType: nextChartType,
+          };
+        });
+      },
+      [setStoredChartSettings],
     );
 
     const handleIndicatorChange = useCallback(
@@ -668,6 +706,7 @@ export const TradingViewNativeContainer = memo(
     return (
       <Stack flex={1} w="100%" h="100%" bg="$transparent">
         <TradingViewNativeChartControlsContainer
+          activeChartType={chartType}
           calendarAvailableTimeRange={calendarAvailableTimeRange}
           enableNativeChartSettings={enableNativeChartSettings}
           intervalConfig={intervalConfig}
@@ -678,6 +717,7 @@ export const TradingViewNativeContainer = memo(
           fullscreenHeader={nativeChartFullscreenHeader}
           isChartSwitchDisabled={isChartSwitchDisabled}
           onChartSwitch={onChartSwitch}
+          onChartTypeChange={handleChartTypeChange}
           onIntervalChange={handleChartIntervalChange}
           onIndicatorChange={handleIndicatorChange}
           onIndicatorSettingsPress={handleIndicatorSettingsPress}
@@ -707,7 +747,7 @@ export const TradingViewNativeContainer = memo(
             onViewportRequestApplied={handleViewportRequestApplied}
             onVisiblePointRangeChange={handleVisiblePointRangeChange}
             candleLabels={candleLabels}
-            points={points}
+            points={primarySeriesPoints}
             subIndicatorPanes={subIndicatorPanes}
             testID={testID}
             viewportRequest={viewportRequest}

--- a/packages/kit/src/components/TradingView/TradingViewNative/chartSettingsAdapter.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/chartSettingsAdapter.test.ts
@@ -1,4 +1,5 @@
 import {
+  TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION,
   TRADING_VIEW_NATIVE_THEME_COLORS,
   createTradingViewNativeChartSettings,
 } from '@onekeyhq/shared/types/tradingViewNative';
@@ -20,6 +21,7 @@ describe('TradingViewNative chart settings adapter', () => {
 
   it('round-trips supported chart settings without the countdown option', () => {
     const currentSettings = createTradingViewNativeChartSettings();
+    currentSettings.chartType = 'area';
     currentSettings.options.yAxis = false;
     const value = getTradingViewChartSettingsValue(currentSettings);
     const candleSection = value.appearanceSections.find(
@@ -43,6 +45,7 @@ describe('TradingViewNative chart settings adapter', () => {
       value,
     });
 
+    expect(nextSettings.chartType).toBe('area');
     expect(nextSettings.options.yAxis).toBe(true);
     expect(nextSettings.options).not.toHaveProperty('countdown');
     expect(nextSettings.options.latestPrice).toBe(false);
@@ -90,10 +93,33 @@ describe('TradingViewNative chart settings adapter', () => {
     expect(migrated).toEqual(createTradingViewNativeChartSettings());
   });
 
+  it('does not repeat the theme migration for schema version 2 settings', () => {
+    const previousSettings = createTradingViewNativeChartSettings();
+    Object.assign(previousSettings, {
+      schemaVersion: 2,
+      background: { style: 'solid', colors: ['#000000', '#171717'] },
+      grid: {
+        style: 'both',
+        horizontalColor: '#171717',
+        verticalColor: '#171717',
+      },
+    });
+
+    const migrated = normalizeTradingViewNativeChartSettings(previousSettings);
+
+    expect(migrated.schemaVersion).toBe(
+      TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION,
+    );
+    expect(migrated.background.colors).toEqual(['#000000', '#171717']);
+    expect(migrated.grid.horizontalColor).toBe('#171717');
+    expect(migrated.grid.verticalColor).toBe('#171717');
+  });
+
   it('sanitizes malformed nested values in the current persisted schema', () => {
     const fallback = createTradingViewNativeChartSettings();
     const normalized = normalizeTradingViewNativeChartSettings({
       schemaVersion: fallback.schemaVersion,
+      chartType: 'unsupported',
       candles: null,
       options: {
         yAxis: false,

--- a/packages/kit/src/components/TradingView/TradingViewNative/chartSettingsAdapter.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/chartSettingsAdapter.ts
@@ -10,6 +10,8 @@ import {
 
 import { createTradingViewChartSettingsValue } from '../TradingViewChartControls/chartSettings';
 
+import { isTradingViewNativeChartTypePreference } from './utils/chartType';
+
 import type { ITradingViewChartSettingsValue } from '../TradingViewChartControls/chartSettings';
 
 type ITradingViewNativeCandlePart =
@@ -94,10 +96,13 @@ export function normalizeTradingViewNativeChartSettings(
   const grid = isRecord(record.grid) ? record.grid : {};
   const crossLine = isRecord(record.crossLine) ? record.crossLine : {};
   const shouldMigrateThemeColors =
-    record.schemaVersion !== TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION;
+    typeof record.schemaVersion !== 'number' || record.schemaVersion < 2;
 
   const normalizedSettings: ITradingViewNativeChartSettings = {
     schemaVersion: TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION,
+    chartType: isTradingViewNativeChartTypePreference(record.chartType)
+      ? record.chartType
+      : fallback.chartType,
     candles: {
       body: normalizeCandlePartSettings(candles.body, fallback.candles.body),
       border: normalizeCandlePartSettings(
@@ -349,15 +354,19 @@ export function getTradingViewChartSettingsValue(
 }
 
 export function getTradingViewNativeChartSettings({
+  currentSettings,
   value,
 }: {
   currentSettings: ITradingViewNativeChartSettings;
   value: ITradingViewChartSettingsValue;
 }): ITradingViewNativeChartSettings {
   const fallback = createTradingViewNativeChartSettings();
+  const normalizedCurrentSettings =
+    normalizeTradingViewNativeChartSettings(currentSettings);
 
   return {
     schemaVersion: fallback.schemaVersion,
+    chartType: normalizedCurrentSettings.chartType,
     candles: {
       body: getCandlePartSettings({
         fallback: fallback.candles.body,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.test.ts
@@ -2,6 +2,7 @@ import {
   applyTradingViewNativeSubIndicatorLatestPaneValues,
   getTradingViewNativeSubIndicatorPanesStructureKey,
   getTradingViewNativeSubIndicatorPanesUpdate,
+  shouldReplaceTradingViewNativeChartPoints,
   shouldReplaceTradingViewNativeIndicatorSeries,
 } from './chartRuntimeData';
 
@@ -74,20 +75,75 @@ function createPane({
 }
 
 function createPictureInput({
-  chartPictureVersion = 1,
   panes,
   pointCount = 3,
+  renderDataRevision = '1:identity',
 }: {
-  chartPictureVersion?: number;
   panes: readonly ITradingViewNativeSubIndicatorRenderPane[];
   pointCount?: number;
+  renderDataRevision?: string;
 }) {
   return {
-    chartPictureVersion,
     pointCount,
+    renderDataRevision,
     structureKey: getTradingViewNativeSubIndicatorPanesStructureKey(panes),
   };
 }
+
+describe('TradingViewNativeChart point-derived data updates', () => {
+  const previous = {
+    pointCount: 100,
+    renderDataRevision: '1:identity',
+  };
+
+  it('keeps the constant-time latest-point path for unchanged data semantics', () => {
+    expect(
+      shouldReplaceTradingViewNativeChartPoints({
+        current: previous,
+        previous,
+      }),
+    ).toBe(false);
+  });
+
+  it('fully replaces points and indicators after a point transform change', () => {
+    const current = {
+      ...previous,
+      renderDataRevision: '1:heikinAshi',
+    };
+    expect(
+      shouldReplaceTradingViewNativeChartPoints({ current, previous }),
+    ).toBe(true);
+    expect(
+      shouldReplaceTradingViewNativeIndicatorSeries({
+        current: {
+          ...current,
+          seriesKey: 'ma-1',
+          settingsKey: 'ma-settings',
+        },
+        previous: {
+          ...previous,
+          seriesKey: 'ma-1',
+          settingsKey: 'ma-settings',
+        },
+      }),
+    ).toBe(true);
+
+    const panes = [createPane()];
+    expect(
+      getTradingViewNativeSubIndicatorPanesUpdate({
+        current: createPictureInput({
+          panes,
+          renderDataRevision: current.renderDataRevision,
+        }),
+        panes,
+        previous: createPictureInput({
+          panes,
+          renderDataRevision: previous.renderDataRevision,
+        }),
+      }).replacementPanes,
+    ).toBe(panes);
+  });
+});
 
 describe('TradingViewNativeChart sub-indicator realtime updates', () => {
   it('transfers and applies only latest values for an unchanged structure', () => {
@@ -183,8 +239,8 @@ describe('TradingViewNativeChart sub-indicator realtime updates', () => {
 
 describe('TradingViewNativeChart main-indicator updates', () => {
   const previous = {
-    chartPictureVersion: 1,
     pointCount: 100,
+    renderDataRevision: '1:identity',
     seriesKey: 'ma-1|ma-2',
     settingsKey: '{"MA":{"period":5}}',
   };

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -40,6 +40,7 @@ import {
   getTradingViewNativeChartRuntimeVisiblePointRange,
   reduceTradingViewNativeChartRuntime,
 } from '../utils/chartRuntime';
+import { getTradingViewNativeRenderDataRevision } from '../utils/chartType';
 import {
   getTradingViewNativeDataUpdateMetadata,
   getTradingViewNativeGestureStartOffsetAfterDataUpdate,
@@ -65,6 +66,7 @@ import {
   applyTradingViewNativeSubIndicatorLatestPaneValues,
   getTradingViewNativeSubIndicatorPanesStructureKey,
   getTradingViewNativeSubIndicatorPanesUpdate,
+  shouldReplaceTradingViewNativeChartPoints,
   shouldReplaceTradingViewNativeIndicatorSeries,
 } from './chartRuntimeData';
 import {
@@ -117,6 +119,10 @@ export const TradingViewNativeChart = memo(
     const [chartWidth, setChartWidth] = useState(0);
     const subIndicatorPanesStructureKey =
       getTradingViewNativeSubIndicatorPanesStructureKey(subIndicatorPanes);
+    const renderDataRevision = getTradingViewNativeRenderDataRevision({
+      chartPictureVersion,
+      chartType,
+    });
     const chartRuntime = useSharedValue(
       createTradingViewNativeChartRuntime({
         candleIntervalSeconds,
@@ -136,10 +142,10 @@ export const TradingViewNativeChart = memo(
       points[points.length - 1]?.t,
     );
     const previousPictureInputRef = useRef({
-      chartPictureVersion,
       indicatorSeriesKey: indicatorSeries.map((series) => series.key).join('|'),
       indicatorSeriesSettingsKey,
       pointCount: points.length,
+      renderDataRevision,
       subIndicatorPanesStructureKey,
     });
     const appliedViewportRequestRef = useRef({
@@ -424,20 +430,27 @@ export const TradingViewNativeChart = memo(
       const indicatorSeriesKey = indicatorSeries
         .map((series) => series.key)
         .join('|');
-      const shouldReplaceAllPoints =
-        previousPictureInput.chartPictureVersion !== chartPictureVersion ||
-        previousPictureInput.pointCount !== points.length;
+      const shouldReplaceAllPoints = shouldReplaceTradingViewNativeChartPoints({
+        current: {
+          pointCount: points.length,
+          renderDataRevision,
+        },
+        previous: {
+          pointCount: previousPictureInput.pointCount,
+          renderDataRevision: previousPictureInput.renderDataRevision,
+        },
+      });
       const shouldReplaceAllIndicatorSeries =
         shouldReplaceTradingViewNativeIndicatorSeries({
           current: {
-            chartPictureVersion,
             pointCount: points.length,
+            renderDataRevision,
             seriesKey: indicatorSeriesKey,
             settingsKey: indicatorSeriesSettingsKey,
           },
           previous: {
-            chartPictureVersion: previousPictureInput.chartPictureVersion,
             pointCount: previousPictureInput.pointCount,
+            renderDataRevision: previousPictureInput.renderDataRevision,
             seriesKey: previousPictureInput.indicatorSeriesKey,
             settingsKey: previousPictureInput.indicatorSeriesSettingsKey,
           },
@@ -445,23 +458,23 @@ export const TradingViewNativeChart = memo(
       const subIndicatorPanesUpdate =
         getTradingViewNativeSubIndicatorPanesUpdate({
           current: {
-            chartPictureVersion,
             pointCount: points.length,
+            renderDataRevision,
             structureKey: subIndicatorPanesStructureKey,
           },
           panes: subIndicatorPanes,
           previous: {
-            chartPictureVersion: previousPictureInput.chartPictureVersion,
             pointCount: previousPictureInput.pointCount,
+            renderDataRevision: previousPictureInput.renderDataRevision,
             structureKey: previousPictureInput.subIndicatorPanesStructureKey,
           },
         });
       previousLatestTimestampRef.current = dataUpdateMetadata.latestTimestamp;
       previousPictureInputRef.current = {
-        chartPictureVersion,
         indicatorSeriesKey,
         indicatorSeriesSettingsKey,
         pointCount: points.length,
+        renderDataRevision,
         subIndicatorPanesStructureKey: subIndicatorPanesUpdate.structureKey,
       };
       const nextSize = chartSize;
@@ -563,7 +576,6 @@ export const TradingViewNativeChart = memo(
     }, [
       candleIntervalSeconds,
       chartType,
-      chartPictureVersion,
       chartRuntime,
       chartSize,
       decayOffset,
@@ -572,6 +584,7 @@ export const TradingViewNativeChart = memo(
       indicatorSeriesSettingsKey,
       points,
       priceAxisWidth,
+      renderDataRevision,
       subIndicatorPanes,
       subIndicatorPanesStructureKey,
     ]);

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartRuntimeData.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartRuntimeData.ts
@@ -1,14 +1,15 @@
 import type { ITradingViewNativeSubIndicatorRenderPane } from '../utils/subIndicatorRender';
 
-interface ITradingViewNativeSubIndicatorPanesPictureInput {
-  chartPictureVersion: number;
+interface ITradingViewNativePictureInput {
   pointCount: number;
+  renderDataRevision: string;
+}
+
+interface ITradingViewNativeSubIndicatorPanesPictureInput extends ITradingViewNativePictureInput {
   structureKey: string;
 }
 
-interface ITradingViewNativeIndicatorSeriesPictureInput {
-  chartPictureVersion: number;
-  pointCount: number;
+interface ITradingViewNativeIndicatorSeriesPictureInput extends ITradingViewNativePictureInput {
   seriesKey: string;
   settingsKey: string;
 }
@@ -30,6 +31,19 @@ export interface ITradingViewNativeSubIndicatorPanesUpdate {
   structureKey: string;
 }
 
+export function shouldReplaceTradingViewNativeChartPoints({
+  current,
+  previous,
+}: {
+  current: ITradingViewNativePictureInput;
+  previous: ITradingViewNativePictureInput;
+}) {
+  return (
+    previous.renderDataRevision !== current.renderDataRevision ||
+    previous.pointCount !== current.pointCount
+  );
+}
+
 export function shouldReplaceTradingViewNativeIndicatorSeries({
   current,
   previous,
@@ -38,8 +52,7 @@ export function shouldReplaceTradingViewNativeIndicatorSeries({
   previous: ITradingViewNativeIndicatorSeriesPictureInput;
 }) {
   return (
-    previous.chartPictureVersion !== current.chartPictureVersion ||
-    previous.pointCount !== current.pointCount ||
+    shouldReplaceTradingViewNativeChartPoints({ current, previous }) ||
     previous.seriesKey !== current.seriesKey ||
     previous.settingsKey !== current.settingsKey
   );
@@ -144,8 +157,7 @@ export function getTradingViewNativeSubIndicatorPanesUpdate({
   previous: ITradingViewNativeSubIndicatorPanesPictureInput;
 }): ITradingViewNativeSubIndicatorPanesUpdate {
   const shouldReplaceAllPanes =
-    previous.chartPictureVersion !== current.chartPictureVersion ||
-    previous.pointCount !== current.pointCount ||
+    shouldReplaceTradingViewNativeChartPoints({ current, previous }) ||
     previous.structureKey !== current.structureKey;
   return {
     latestPaneValues: shouldReplaceAllPanes

--- a/packages/kit/src/components/TradingView/TradingViewNative/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/types.ts
@@ -4,8 +4,9 @@ import type { ITradingViewNativeChartLineStyle } from '@onekeyhq/shared/types/tr
 
 import type { ITradingViewNativeChartInterval } from './data/tradingViewNativeIntervals';
 
+export type { ITradingViewNativeChartType } from '@onekeyhq/shared/types/tradingViewNative';
+
 export type ITradingViewNativeHyperliquidEnvironment = 'mainnet' | 'testnet';
-export type ITradingViewNativeChartType = 'candlestick' | 'line';
 export type ITradingViewNativePriceScaleMode = 'linear' | 'logarithmic';
 
 export interface ITradingViewNativeCandleLabels {

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts
@@ -62,7 +62,7 @@ describe('TradingViewNative chart legend', () => {
   });
 
   it('shows close price and price change for a line series', () => {
-    expect(
+    const buildLegend = (chartType: 'area' | 'line') =>
       getTradingViewNativeChartLegend(
         {
           c: 9,
@@ -73,16 +73,19 @@ describe('TradingViewNative chart legend', () => {
           v: 500,
         },
         CANDLE_LABELS,
-        'line',
-      ),
-    ).toEqual({
+        chartType,
+      );
+    const expectedLegend = {
       isUp: false,
       priceItems: [
         { label: 'Price', value: '9.00' },
         { label: '', value: '-1 (-10%)', valueColorRole: 'trend' },
       ],
       volumeItem: { label: 'Volume', value: '500' },
-    });
+    };
+
+    expect(buildLegend('line')).toEqual(expectedLegend);
+    expect(buildLegend('area')).toEqual(expectedLegend);
   });
 
   it('uses the previous close for the TradingView bar-change value and color', () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.ts
@@ -11,6 +11,7 @@ import {
 } from '../chartConstants';
 
 import { formatTradingViewNativePriceTick } from './chartLayout';
+import { getTradingViewNativePrimarySeriesModel } from './chartType';
 
 import type {
   ITradingViewNativeCandleLabels,
@@ -241,10 +242,11 @@ export function getTradingViewNativeChartLegend(
     }),
     valueColorRole: 'trend',
   };
+  const primarySeries = getTradingViewNativePrimarySeriesModel(chartType);
   return {
     isUp: point.c >= changeReference,
     priceItems:
-      chartType === 'line'
+      primarySeries.priceSource === 'close'
         ? [{ label: 'Price', value: formatPrice(point.c) }, priceChangeItem]
         : [
             { label: candleLabels.open, value: formatPrice(point.o) },

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
@@ -554,6 +554,17 @@ describe('TradingViewNative shared chart scene', () => {
     expect(styles.gridLine.dash).toEqual([2, 4]);
     expect(styles.crosshairLine.opacity).toBe(0.6);
     expect(styles.line.color).toBe('#444444');
+    expect(styles.areaFill).toMatchObject({
+      color: TRADING_VIEW_NATIVE_CHART_UP_COLOR,
+      opacity: 0.12,
+    });
+    expect(styles.areaStroke).toMatchObject({
+      color: TRADING_VIEW_NATIVE_CHART_UP_COLOR,
+      drawStyle: 'stroke',
+      strokeCap: 'round',
+      strokeJoin: 'round',
+      strokeWidth: 2,
+    });
     expect(styles.lineStroke).toMatchObject({
       color: '#444444',
       drawStyle: 'stroke',
@@ -659,6 +670,91 @@ describe('TradingViewNative shared chart scene', () => {
         (command) => command.kind === 'text' && command.text === '-10 (-10%)',
       ),
     ).toMatchObject({ paint: 'down' });
+  });
+
+  it('fills an area below the close-price line', () => {
+    const scene = buildTradingViewNativeChartScene({
+      candleIntervalSeconds: 3600,
+      chartType: 'area',
+      crosshair: { visible: false, x: 0, y: 0 },
+      hasVolume: false,
+      height: 240,
+      measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
+      points: POINTS,
+      viewport: { offset: 0, zoomScale: 1 },
+      watermarkOpacity: 0.16,
+      width: 320,
+    });
+    const area = scene.commands.find(
+      (command) => command.kind === 'polygon' && command.paint === 'areaFill',
+    );
+    const line = scene.commands.find(
+      (command) =>
+        command.kind === 'polyline' && command.paint === 'areaStroke',
+    );
+    const latestPoint = scene.commands.find(
+      (command) => command.kind === 'circle' && command.paint === 'up',
+    );
+    const priceLegend = scene.commands.find(
+      (command) =>
+        command.kind === 'text' &&
+        command.text === 'Price' &&
+        command.paint === 'axisText',
+    );
+    const priceLegendValue = scene.commands.find(
+      (command) =>
+        command.kind === 'text' &&
+        command.text === '104.00' &&
+        command.paint === 'up',
+    );
+    const text = scene.commands.flatMap((command) =>
+      command.kind === 'text' ? [command.text] : [],
+    );
+
+    expect(area).toMatchObject({ kind: 'polygon', paint: 'areaFill' });
+    expect(area?.kind === 'polygon' ? area.points : []).toHaveLength(
+      POINTS.length + 2,
+    );
+    expect(line).toMatchObject({ kind: 'polyline', paint: 'areaStroke' });
+    expect(latestPoint).toMatchObject({ kind: 'circle', paint: 'up' });
+    expect(priceLegend).toBeDefined();
+    expect(priceLegendValue).toBeDefined();
+    expect(text).toContain('Price');
+    expect(text).not.toEqual(expect.arrayContaining(['O', 'H', 'L', 'C']));
+  });
+
+  it('draws OHLC bars with open and close ticks', () => {
+    const scene = buildTradingViewNativeChartScene({
+      candleIntervalSeconds: 3600,
+      chartType: 'bars',
+      crosshair: { visible: false, x: 0, y: 0 },
+      hasVolume: false,
+      height: 240,
+      measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
+      points: POINTS,
+      viewport: { offset: 0, zoomScale: 1 },
+      watermarkOpacity: 0.16,
+      width: 320,
+    });
+    const barLines = scene.commands.filter(
+      (command) =>
+        command.kind === 'line' &&
+        (command.paint === 'up' || command.paint === 'down'),
+    );
+    const candleRects = scene.commands.filter(
+      (command) =>
+        command.kind === 'rect' &&
+        command.customPaintId?.startsWith('chart.candle.'),
+    );
+    const text = scene.commands.flatMap((command) =>
+      command.kind === 'text' ? [command.text] : [],
+    );
+
+    expect(barLines).toHaveLength(POINTS.length * 3);
+    expect(candleRects).toHaveLength(0);
+    expect(text).toEqual(expect.arrayContaining(['O', 'H', 'L', 'C']));
   });
 
   it('keeps a long price change visible on narrow charts', () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
@@ -34,8 +34,6 @@ import {
   TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT as TIME_AXIS_HEIGHT,
   TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH,
   TRADING_VIEW_NATIVE_CANDLE_STEP,
-  TRADING_VIEW_NATIVE_CANDLE_WICK_WIDTH,
-  TRADING_VIEW_NATIVE_LINE_POINT_RADIUS,
   TRADING_VIEW_NATIVE_LINE_WIDTH,
   TRADING_VIEW_NATIVE_VOLUME_LEGEND_TOP_PADDING as VOLUME_LEGEND_TOP_PADDING,
   TRADING_VIEW_NATIVE_VOLUME_OPACITY as VOLUME_OPACITY,
@@ -74,6 +72,7 @@ import {
   getTradingViewNativeVolumeAxisLabel,
 } from './chartLegend';
 import { isTradingViewNativePriceUp } from './chartStyle';
+import { getTradingViewNativePrimarySeriesModel } from './chartType';
 import {
   type ITradingViewNativeVisiblePointRange,
   clampTradingViewNativePanOffset,
@@ -83,6 +82,10 @@ import {
   getTradingViewNativePriceExtrema,
   getTradingViewNativeVisiblePointRange,
 } from './chartViewport';
+import {
+  appendTradingViewNativePrimarySeriesCommands,
+  appendTradingViewNativePrimarySeriesPaintStyles,
+} from './primarySeriesScene';
 import {
   appendTradingViewNativeSubIndicatorCommands,
   appendTradingViewNativeSubIndicatorLegendCommands,
@@ -111,6 +114,8 @@ export type ITradingViewNativeChartSceneFont = 'axis' | 'legend' | 'priceAxis';
 
 export type ITradingViewNativeChartScenePaint =
   | 'axisText'
+  | 'areaFill'
+  | 'areaStroke'
   | 'background'
   | 'crosshairLabelBackground'
   | 'crosshairLabelText'
@@ -246,18 +251,6 @@ export interface IBuildTradingViewNativeChartSceneOptions {
   width: number;
 }
 
-const CANDLE_BODY_PAINT_IDS = {
-  down: 'chart.candle.body.down',
-  up: 'chart.candle.body.up',
-} as const;
-const CANDLE_BORDER_PAINT_IDS = {
-  down: 'chart.candle.border.down',
-  up: 'chart.candle.border.up',
-} as const;
-const CANDLE_WICK_PAINT_IDS = {
-  down: 'chart.candle.wick.down',
-  up: 'chart.candle.wick.up',
-} as const;
 const CROSSHAIR_PAINT_ID = 'chart.crosshair';
 const GRID_HORIZONTAL_PAINT_ID = 'chart.grid.horizontal';
 const GRID_VERTICAL_PAINT_ID = 'chart.grid.vertical';
@@ -296,6 +289,15 @@ export function getTradingViewNativeChartScenePaintStyles({
 
   return {
     axisText: { color: axisText, opacity: 1 },
+    areaFill: { color: up, opacity: 0.12 },
+    areaStroke: {
+      color: up,
+      drawStyle: 'stroke',
+      opacity: 1,
+      strokeCap: 'round',
+      strokeJoin: 'round',
+      strokeWidth: TRADING_VIEW_NATIVE_LINE_WIDTH,
+    },
     background: { color: background, opacity: 1 },
     crosshairLabelBackground: {
       color: CROSSHAIR_LABEL_BACKGROUND_COLOR,
@@ -539,6 +541,7 @@ export function buildTradingViewNativeChartScene({
 }: IBuildTradingViewNativeChartSceneOptions): ITradingViewNativeChartScene {
   'worklet';
 
+  const primarySeries = getTradingViewNativePrimarySeriesModel(chartType);
   const visibleSubIndicatorPanes = subIndicatorPanes.filter(
     (pane) => pane.isVisible,
   );
@@ -639,22 +642,12 @@ export function buildTradingViewNativeChartScene({
           : undefined,
       opacity: CROSSHAIR_LINE_OPACITY,
     };
+    appendTradingViewNativePrimarySeriesPaintStyles({
+      chartSettings,
+      customPaintStyles,
+    });
     for (const direction of ['up', 'down'] as const) {
       const colorKey = direction === 'up' ? 'upColor' : 'downColor';
-      customPaintStyles[CANDLE_BODY_PAINT_IDS[direction]] = {
-        color: chartSettings.candles.body[colorKey],
-        opacity: 1,
-      };
-      customPaintStyles[CANDLE_BORDER_PAINT_IDS[direction]] = {
-        color: chartSettings.candles.border[colorKey],
-        drawStyle: 'stroke',
-        opacity: 1,
-        strokeWidth: 1,
-      };
-      customPaintStyles[CANDLE_WICK_PAINT_IDS[direction]] = {
-        color: chartSettings.candles.wick[colorKey],
-        opacity: 1,
-      };
       customPaintStyles[LATEST_PRICE_LINE_PAINT_IDS[direction]] = {
         color: chartSettings.latestPriceLine[colorKey],
         dash:
@@ -888,114 +881,16 @@ export function buildTradingViewNativeChartScene({
       y: 0,
     },
   });
-  if (chartType === 'line') {
-    const lineStartIndex = Math.max(visiblePointRange.startIndex - 1, 0);
-    const lineEndIndex = Math.min(
-      visiblePointRange.endIndex + 1,
-      points.length,
-    );
-    const lineSegments: { x: number; y: number }[][] = [];
-    let linePoints: { x: number; y: number }[] = [];
-    for (let index = lineStartIndex; index < lineEndIndex; index += 1) {
-      const point = points[index];
-      if (point && Number.isFinite(point.c)) {
-        linePoints.push({
-          x: getPointX(index),
-          y: getTradingViewNativePriceY(point.c, layout),
-        });
-      } else {
-        if (linePoints.length > 1) {
-          lineSegments.push(linePoints);
-        }
-        linePoints = [];
-      }
-    }
-    if (linePoints.length > 1) {
-      lineSegments.push(linePoints);
-    }
-    for (const segment of lineSegments) {
-      commands.push({
-        kind: 'polyline',
-        paint: 'lineStroke',
-        points: segment,
-      });
-    }
-
-    const latestPointIndex = points.length - 1;
-    const latestLinePoint = points[latestPointIndex];
-    if (latestLinePoint && Number.isFinite(latestLinePoint.c)) {
-      commands.push({
-        cx: getPointX(latestPointIndex),
-        cy: getTradingViewNativePriceY(latestLinePoint.c, layout),
-        kind: 'circle',
-        paint: 'line',
-        radius: TRADING_VIEW_NATIVE_LINE_POINT_RADIUS,
-      });
-    }
-  } else {
-    for (
-      let index = visiblePointRange.startIndex;
-      index < visiblePointRange.endIndex;
-      index += 1
-    ) {
-      const point = points[index];
-      if (point) {
-        const direction = isTradingViewNativePriceUp(point) ? 'up' : 'down';
-        const paint = direction;
-        const x = getPointX(index);
-        const openY = getTradingViewNativePriceY(point.o, layout);
-        const highY = getTradingViewNativePriceY(point.h, layout);
-        const lowY = getTradingViewNativePriceY(point.l, layout);
-        const closeY = getTradingViewNativePriceY(point.c, layout);
-        const colorKey = direction === 'up' ? 'upColor' : 'downColor';
-        const candleBodyRect = {
-          height: Math.max(Math.abs(closeY - openY), 1),
-          width: candleBodyWidth,
-          x: x - candleBodyWidth / 2,
-          y: Math.min(openY, closeY),
-        };
-        if (chartSettings?.candles.wick.enabled ?? true) {
-          commands.push({
-            ...(chartSettings
-              ? { customPaintId: CANDLE_WICK_PAINT_IDS[direction] }
-              : {}),
-            height: Math.max(lowY - highY, 1),
-            kind: 'rect',
-            paint,
-            width: TRADING_VIEW_NATIVE_CANDLE_WICK_WIDTH,
-            x: x - TRADING_VIEW_NATIVE_CANDLE_WICK_WIDTH / 2,
-            y: highY,
-          });
-        }
-        if (chartSettings?.candles.body.enabled ?? true) {
-          commands.push({
-            ...candleBodyRect,
-            ...(chartSettings
-              ? { customPaintId: CANDLE_BODY_PAINT_IDS[direction] }
-              : {}),
-            kind: 'rect',
-            paint,
-          });
-        }
-        const bodyAlreadyDrawsBorderColor = Boolean(
-          chartSettings?.candles.body.enabled &&
-          chartSettings.candles.body[colorKey] ===
-            chartSettings.candles.border[colorKey],
-        );
-        if (
-          chartSettings?.candles.border.enabled &&
-          !bodyAlreadyDrawsBorderColor
-        ) {
-          commands.push({
-            ...candleBodyRect,
-            customPaintId: CANDLE_BORDER_PAINT_IDS[direction],
-            kind: 'rect',
-            paint,
-          });
-        }
-      }
-    }
-  }
+  appendTradingViewNativePrimarySeriesCommands({
+    candleBodyWidth,
+    chartSettings,
+    commands,
+    getPointX,
+    layout,
+    points,
+    primarySeries,
+    visiblePointRange,
+  });
   for (
     let index = visiblePointRange.startIndex;
     index < visiblePointRange.endIndex;
@@ -1046,12 +941,12 @@ export function buildTradingViewNativeChartScene({
   });
 
   const visiblePriceExtrema =
-    chartType === 'candlestick'
-      ? getTradingViewNativePriceExtrema({
+    primarySeries.priceSource === 'close'
+      ? null
+      : getTradingViewNativePriceExtrema({
           ...visiblePointRange,
           points,
-        })
-      : null;
+        });
   if (visiblePriceExtrema) {
     commands.push({ kind: 'clip', rect: mainChartClip });
     const extrema = visiblePriceExtrema.low
@@ -1161,7 +1056,9 @@ export function buildTradingViewNativeChartScene({
     ? 'up'
     : 'down';
   const legendValuePaint: ITradingViewNativeChartScenePaint =
-    chartType === 'line' ? 'line' : trendValuePaint;
+    primarySeries.colorRole === 'directional'
+      ? trendValuePaint
+      : primarySeries.colorRole;
   const measureLegendTextWidth = (text: string) =>
     measureTextWidth(text, 'legend');
   const appendLegendRows = (

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartType.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartType.test.ts
@@ -1,6 +1,13 @@
 import {
+  TRADING_VIEW_NATIVE_CHART_TYPE_OPTIONS,
   getTradingViewNativeChartType,
+  getTradingViewNativeChartTypeFromValue,
+  getTradingViewNativeChartTypeValue,
+  getTradingViewNativePrimarySeriesModel,
+  getTradingViewNativePrimarySeriesPoints,
+  getTradingViewNativeRenderDataRevision,
   isTradingViewNativeSingleValueHistory,
+  resolveTradingViewNativeChartType,
 } from './chartType';
 
 describe('TradingViewNative chart type', () => {
@@ -29,5 +36,112 @@ describe('TradingViewNative chart type', () => {
     expect(isTradingViewNativeSingleValueHistory('single')).toBe(true);
     expect(isTradingViewNativeSingleValueHistory('ohlc')).toBe(false);
     expect(isTradingViewNativeSingleValueHistory()).toBe(false);
+  });
+
+  it('uses the same five chart type values as the shared controls', () => {
+    expect(TRADING_VIEW_NATIVE_CHART_TYPE_OPTIONS).toEqual([
+      { id: 'candlestick', label: 'Candles', value: 1 },
+      { id: 'heikinAshi', label: 'Heikin Ashi', value: 8 },
+      { id: 'bars', label: 'Bars', value: 0 },
+      { id: 'line', label: 'Line', value: 2 },
+      { id: 'area', label: 'Area', value: 3 },
+    ]);
+    expect(getTradingViewNativeChartTypeFromValue(8)).toBe('heikinAshi');
+    expect(getTradingViewNativeChartTypeValue('area')).toBe(3);
+    expect(getTradingViewNativeChartTypeFromValue(21)).toBeUndefined();
+  });
+
+  it('keeps automatic data-based defaults until a chart type is selected', () => {
+    expect(
+      resolveTradingViewNativeChartType({
+        automaticChartType: 'line',
+        preference: 'auto',
+      }),
+    ).toBe('line');
+    expect(
+      resolveTradingViewNativeChartType({
+        automaticChartType: 'line',
+        preference: 'bars',
+      }),
+    ).toBe('bars');
+  });
+
+  it('defines rendering and price semantics for every chart type', () => {
+    expect(getTradingViewNativePrimarySeriesModel('candlestick')).toMatchObject(
+      {
+        colorRole: 'directional',
+        pointTransform: 'identity',
+        priceSource: 'ohlc',
+        renderKind: 'candles',
+      },
+    );
+    expect(getTradingViewNativePrimarySeriesModel('heikinAshi')).toMatchObject({
+      colorRole: 'directional',
+      pointTransform: 'heikinAshi',
+      priceSource: 'ohlc',
+      renderKind: 'candles',
+    });
+    expect(getTradingViewNativePrimarySeriesModel('bars')).toMatchObject({
+      colorRole: 'directional',
+      priceSource: 'ohlc',
+      renderKind: 'bars',
+    });
+    expect(getTradingViewNativePrimarySeriesModel('line')).toMatchObject({
+      colorRole: 'line',
+      fillArea: false,
+      priceSource: 'close',
+      renderKind: 'line',
+    });
+    expect(getTradingViewNativePrimarySeriesModel('area')).toMatchObject({
+      colorRole: 'up',
+      fillArea: true,
+      priceSource: 'close',
+      renderKind: 'line',
+    });
+  });
+
+  it('revises render data only when its source data semantics change', () => {
+    const getRevision = (
+      chartType: Parameters<
+        typeof getTradingViewNativeRenderDataRevision
+      >[0]['chartType'],
+    ) =>
+      getTradingViewNativeRenderDataRevision({
+        chartPictureVersion: 2,
+        chartType,
+      });
+
+    expect(getRevision('candlestick')).toBe('2:identity');
+    expect(getRevision('bars')).toBe(getRevision('candlestick'));
+    expect(getRevision('line')).toBe(getRevision('candlestick'));
+    expect(getRevision('heikinAshi')).toBe('2:heikinAshi');
+  });
+
+  it('derives recursive Heikin Ashi OHLC values without changing raw points', () => {
+    const points = [
+      { c: 106, h: 110, l: 90, o: 100, t: 1, v: 10 },
+      { c: 108, h: 112, l: 100, o: 106, t: 2, v: 20 },
+    ];
+
+    expect(
+      getTradingViewNativePrimarySeriesPoints({
+        chartType: 'heikinAshi',
+        points,
+      }),
+    ).toEqual([
+      { c: 101.5, h: 110, l: 90, o: 103, t: 1, v: 10 },
+      { c: 106.5, h: 112, l: 100, o: 102.25, t: 2, v: 20 },
+    ]);
+    expect(points[0]).toEqual({
+      c: 106,
+      h: 110,
+      l: 90,
+      o: 100,
+      t: 1,
+      v: 10,
+    });
+    expect(
+      getTradingViewNativePrimarySeriesPoints({ chartType: 'bars', points }),
+    ).toBe(points);
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartType.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartType.ts
@@ -1,5 +1,114 @@
+// cspell:words heikin ashi
+import type { IMarketTokenKLineDataPoint } from '@onekeyhq/shared/types/marketV2';
+import type {
+  ITradingViewNativeChartType,
+  ITradingViewNativeChartTypePreference,
+} from '@onekeyhq/shared/types/tradingViewNative';
+
+import type { ITradingViewChartTypeOption } from '../../TradingViewChartControls';
 import type { IMarketKLinePointType } from '../../utils/fetchMarketKLineData';
-import type { ITradingViewNativeChartType } from '../types';
+
+export type ITradingViewNativePrimarySeriesRenderKind =
+  | 'bars'
+  | 'candles'
+  | 'line';
+export type ITradingViewNativePrimarySeriesPointTransform =
+  | 'heikinAshi'
+  | 'identity';
+export type ITradingViewNativePrimarySeriesColorRole =
+  | 'directional'
+  | 'line'
+  | 'up';
+export type ITradingViewNativePrimarySeriesPriceSource = 'close' | 'ohlc';
+
+export interface ITradingViewNativePrimarySeriesModel {
+  colorRole: ITradingViewNativePrimarySeriesColorRole;
+  fillArea: boolean;
+  pointTransform: ITradingViewNativePrimarySeriesPointTransform;
+  priceSource: ITradingViewNativePrimarySeriesPriceSource;
+  renderKind: ITradingViewNativePrimarySeriesRenderKind;
+}
+
+type ITradingViewNativeChartTypeDefinitions = {
+  [TChartType in ITradingViewNativeChartType]: {
+    option: ITradingViewChartTypeOption & { id: TChartType };
+    primarySeries: ITradingViewNativePrimarySeriesModel;
+  };
+};
+
+const TRADING_VIEW_NATIVE_CHART_TYPE_DEFINITIONS = {
+  candlestick: {
+    option: { id: 'candlestick', label: 'Candles', value: 1 },
+    primarySeries: {
+      colorRole: 'directional',
+      fillArea: false,
+      pointTransform: 'identity',
+      priceSource: 'ohlc',
+      renderKind: 'candles',
+    },
+  },
+  heikinAshi: {
+    option: { id: 'heikinAshi', label: 'Heikin Ashi', value: 8 },
+    primarySeries: {
+      colorRole: 'directional',
+      fillArea: false,
+      pointTransform: 'heikinAshi',
+      priceSource: 'ohlc',
+      renderKind: 'candles',
+    },
+  },
+  bars: {
+    option: { id: 'bars', label: 'Bars', value: 0 },
+    primarySeries: {
+      colorRole: 'directional',
+      fillArea: false,
+      pointTransform: 'identity',
+      priceSource: 'ohlc',
+      renderKind: 'bars',
+    },
+  },
+  line: {
+    option: { id: 'line', label: 'Line', value: 2 },
+    primarySeries: {
+      colorRole: 'line',
+      fillArea: false,
+      pointTransform: 'identity',
+      priceSource: 'close',
+      renderKind: 'line',
+    },
+  },
+  area: {
+    option: { id: 'area', label: 'Area', value: 3 },
+    primarySeries: {
+      colorRole: 'up',
+      fillArea: true,
+      pointTransform: 'identity',
+      priceSource: 'close',
+      renderKind: 'line',
+    },
+  },
+} as const satisfies ITradingViewNativeChartTypeDefinitions;
+
+const TRADING_VIEW_NATIVE_CHART_TYPES_BY_VALUE = new Map<
+  number,
+  ITradingViewNativeChartType
+>(
+  Object.values(TRADING_VIEW_NATIVE_CHART_TYPE_DEFINITIONS).map(
+    ({ option }) => [option.value, option.id] as const,
+  ),
+);
+
+export const TRADING_VIEW_NATIVE_CHART_TYPE_OPTIONS = Object.values(
+  TRADING_VIEW_NATIVE_CHART_TYPE_DEFINITIONS,
+).map(({ option }) => option);
+
+export function getTradingViewNativePrimarySeriesModel(
+  chartType: ITradingViewNativeChartType,
+): ITradingViewNativePrimarySeriesModel {
+  'worklet';
+
+  return TRADING_VIEW_NATIVE_CHART_TYPE_DEFINITIONS[chartType].primarySeries;
+}
 
 export function getTradingViewNativeChartType({
   hasSingleValueHistory,
@@ -15,4 +124,94 @@ export function isTradingViewNativeSingleValueHistory(
   pointType?: IMarketKLinePointType,
 ) {
   return pointType === 'single';
+}
+
+export function isTradingViewNativeChartTypePreference(
+  value: unknown,
+): value is ITradingViewNativeChartTypePreference {
+  return (
+    value === 'auto' ||
+    (typeof value === 'string' &&
+      Object.prototype.hasOwnProperty.call(
+        TRADING_VIEW_NATIVE_CHART_TYPE_DEFINITIONS,
+        value,
+      ))
+  );
+}
+
+export function getTradingViewNativeChartTypeValue(
+  chartType: ITradingViewNativeChartType,
+): number {
+  return TRADING_VIEW_NATIVE_CHART_TYPE_DEFINITIONS[chartType].option.value;
+}
+
+export function getTradingViewNativeChartTypeFromValue(
+  value: number,
+): ITradingViewNativeChartType | undefined {
+  return TRADING_VIEW_NATIVE_CHART_TYPES_BY_VALUE.get(value);
+}
+
+export function resolveTradingViewNativeChartType({
+  automaticChartType,
+  preference,
+}: {
+  automaticChartType: ITradingViewNativeChartType;
+  preference: ITradingViewNativeChartTypePreference;
+}): ITradingViewNativeChartType {
+  return preference === 'auto' ? automaticChartType : preference;
+}
+
+export function getTradingViewNativeRenderDataRevision({
+  chartPictureVersion,
+  chartType,
+}: {
+  chartPictureVersion: number;
+  chartType: ITradingViewNativeChartType;
+}): string {
+  const { pointTransform } = getTradingViewNativePrimarySeriesModel(chartType);
+  return `${chartPictureVersion.toString()}:${pointTransform}`;
+}
+
+export function getTradingViewNativePrimarySeriesPoints({
+  chartType,
+  points,
+}: {
+  chartType: ITradingViewNativeChartType;
+  points: IMarketTokenKLineDataPoint[];
+}): IMarketTokenKLineDataPoint[] {
+  const { pointTransform } = getTradingViewNativePrimarySeriesModel(chartType);
+  if (pointTransform === 'identity') {
+    return points;
+  }
+
+  let previousOpen: number | undefined;
+  let previousClose: number | undefined;
+  return points.map((point) => {
+    if (
+      !Number.isFinite(point.o) ||
+      !Number.isFinite(point.h) ||
+      !Number.isFinite(point.l) ||
+      !Number.isFinite(point.c)
+    ) {
+      previousOpen = undefined;
+      previousClose = undefined;
+      return point;
+    }
+
+    const close = (point.o + point.h + point.l + point.c) / 4;
+    const open =
+      previousOpen === undefined || previousClose === undefined
+        ? (point.o + point.c) / 2
+        : (previousOpen + previousClose) / 2;
+    const nextPoint = {
+      ...point,
+      c: close,
+      h: Math.max(point.h, open, close),
+      l: Math.min(point.l, open, close),
+      o: open,
+    };
+    previousOpen = open;
+    previousClose = close;
+    return nextPoint;
+  });
 }

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts
@@ -387,7 +387,7 @@ describe('TradingViewNative chart viewport', () => {
     });
   });
 
-  it('derives line price ranges from close prices', () => {
+  it('derives line and area price ranges from close prices', () => {
     const points: IMarketTokenKLineDataPoint[] = [
       { c: 10, h: 1000, l: 1, o: 9, t: 1, v: 0 },
       { c: 30, h: 500, l: 2, o: 10, t: 2, v: 0 },
@@ -397,6 +397,14 @@ describe('TradingViewNative chart viewport', () => {
     expect(
       getTradingViewNativePriceRange({
         chartType: 'line',
+        endIndex: points.length,
+        points,
+        startIndex: 0,
+      }),
+    ).toEqual({ maxPrice: 30, minPrice: 10 });
+    expect(
+      getTradingViewNativePriceRange({
+        chartType: 'area',
         endIndex: points.length,
         points,
         startIndex: 0,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.ts
@@ -8,6 +8,8 @@ import {
   TRADING_VIEW_NATIVE_MIN_ZOOM_SCALE,
 } from '../chartConstants';
 
+import { getTradingViewNativePrimarySeriesModel } from './chartType';
+
 import type {
   ITradingViewNativeChartType,
   ITradingViewNativeInitialRightOffset,
@@ -718,11 +720,12 @@ export function getTradingViewNativePriceRange({
   );
   let minPrice = Number.POSITIVE_INFINITY;
   let maxPrice = Number.NEGATIVE_INFINITY;
+  const { priceSource } = getTradingViewNativePrimarySeriesModel(chartType);
 
   for (let index = clampedStartIndex; index < clampedEndIndex; index += 1) {
     const point = points[index];
-    const pointHigh = chartType === 'line' ? point.c : point.h;
-    const pointLow = chartType === 'line' ? point.c : point.l;
+    const pointHigh = priceSource === 'close' ? point.c : point.h;
+    const pointLow = priceSource === 'close' ? point.c : point.l;
     if (Number.isFinite(pointLow) && Number.isFinite(pointHigh)) {
       minPrice = Math.min(minPrice, pointLow);
       maxPrice = Math.max(maxPrice, pointHigh);

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/primarySeriesScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/primarySeriesScene.ts
@@ -1,0 +1,294 @@
+import type { IMarketTokenKLineDataPoint } from '@onekeyhq/shared/types/marketV2';
+import type { ITradingViewNativeChartSettings } from '@onekeyhq/shared/types/tradingViewNative';
+
+import {
+  TRADING_VIEW_NATIVE_CANDLE_WICK_WIDTH,
+  TRADING_VIEW_NATIVE_LINE_POINT_RADIUS,
+} from '../chartConstants';
+
+import { getTradingViewNativePriceY } from './chartLayout';
+import { isTradingViewNativePriceUp } from './chartStyle';
+
+import type { ITradingViewNativeChartLayout } from './chartLayout';
+import type {
+  ITradingViewNativeChartSceneCommand,
+  ITradingViewNativeChartScenePaint,
+  ITradingViewNativeChartScenePaintStyle,
+} from './chartScene';
+import type { ITradingViewNativePrimarySeriesModel } from './chartType';
+import type { ITradingViewNativeVisiblePointRange } from './chartViewport';
+
+const TRADING_VIEW_NATIVE_CANDLE_BODY_PAINT_IDS = {
+  down: 'chart.candle.body.down',
+  up: 'chart.candle.body.up',
+} as const;
+const TRADING_VIEW_NATIVE_CANDLE_BORDER_PAINT_IDS = {
+  down: 'chart.candle.border.down',
+  up: 'chart.candle.border.up',
+} as const;
+const TRADING_VIEW_NATIVE_CANDLE_WICK_PAINT_IDS = {
+  down: 'chart.candle.wick.down',
+  up: 'chart.candle.wick.up',
+} as const;
+
+interface ITradingViewNativePrimarySeriesSceneOptions {
+  candleBodyWidth: number;
+  chartSettings?: ITradingViewNativeChartSettings;
+  commands: ITradingViewNativeChartSceneCommand[];
+  getPointX: (index: number) => number;
+  layout: ITradingViewNativeChartLayout;
+  points: IMarketTokenKLineDataPoint[];
+  primarySeries: ITradingViewNativePrimarySeriesModel;
+  visiblePointRange: ITradingViewNativeVisiblePointRange;
+}
+
+export function appendTradingViewNativePrimarySeriesPaintStyles({
+  chartSettings,
+  customPaintStyles,
+}: {
+  chartSettings: ITradingViewNativeChartSettings;
+  customPaintStyles: Record<string, ITradingViewNativeChartScenePaintStyle>;
+}): void {
+  'worklet';
+
+  for (const direction of ['up', 'down'] as const) {
+    const colorKey = direction === 'up' ? 'upColor' : 'downColor';
+    customPaintStyles[TRADING_VIEW_NATIVE_CANDLE_BODY_PAINT_IDS[direction]] = {
+      color: chartSettings.candles.body[colorKey],
+      opacity: 1,
+    };
+    customPaintStyles[TRADING_VIEW_NATIVE_CANDLE_BORDER_PAINT_IDS[direction]] =
+      {
+        color: chartSettings.candles.border[colorKey],
+        drawStyle: 'stroke',
+        opacity: 1,
+        strokeWidth: 1,
+      };
+    customPaintStyles[TRADING_VIEW_NATIVE_CANDLE_WICK_PAINT_IDS[direction]] = {
+      color: chartSettings.candles.wick[colorKey],
+      opacity: 1,
+    };
+  }
+}
+
+function appendTradingViewNativeLineSeriesCommands({
+  commands,
+  getPointX,
+  layout,
+  points,
+  primarySeries,
+  visiblePointRange,
+}: ITradingViewNativePrimarySeriesSceneOptions) {
+  'worklet';
+
+  const lineStartIndex = Math.max(visiblePointRange.startIndex - 1, 0);
+  const lineEndIndex = Math.min(visiblePointRange.endIndex + 1, points.length);
+  const lineSegments: { x: number; y: number }[][] = [];
+  let linePoints: { x: number; y: number }[] = [];
+  for (let index = lineStartIndex; index < lineEndIndex; index += 1) {
+    const point = points[index];
+    if (point && Number.isFinite(point.c)) {
+      linePoints.push({
+        x: getPointX(index),
+        y: getTradingViewNativePriceY(point.c, layout),
+      });
+    } else {
+      if (linePoints.length > 1) {
+        lineSegments.push(linePoints);
+      }
+      linePoints = [];
+    }
+  }
+  if (linePoints.length > 1) {
+    lineSegments.push(linePoints);
+  }
+
+  if (primarySeries.fillArea) {
+    const areaBottomY = getTradingViewNativePriceY(layout.minPrice, layout);
+    for (const segment of lineSegments) {
+      const firstPoint = segment[0];
+      const lastPoint = segment[segment.length - 1];
+      if (firstPoint && lastPoint) {
+        commands.push({
+          kind: 'polygon',
+          paint: 'areaFill',
+          points: [
+            { x: firstPoint.x, y: areaBottomY },
+            ...segment,
+            { x: lastPoint.x, y: areaBottomY },
+          ],
+        });
+      }
+    }
+  }
+  for (const segment of lineSegments) {
+    commands.push({
+      kind: 'polyline',
+      paint: primarySeries.colorRole === 'up' ? 'areaStroke' : 'lineStroke',
+      points: segment,
+    });
+  }
+
+  const latestPointIndex = points.length - 1;
+  const latestPoint = points[latestPointIndex];
+  if (latestPoint && Number.isFinite(latestPoint.c)) {
+    commands.push({
+      cx: getPointX(latestPointIndex),
+      cy: getTradingViewNativePriceY(latestPoint.c, layout),
+      kind: 'circle',
+      paint: primarySeries.colorRole === 'up' ? 'up' : 'line',
+      radius: TRADING_VIEW_NATIVE_LINE_POINT_RADIUS,
+    });
+  }
+}
+
+function appendTradingViewNativeBarSeriesCommands({
+  candleBodyWidth,
+  commands,
+  getPointX,
+  layout,
+  points,
+  visiblePointRange,
+}: ITradingViewNativePrimarySeriesSceneOptions) {
+  'worklet';
+
+  const barTickWidth = Math.max(candleBodyWidth / 2, 1);
+  for (
+    let index = visiblePointRange.startIndex;
+    index < visiblePointRange.endIndex;
+    index += 1
+  ) {
+    const point = points[index];
+    if (point) {
+      const paint = isTradingViewNativePriceUp(point) ? 'up' : 'down';
+      const x = getPointX(index);
+      const openY = getTradingViewNativePriceY(point.o, layout);
+      const highY = getTradingViewNativePriceY(point.h, layout);
+      const lowY = getTradingViewNativePriceY(point.l, layout);
+      const closeY = getTradingViewNativePriceY(point.c, layout);
+      commands.push(
+        {
+          kind: 'line',
+          paint,
+          x1: x,
+          x2: x,
+          y1: highY,
+          y2: lowY,
+        },
+        {
+          kind: 'line',
+          paint,
+          x1: x - barTickWidth,
+          x2: x,
+          y1: openY,
+          y2: openY,
+        },
+        {
+          kind: 'line',
+          paint,
+          x1: x,
+          x2: x + barTickWidth,
+          y1: closeY,
+          y2: closeY,
+        },
+      );
+    }
+  }
+}
+
+function appendTradingViewNativeCandleSeriesCommands({
+  candleBodyWidth,
+  chartSettings,
+  commands,
+  getPointX,
+  layout,
+  points,
+  visiblePointRange,
+}: ITradingViewNativePrimarySeriesSceneOptions) {
+  'worklet';
+
+  for (
+    let index = visiblePointRange.startIndex;
+    index < visiblePointRange.endIndex;
+    index += 1
+  ) {
+    const point = points[index];
+    if (point) {
+      const direction = isTradingViewNativePriceUp(point) ? 'up' : 'down';
+      const paint: ITradingViewNativeChartScenePaint = direction;
+      const x = getPointX(index);
+      const openY = getTradingViewNativePriceY(point.o, layout);
+      const highY = getTradingViewNativePriceY(point.h, layout);
+      const lowY = getTradingViewNativePriceY(point.l, layout);
+      const closeY = getTradingViewNativePriceY(point.c, layout);
+      const colorKey = direction === 'up' ? 'upColor' : 'downColor';
+      const candleBodyRect = {
+        height: Math.max(Math.abs(closeY - openY), 1),
+        width: candleBodyWidth,
+        x: x - candleBodyWidth / 2,
+        y: Math.min(openY, closeY),
+      };
+      if (chartSettings?.candles.wick.enabled ?? true) {
+        commands.push({
+          ...(chartSettings
+            ? {
+                customPaintId:
+                  TRADING_VIEW_NATIVE_CANDLE_WICK_PAINT_IDS[direction],
+              }
+            : {}),
+          height: Math.max(lowY - highY, 1),
+          kind: 'rect',
+          paint,
+          width: TRADING_VIEW_NATIVE_CANDLE_WICK_WIDTH,
+          x: x - TRADING_VIEW_NATIVE_CANDLE_WICK_WIDTH / 2,
+          y: highY,
+        });
+      }
+      if (chartSettings?.candles.body.enabled ?? true) {
+        commands.push({
+          ...candleBodyRect,
+          ...(chartSettings
+            ? {
+                customPaintId:
+                  TRADING_VIEW_NATIVE_CANDLE_BODY_PAINT_IDS[direction],
+              }
+            : {}),
+          kind: 'rect',
+          paint,
+        });
+      }
+      const bodyAlreadyDrawsBorderColor = Boolean(
+        chartSettings?.candles.body.enabled &&
+        chartSettings.candles.body[colorKey] ===
+          chartSettings.candles.border[colorKey],
+      );
+      if (
+        chartSettings?.candles.border.enabled &&
+        !bodyAlreadyDrawsBorderColor
+      ) {
+        commands.push({
+          ...candleBodyRect,
+          customPaintId: TRADING_VIEW_NATIVE_CANDLE_BORDER_PAINT_IDS[direction],
+          kind: 'rect',
+          paint,
+        });
+      }
+    }
+  }
+}
+
+export function appendTradingViewNativePrimarySeriesCommands(
+  options: ITradingViewNativePrimarySeriesSceneOptions,
+): void {
+  'worklet';
+
+  if (options.primarySeries.renderKind === 'line') {
+    appendTradingViewNativeLineSeriesCommands(options);
+    return;
+  }
+  if (options.primarySeries.renderKind === 'bars') {
+    appendTradingViewNativeBarSeriesCommands(options);
+    return;
+  }
+  appendTradingViewNativeCandleSeriesCommands(options);
+}

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
@@ -67,4 +67,17 @@ describe('NativeChartControlsShared', () => {
       'ChartTrending2Outline',
     );
   });
+
+  it('uses a stable chart type id before the display label', () => {
+    expect(
+      formatChartTypeOptionLabel(intl, {
+        id: 'heikinAshi',
+        label: 'Custom label',
+        value: 8,
+      }),
+    ).toBe('HEIKIN_ASHI_I18N');
+    expect(getChartTypeIconName({ id: 'bars', label: 'Line', value: 0 })).toBe(
+      'TradingViewCandlesHlcOutline',
+    );
+  });
 });

--- a/packages/shared/types/tradingViewNative.ts
+++ b/packages/shared/types/tradingViewNative.ts
@@ -1,4 +1,4 @@
-export const TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION = 2 as const;
+export const TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION = 3 as const;
 export const TRADING_VIEW_NATIVE_INDICATOR_SETTINGS_SCHEMA_VERSION = 2 as const;
 
 export const TRADING_VIEW_NATIVE_THEME_COLORS = {
@@ -40,6 +40,17 @@ export type ITradingViewNativeChartColorMode = 'modern' | 'classic';
 export type ITradingViewNativeChartPriceColorMode =
   | 'greenUpRedDown'
   | 'redUpGreenDown';
+
+export type ITradingViewNativeChartType =
+  | 'area'
+  | 'bars'
+  | 'candlestick'
+  | 'heikinAshi'
+  | 'line';
+
+export type ITradingViewNativeChartTypePreference =
+  | 'auto'
+  | ITradingViewNativeChartType;
 
 export type ITradingViewNativeMainIndicatorId = 'MA' | 'EMA' | 'BOLL' | 'SAR';
 
@@ -115,6 +126,7 @@ export type ITradingViewNativeChartSettingsOptions = {
 
 export type ITradingViewNativeChartSettings = {
   schemaVersion: typeof TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION;
+  chartType: ITradingViewNativeChartTypePreference;
   candles: {
     body: ITradingViewNativeChartCandlePartSettings;
     border: ITradingViewNativeChartCandlePartSettings;
@@ -147,6 +159,7 @@ export function createTradingViewNativeChartSettings(): ITradingViewNativeChartS
   const colors = TRADING_VIEW_NATIVE_THEME_COLORS;
   return {
     schemaVersion: TRADING_VIEW_NATIVE_CHART_SETTINGS_SCHEMA_VERSION,
+    chartType: 'auto',
     candles: {
       body: {
         enabled: true,


### PR DESCRIPTION
## Summary

- add Candles, Heikin Ashi, Bars, Line, and Area to TradingViewNative controls and persisted settings
- centralize chart-type rendering semantics and extract primary-series scene generation from the shared chart scene
- replace point-derived Native runtime data when switching between raw and Heikin Ashi transforms
- render Area with the configured bullish stroke, translucent fill, latest point, and legend color

## Testing

- yarn agent:check --profile commit
- targeted Jest regression: 10 suites, 118 tests passed