### PR TITLE
feat: add TradingViewNative time-axis scaling

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -558,6 +558,15 @@ export const TradingViewNativeChart = memo(
           points: nextPoints,
           size: nextSize,
           subIndicatorPanes: nextSubIndicatorPanes,
+          timeAxisScaleGesture: {
+            ...runtime.timeAxisScaleGesture,
+            startOffset: getTradingViewNativeGestureStartOffsetAfterDataUpdate({
+              currentZoomScale: runtime.viewport.zoomScale,
+              offsetDelta,
+              startOffset: runtime.timeAxisScaleGesture.startOffset,
+              startZoomScale: runtime.timeAxisScaleGesture.startZoomScale,
+            }),
+          },
         };
       });
     }, [
@@ -639,6 +648,15 @@ export const TradingViewNativeChart = memo(
               ? runtime.pinchGesture.currentScale
               : 1,
             startOffset: nextViewport.offset,
+            startZoomScale: nextViewport.zoomScale,
+          },
+          timeAxisScaleGesture: {
+            ...runtime.timeAxisScaleGesture,
+            chartWidth,
+            startOffset: nextViewport.offset,
+            startX: runtime.timeAxisScaleGesture.isActive
+              ? runtime.timeAxisScaleGesture.currentX
+              : runtime.timeAxisScaleGesture.startX,
             startZoomScale: nextViewport.zoomScale,
           },
         };

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartRuntime.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartRuntime.ts
@@ -51,6 +51,14 @@ export interface ITradingViewNativeChartRuntime extends ITradingViewNativeChartR
   points: IMarketTokenKLineDataPoint[];
   size: ITradingViewNativeChartSize;
   subIndicatorPanes: readonly ITradingViewNativeSubIndicatorRenderPane[];
+  timeAxisScaleGesture: {
+    chartWidth: number;
+    currentX: number;
+    isActive: boolean;
+    startOffset: number;
+    startX: number;
+    startZoomScale: number;
+  };
 }
 
 export function createTradingViewNativeChartRuntime({
@@ -107,5 +115,13 @@ export function createTradingViewNativeChartRuntime({
     points,
     size: { height: 0, width: 0 },
     subIndicatorPanes,
+    timeAxisScaleGesture: {
+      chartWidth: 0,
+      currentX: 0,
+      isActive: false,
+      startOffset: 0,
+      startX: 0,
+      startZoomScale: TRADING_VIEW_NATIVE_DEFAULT_ZOOM_SCALE,
+    },
   };
 }

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.test.ts
@@ -252,7 +252,7 @@ describe('useTradingViewNativeChartGestures', () => {
     expect(failContentPan).toHaveBeenCalledTimes(1);
     expect(failTimeAxisScale).not.toHaveBeenCalled();
     expect(chartRuntime.value.crosshair.visible).toBe(false);
-    expect(chartRuntime.value.viewport.zoomScale).toBeGreaterThan(1);
+    expect(chartRuntime.value.viewport.zoomScale).toBeLessThan(1);
     expect(decayOffset.value).toBe(chartRuntime.value.viewport.offset);
     expect(chartRuntime.value.timeAxisScaleGesture).toMatchObject({
       currentX: 150,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.test.ts
@@ -19,6 +19,7 @@ interface IMockGestureBuilder {
 }
 
 const mockTapGestures: IMockGestureBuilder[] = [];
+const mockPanGestures: IMockGestureBuilder[] = [];
 const mockScheduleOnRN = jest.mocked(scheduleOnRN);
 const mockGetSubIndicatorAtPoint = jest.mocked(
   getTradingViewNativeSubIndicatorLegendIndicatorAtPoint,
@@ -55,7 +56,11 @@ function mockCreateGestureBuilder(): IMockGestureBuilder {
 jest.mock('react-native-gesture-handler', () => ({
   Gesture: {
     Exclusive: jest.fn((...gestures: unknown[]) => gestures[0]),
-    Pan: jest.fn(() => mockCreateGestureBuilder()),
+    Pan: jest.fn(() => {
+      const gesture = mockCreateGestureBuilder();
+      mockPanGestures.push(gesture);
+      return gesture;
+    }),
     Pinch: jest.fn(() => mockCreateGestureBuilder()),
     Race: jest.fn((...gestures: unknown[]) => gestures[0]),
     Tap: jest.fn(() => {
@@ -125,9 +130,62 @@ function renderSettingsGesture(
   return settingsGesture as IMockGestureBuilder;
 }
 
+function renderChartGestures() {
+  const chartRuntime = {
+    value: {
+      crosshair: { visible: true, x: 0, y: 0 },
+      panGesture: { startOffset: 0, translationX: 0 },
+      pinchGesture: {
+        anchorX: 0,
+        currentScale: 1,
+        isActive: false,
+        scaleBaseline: 1,
+        startOffset: 0,
+        startZoomScale: 1,
+      },
+      points: Array.from({ length: 100 }, () => ({})),
+      size: { height: 300, width: 320 },
+      subIndicatorPanes: [],
+      timeAxisScaleGesture: {
+        chartWidth: 0,
+        currentX: 0,
+        isActive: false,
+        startOffset: 0,
+        startX: 0,
+        startZoomScale: 1,
+      },
+      viewport: { offset: 0, zoomScale: 1 },
+    },
+  };
+  const decayOffset = { value: 0 };
+  const props = {
+    chartRuntime,
+    decayOffset,
+    isClickInteractionEnabled: true,
+    isCrosshairEnabled: true,
+    onSubIndicatorSettingsPress: jest.fn(),
+    priceAxisResetGesture: {},
+    priceAxisScaleGesture: {},
+    priceAxisWidth: { value: 44 },
+    resources: {
+      value: {
+        fonts: {
+          legend: {
+            measureText: () => ({ width: 0 }),
+          },
+        },
+      },
+    },
+  } as unknown as Parameters<typeof useTradingViewNativeChartGestures>[0];
+
+  renderHook(() => useTradingViewNativeChartGestures(props));
+  return { chartRuntime, decayOffset };
+}
+
 describe('useTradingViewNativeChartGestures', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPanGestures.length = 0;
     mockTapGestures.length = 0;
     mockGetSubIndicatorAtPoint.mockImplementation(
       ({ y }: { y: number }): 'RSI' | null => (y === 100 ? 'RSI' : null),
@@ -171,5 +229,52 @@ describe('useTradingViewNativeChartGestures', () => {
     );
     expect(mockScheduleOnRN).not.toHaveBeenCalled();
     expect(onSubIndicatorSettingsPress).not.toHaveBeenCalled();
+  });
+
+  it('scales the time range only when a horizontal drag starts on the time axis', () => {
+    const { chartRuntime, decayOffset } = renderChartGestures();
+    const contentPanGesture = mockPanGestures[1];
+    const timeAxisScaleGesture = mockPanGestures[2];
+    const failContentPan = jest.fn();
+    const failTimeAxisScale = jest.fn();
+
+    contentPanGesture.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 280 }] },
+      { fail: failContentPan },
+    );
+    timeAxisScaleGesture.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 280 }] },
+      { fail: failTimeAxisScale },
+    );
+    timeAxisScaleGesture.handlers.onStart?.({ x: 100 });
+    timeAxisScaleGesture.handlers.onUpdate?.({ x: 150 });
+
+    expect(failContentPan).toHaveBeenCalledTimes(1);
+    expect(failTimeAxisScale).not.toHaveBeenCalled();
+    expect(chartRuntime.value.crosshair.visible).toBe(false);
+    expect(chartRuntime.value.viewport.zoomScale).toBeGreaterThan(1);
+    expect(decayOffset.value).toBe(chartRuntime.value.viewport.offset);
+    expect(chartRuntime.value.timeAxisScaleGesture).toMatchObject({
+      currentX: 150,
+      isActive: true,
+      startX: 100,
+      startZoomScale: 1,
+    });
+
+    timeAxisScaleGesture.handlers.onFinalize?.();
+    expect(chartRuntime.value.timeAxisScaleGesture.isActive).toBe(false);
+  });
+
+  it('rejects time-scale dragging outside the time axis', () => {
+    renderChartGestures();
+    const timeAxisScaleGesture = mockPanGestures[2];
+    const fail = jest.fn();
+
+    timeAxisScaleGesture.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 200 }] },
+      { fail },
+    );
+
+    expect(fail).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.test.ts
@@ -265,6 +265,41 @@ describe('useTradingViewNativeChartGestures', () => {
     expect(chartRuntime.value.timeAxisScaleGesture.isActive).toBe(false);
   });
 
+  it('keeps crosshair gestures from claiming time-axis touches', () => {
+    renderChartGestures();
+    const crosshairGesture = mockPanGestures[0];
+    const tapCrosshairGesture = mockTapGestures.find(
+      (gesture) => gesture.maxDistance.mock.calls.length === 0,
+    );
+    const failCrosshair = jest.fn();
+    const failTapCrosshair = jest.fn();
+    const failMainChartCrosshair = jest.fn();
+    const failMainChartTapCrosshair = jest.fn();
+
+    expect(tapCrosshairGesture).toBeDefined();
+    crosshairGesture.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 280 }] },
+      { fail: failCrosshair },
+    );
+    tapCrosshairGesture?.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 280 }] },
+      { fail: failTapCrosshair },
+    );
+    crosshairGesture.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 200 }] },
+      { fail: failMainChartCrosshair },
+    );
+    tapCrosshairGesture?.handlers.onTouchesDown?.(
+      { changedTouches: [{ x: 100, y: 200 }] },
+      { fail: failMainChartTapCrosshair },
+    );
+
+    expect(failCrosshair).toHaveBeenCalledTimes(1);
+    expect(failTapCrosshair).toHaveBeenCalledTimes(1);
+    expect(failMainChartCrosshair).not.toHaveBeenCalled();
+    expect(failMainChartTapCrosshair).not.toHaveBeenCalled();
+  });
+
   it('rejects time-scale dragging outside the time axis', () => {
     renderChartGestures();
     const timeAxisScaleGesture = mockPanGestures[2];

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.ts
@@ -160,6 +160,14 @@ export function useTradingViewNativeChartGestures({
       .enabled(isCrosshairEnabled)
       .activateAfterLongPress(TRADING_VIEW_NATIVE_CROSSHAIR_LONG_PRESS_DURATION)
       .maxPointers(1)
+      .onTouchesDown((event, stateManager) => {
+        'worklet';
+
+        const touch = event.changedTouches[0];
+        if (touch && isTimeAxisTouch(touch.x, touch.y)) {
+          stateManager.fail();
+        }
+      })
       .onStart((event) => {
         'worklet';
 
@@ -186,6 +194,14 @@ export function useTradingViewNativeChartGestures({
 
     const tapCrosshairGesture = Gesture.Tap()
       .enabled(isCrosshairEnabled && isClickInteractionEnabled)
+      .onTouchesDown((event, stateManager) => {
+        'worklet';
+
+        const touch = event.changedTouches[0];
+        if (touch && isTimeAxisTouch(touch.x, touch.y)) {
+          stateManager.fail();
+        }
+      })
       .onEnd((event, success) => {
         'worklet';
 

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativeChartGestures.ts
@@ -27,6 +27,10 @@ import {
   getTradingViewNativeSubIndicatorLegendIndicatorAtPoint,
   getTradingViewNativeVisibleSubIndicatorPaneCount,
 } from '../utils/subIndicatorRender';
+import {
+  getTradingViewNativeTimeAxisZoomScaleAfterDrag,
+  isTradingViewNativeTimeAxisTouch,
+} from '../utils/timeAxisScale';
 
 import type { ITradingViewNativeChartRuntime } from './chartRuntime';
 import type { ITradingViewNativeSkiaResources } from './chartSkiaRenderer';
@@ -74,6 +78,19 @@ export function useTradingViewNativeChartGestures({
       return isTradingViewNativeMainPriceAxisTouch({
         height: runtime.size.height,
         paneCount,
+        priceAxisWidth: priceAxisWidth.value,
+        width: runtime.size.width,
+        x,
+        y,
+      });
+    };
+
+    const isTimeAxisTouch = (x: number, y: number) => {
+      'worklet';
+
+      const runtime = chartRuntime.value;
+      return isTradingViewNativeTimeAxisTouch({
+        height: runtime.size.height,
         priceAxisWidth: priceAxisWidth.value,
         width: runtime.size.width,
         x,
@@ -213,7 +230,11 @@ export function useTradingViewNativeChartGestures({
         'worklet';
 
         const touch = event.changedTouches[0];
-        if (touch && isMainPriceAxisTouch(touch.x, touch.y)) {
+        if (
+          touch &&
+          (isMainPriceAxisTouch(touch.x, touch.y) ||
+            isTimeAxisTouch(touch.x, touch.y))
+        ) {
           stateManager.fail();
         }
       })
@@ -327,6 +348,100 @@ export function useTradingViewNativeChartGestures({
         };
       });
 
+    const timeAxisScaleGesture = Gesture.Pan()
+      .activeOffsetX([-4, 4])
+      .failOffsetY([-12, 12])
+      .maxPointers(1)
+      .onTouchesDown((event, stateManager) => {
+        'worklet';
+
+        const touch = event.changedTouches[0];
+        if (!touch || !isTimeAxisTouch(touch.x, touch.y)) {
+          stateManager.fail();
+        }
+      })
+      .onStart((event) => {
+        'worklet';
+
+        cancelAnimation(decayOffset);
+        const runtime = chartRuntime.value;
+        const chartWidth = getTradingViewNativeChartWidth(
+          runtime.size.width,
+          priceAxisWidth.value,
+        );
+        const nextRuntimeState = reduceTradingViewNativeChartRuntime(runtime, {
+          chartWidth,
+          hideCrosshair: true,
+          offset: runtime.viewport.offset,
+          pointCount: runtime.points.length,
+          type: 'panMoved',
+        });
+        const startOffset = nextRuntimeState.viewport.offset;
+        const startX = event.x - TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING;
+        decayOffset.value = startOffset;
+        chartRuntime.value = {
+          ...runtime,
+          ...nextRuntimeState,
+          timeAxisScaleGesture: {
+            chartWidth,
+            currentX: startX,
+            isActive: true,
+            startOffset,
+            startX,
+            startZoomScale: nextRuntimeState.viewport.zoomScale,
+          },
+        };
+      })
+      .onUpdate((event) => {
+        'worklet';
+
+        const runtime = chartRuntime.value;
+        const gesture = runtime.timeAxisScaleGesture;
+        const chartWidth = getTradingViewNativeChartWidth(
+          runtime.size.width,
+          priceAxisWidth.value,
+        );
+        const currentX = event.x - TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING;
+        const nextRuntimeState = reduceTradingViewNativeChartRuntime(runtime, {
+          anchorX: chartWidth,
+          baseViewport: {
+            offset: gesture.startOffset,
+            zoomScale: gesture.startZoomScale,
+          },
+          chartWidth,
+          hideCrosshair: true,
+          nextZoomScale: getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+            chartWidth: gesture.chartWidth,
+            currentX,
+            startX: gesture.startX,
+            startZoomScale: gesture.startZoomScale,
+          }),
+          pointCount: runtime.points.length,
+          type: 'zoomed',
+        });
+        decayOffset.value = nextRuntimeState.viewport.offset;
+        chartRuntime.value = {
+          ...runtime,
+          ...nextRuntimeState,
+          timeAxisScaleGesture: {
+            ...gesture,
+            currentX,
+          },
+        };
+      })
+      .onFinalize(() => {
+        'worklet';
+
+        const runtime = chartRuntime.value;
+        chartRuntime.value = {
+          ...runtime,
+          timeAxisScaleGesture: {
+            ...runtime.timeAxisScaleGesture,
+            isActive: false,
+          },
+        };
+      });
+
     const pinchGesture = Gesture.Pinch()
       .onStart((event) => {
         'worklet';
@@ -412,7 +527,12 @@ export function useTradingViewNativeChartGestures({
       crosshairGesture,
       priceAxisResetGesture,
       tapCrosshairGesture,
-      Gesture.Race(priceAxisScaleGesture, panGesture, pinchGesture),
+      Gesture.Race(
+        priceAxisScaleGesture,
+        timeAxisScaleGesture,
+        panGesture,
+        pinchGesture,
+      ),
     );
   }, [
     chartRuntime,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.test.ts
@@ -1,0 +1,86 @@
+import {
+  getTradingViewNativeTimeAxisZoomScaleAfterDrag,
+  isTradingViewNativeTimeAxisTouch,
+} from './timeAxisScale';
+
+describe('TradingViewNative time-axis scaling', () => {
+  it('zooms in when dragging right and zooms out when dragging left', () => {
+    const input = {
+      chartWidth: 200,
+      startX: 100,
+      startZoomScale: 1,
+    };
+
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        ...input,
+        currentX: 150,
+      }),
+    ).toBeGreaterThan(1);
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        ...input,
+        currentX: 50,
+      }),
+    ).toBeLessThan(1);
+  });
+
+  it('clamps time-axis dragging to the supported zoom range', () => {
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        chartWidth: 200,
+        currentX: 1000,
+        startX: 190,
+        startZoomScale: 3,
+      }),
+    ).toBe(3);
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        chartWidth: 200,
+        currentX: -10_000,
+        startX: 10,
+        startZoomScale: 0.2,
+      }),
+    ).toBe(0.2);
+  });
+
+  it('keeps the normalized starting scale for invalid coordinates', () => {
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        chartWidth: 0,
+        currentX: 150,
+        startX: 100,
+        startZoomScale: 2,
+      }),
+    ).toBe(2);
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        chartWidth: 200,
+        currentX: Number.NaN,
+        startX: 100,
+        startZoomScale: Number.NaN,
+      }),
+    ).toBe(1);
+  });
+
+  it('only accepts touches inside the visible time axis', () => {
+    const input = {
+      height: 300,
+      priceAxisWidth: 44,
+      width: 320,
+    };
+
+    expect(isTradingViewNativeTimeAxisTouch({ ...input, x: 275, y: 276 })).toBe(
+      true,
+    );
+    expect(isTradingViewNativeTimeAxisTouch({ ...input, x: 276, y: 276 })).toBe(
+      false,
+    );
+    expect(isTradingViewNativeTimeAxisTouch({ ...input, x: 100, y: 275 })).toBe(
+      false,
+    );
+    expect(isTradingViewNativeTimeAxisTouch({ ...input, x: 100, y: 300 })).toBe(
+      true,
+    );
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.test.ts
@@ -25,6 +25,46 @@ describe('TradingViewNative time-axis scaling', () => {
     ).toBeLessThan(1);
   });
 
+  it('uses drag distance consistently regardless of the starting position', () => {
+    const dragFromLeft = getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+      chartWidth: 200,
+      currentX: 70,
+      startX: 20,
+      startZoomScale: 1,
+    });
+    const dragFromRight = getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+      chartWidth: 200,
+      currentX: 230,
+      startX: 180,
+      startZoomScale: 1,
+    });
+
+    expect(dragFromRight).toBeCloseTo(dragFromLeft);
+    expect(dragFromRight).toBeGreaterThan(1);
+  });
+
+  it('zooms in when dragging right from the chart boundary', () => {
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        chartWidth: 200,
+        currentX: 205,
+        startX: 200,
+        startZoomScale: 1,
+      }),
+    ).toBeGreaterThan(1);
+  });
+
+  it('keeps the starting scale before an out-of-bounds drag moves', () => {
+    expect(
+      getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+        chartWidth: 200,
+        currentX: 205,
+        startX: 205,
+        startZoomScale: 1,
+      }),
+    ).toBe(1);
+  });
+
   it('clamps time-axis dragging to the supported zoom range', () => {
     expect(
       getTradingViewNativeTimeAxisZoomScaleAfterDrag({

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.test.ts
@@ -4,7 +4,7 @@ import {
 } from './timeAxisScale';
 
 describe('TradingViewNative time-axis scaling', () => {
-  it('zooms in when dragging right and zooms out when dragging left', () => {
+  it('compresses the time axis when dragging right and expands it when dragging left', () => {
     const input = {
       chartWidth: 200,
       startX: 100,
@@ -16,13 +16,13 @@ describe('TradingViewNative time-axis scaling', () => {
         ...input,
         currentX: 150,
       }),
-    ).toBeGreaterThan(1);
+    ).toBeLessThan(1);
     expect(
       getTradingViewNativeTimeAxisZoomScaleAfterDrag({
         ...input,
         currentX: 50,
       }),
-    ).toBeLessThan(1);
+    ).toBeGreaterThan(1);
   });
 
   it('uses drag distance consistently regardless of the starting position', () => {
@@ -40,10 +40,10 @@ describe('TradingViewNative time-axis scaling', () => {
     });
 
     expect(dragFromRight).toBeCloseTo(dragFromLeft);
-    expect(dragFromRight).toBeGreaterThan(1);
+    expect(dragFromRight).toBeLessThan(1);
   });
 
-  it('zooms in when dragging right from the chart boundary', () => {
+  it('compresses the time axis when dragging right from the chart boundary', () => {
     expect(
       getTradingViewNativeTimeAxisZoomScaleAfterDrag({
         chartWidth: 200,
@@ -51,7 +51,7 @@ describe('TradingViewNative time-axis scaling', () => {
         startX: 200,
         startZoomScale: 1,
       }),
-    ).toBeGreaterThan(1);
+    ).toBeLessThan(1);
   });
 
   it('keeps the starting scale before an out-of-bounds drag moves', () => {
@@ -69,7 +69,7 @@ describe('TradingViewNative time-axis scaling', () => {
     expect(
       getTradingViewNativeTimeAxisZoomScaleAfterDrag({
         chartWidth: 200,
-        currentX: 1000,
+        currentX: -10_000,
         startX: 190,
         startZoomScale: 3,
       }),
@@ -77,7 +77,7 @@ describe('TradingViewNative time-axis scaling', () => {
     expect(
       getTradingViewNativeTimeAxisZoomScaleAfterDrag({
         chartWidth: 200,
-        currentX: -10_000,
+        currentX: 10_000,
         startX: 10,
         startZoomScale: 0.2,
       }),

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.ts
@@ -36,7 +36,7 @@ export function getTradingViewNativeTimeAxisZoomScaleAfterDrag({
     return normalizedStartZoomScale;
   }
 
-  const dragRatio = (currentX - startX) / chartWidth;
+  const dragRatio = (startX - currentX) / chartWidth;
   const relativeScale = Math.exp(dragRatio * TIME_AXIS_SCALE_SENSITIVITY);
 
   return clampTradingViewNativeZoomScale(

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.ts
@@ -1,0 +1,90 @@
+import {
+  TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING,
+  TRADING_VIEW_NATIVE_DEFAULT_ZOOM_SCALE,
+  TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT,
+} from '../chartConstants';
+
+import { getTradingViewNativeChartWidth } from './chartLayout';
+import { clampTradingViewNativeZoomScale } from './chartViewport';
+
+const TIME_AXIS_SCALE_MARGIN_RATIO = 0.2;
+
+export function getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+  chartWidth,
+  currentX,
+  startX,
+  startZoomScale,
+}: {
+  chartWidth: number;
+  currentX: number;
+  startX: number;
+  startZoomScale: number;
+}) {
+  'worklet';
+
+  const normalizedStartZoomScale = clampTradingViewNativeZoomScale(
+    Number.isFinite(startZoomScale)
+      ? startZoomScale
+      : TRADING_VIEW_NATIVE_DEFAULT_ZOOM_SCALE,
+  );
+  if (
+    !Number.isFinite(chartWidth) ||
+    chartWidth <= 0 ||
+    !Number.isFinite(currentX) ||
+    !Number.isFinite(startX)
+  ) {
+    return normalizedStartZoomScale;
+  }
+
+  const normalizedStartX = Math.min(Math.max(startX, 0), chartWidth);
+  const startPoint = chartWidth - normalizedStartX;
+  const currentPoint = Math.max(chartWidth - currentX, 0);
+  const scaleMargin = chartWidth * TIME_AXIS_SCALE_MARGIN_RATIO;
+  const relativeScale =
+    (startPoint + scaleMargin) / (currentPoint + scaleMargin);
+
+  return clampTradingViewNativeZoomScale(
+    normalizedStartZoomScale * relativeScale,
+  );
+}
+
+export function isTradingViewNativeTimeAxisTouch({
+  height,
+  priceAxisWidth,
+  width,
+  x,
+  y,
+}: {
+  height: number;
+  priceAxisWidth: number;
+  width: number;
+  x: number;
+  y: number;
+}) {
+  'worklet';
+
+  if (
+    !Number.isFinite(height) ||
+    !Number.isFinite(priceAxisWidth) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    height <= 0 ||
+    width <= 0
+  ) {
+    return false;
+  }
+
+  const chartWidth = getTradingViewNativeChartWidth(width, priceAxisWidth);
+  const axisStartX = TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING;
+  const axisEndX = axisStartX + chartWidth;
+  const axisStartY = Math.max(height - TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT, 0);
+
+  return (
+    chartWidth > 0 &&
+    x >= axisStartX &&
+    x < axisEndX &&
+    y >= axisStartY &&
+    y <= height
+  );
+}

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/timeAxisScale.ts
@@ -7,7 +7,7 @@ import {
 import { getTradingViewNativeChartWidth } from './chartLayout';
 import { clampTradingViewNativeZoomScale } from './chartViewport';
 
-const TIME_AXIS_SCALE_MARGIN_RATIO = 0.2;
+const TIME_AXIS_SCALE_SENSITIVITY = 2;
 
 export function getTradingViewNativeTimeAxisZoomScaleAfterDrag({
   chartWidth,
@@ -36,12 +36,8 @@ export function getTradingViewNativeTimeAxisZoomScaleAfterDrag({
     return normalizedStartZoomScale;
   }
 
-  const normalizedStartX = Math.min(Math.max(startX, 0), chartWidth);
-  const startPoint = chartWidth - normalizedStartX;
-  const currentPoint = Math.max(chartWidth - currentX, 0);
-  const scaleMargin = chartWidth * TIME_AXIS_SCALE_MARGIN_RATIO;
-  const relativeScale =
-    (startPoint + scaleMargin) / (currentPoint + scaleMargin);
+  const dragRatio = (currentX - startX) / chartWidth;
+  const relativeScale = Math.exp(dragRatio * TIME_AXIS_SCALE_SENSITIVITY);
 
   return clampTradingViewNativeZoomScale(
     normalizedStartZoomScale * relativeScale,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
@@ -57,7 +57,8 @@ import {
 import { getTradingViewNativeCanvasFont } from './chartCanvasRenderer';
 import {
   getTradingViewNativePointerDragIntent,
-  getTradingViewNativeTimeAxisPointerZoomScale,
+  getTradingViewNativeTimeAxisPointerDragUpdate,
+  shouldStartTradingViewNativeViewportPointerDrag,
 } from './chartPointerInteraction';
 import {
   TradingViewNativeWheelDeltaNormalizer,
@@ -100,6 +101,7 @@ interface ITimeAxisPointerDragState {
   pointerId: number;
   startOffset: number;
   startX: number;
+  startY: number;
   startZoomScale: number;
 }
 
@@ -603,7 +605,15 @@ export const TradingViewNativeChart = memo(
 
     const handlePointerDown = useCallback(
       (event: ReactPointerEvent<HTMLCanvasElement>) => {
-        if (event.button !== 0) {
+        if (
+          !shouldStartTradingViewNativeViewportPointerDrag({
+            button: event.button,
+            hasActiveDrag: Boolean(
+              pointerPanDragStateRef.current ||
+              timeAxisPointerDragStateRef.current,
+            ),
+          })
+        ) {
           return;
         }
         try {
@@ -653,6 +663,9 @@ export const TradingViewNativeChart = memo(
 
     const handlePointerMove = useCallback(
       (event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (timeAxisPointerDragStateRef.current) {
+          return;
+        }
         const dragState = pointerPanDragStateRef.current;
         if (dragState) {
           if (dragState.pointerId !== event.pointerId) {
@@ -793,15 +806,23 @@ export const TradingViewNativeChart = memo(
 
     const handleTimeAxisPointerDown = useCallback(
       (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (event.button !== 0 || measuredChartWidth <= 0) {
+        if (
+          measuredChartWidth <= 0 ||
+          !shouldStartTradingViewNativeViewportPointerDrag({
+            button: event.button,
+            hasActiveDrag: Boolean(
+              pointerPanDragStateRef.current ||
+              timeAxisPointerDragStateRef.current,
+            ),
+          })
+        ) {
           return;
         }
         try {
           event.currentTarget.setPointerCapture(event.pointerId);
         } catch {
-          // Pointer capture is optional; dragging still works while the pointer remains over the axis.
+          return;
         }
-        event.preventDefault();
         const targetRect = event.currentTarget.getBoundingClientRect();
         const startX = event.clientX - targetRect.left;
         const runtime = renderWithCrosshairHidden();
@@ -812,6 +833,7 @@ export const TradingViewNativeChart = memo(
           pointerId: event.pointerId,
           startOffset: runtime.viewport.offset,
           startX,
+          startY: event.clientY - targetRect.top,
           startZoomScale: runtime.viewport.zoomScale,
         };
       },
@@ -824,20 +846,29 @@ export const TradingViewNativeChart = memo(
         if (!dragState || dragState.pointerId !== event.pointerId) {
           return;
         }
-        event.preventDefault();
         const targetRect = event.currentTarget.getBoundingClientRect();
         const currentX = event.clientX - targetRect.left;
         dragState.currentX = currentX;
-        const nextZoomScale = getTradingViewNativeTimeAxisPointerZoomScale({
+        const dragUpdate = getTradingViewNativeTimeAxisPointerDragUpdate({
           chartWidth: dragState.chartWidth,
           currentX,
+          currentY: event.clientY - targetRect.top,
           isActive: dragState.isActive,
           startX: dragState.startX,
+          startY: dragState.startY,
           startZoomScale: dragState.startZoomScale,
         });
-        if (nextZoomScale === null) {
+        if (dragUpdate.type === 'cancel') {
+          timeAxisPointerDragStateRef.current = null;
+          if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
           return;
         }
+        if (dragUpdate.type === 'pending') {
+          return;
+        }
+        event.preventDefault();
         dragState.isActive = true;
         const chartWidth = measuredChartWidth;
         const nextRuntimeState = reduceTradingViewNativeChartRuntime(
@@ -850,7 +881,7 @@ export const TradingViewNativeChart = memo(
             },
             chartWidth,
             hideCrosshair: true,
-            nextZoomScale,
+            nextZoomScale: dragUpdate.zoomScale,
             pointCount,
             type: 'zoomed',
           },
@@ -1029,7 +1060,7 @@ export const TradingViewNativeChart = memo(
               height: TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT,
               left: CHART_HORIZONTAL_PADDING,
               position: 'absolute',
-              touchAction: 'none',
+              touchAction: 'pan-y',
               userSelect: 'none',
               width: measuredChartWidth,
               zIndex: 1,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
@@ -55,7 +55,10 @@ import {
   isTradingViewNativeCanvasMainPriceAxisPointer,
 } from './chartCanvasLayout';
 import { getTradingViewNativeCanvasFont } from './chartCanvasRenderer';
-import { getTradingViewNativePointerDragIntent } from './chartPointerInteraction';
+import {
+  getTradingViewNativePointerDragIntent,
+  getTradingViewNativeTimeAxisPointerZoomScale,
+} from './chartPointerInteraction';
 import {
   TradingViewNativeWheelDeltaNormalizer,
   getTradingViewNativeWheelPanOffsetDelta,
@@ -90,6 +93,16 @@ interface IPointerPanDragState {
   zoomScale: number;
 }
 
+interface ITimeAxisPointerDragState {
+  chartWidth: number;
+  currentX: number;
+  isActive: boolean;
+  pointerId: number;
+  startOffset: number;
+  startX: number;
+  startZoomScale: number;
+}
+
 export const TradingViewNativeChart = memo(
   ({
     candleIntervalSeconds,
@@ -119,6 +132,8 @@ export const TradingViewNativeChart = memo(
       }),
     );
     const pointerPanDragStateRef = useRef<IPointerPanDragState | null>(null);
+    const timeAxisPointerDragStateRef =
+      useRef<ITimeAxisPointerDragState | null>(null);
     const subIndicatorLegendHitRegionsRef = useRef<
       ITradingViewNativeSubIndicatorLegendHitRegion[]
     >([]);
@@ -363,6 +378,20 @@ export const TradingViewNativeChart = memo(
           runtimeEvent,
         ).viewport.offset;
       }
+      const timeAxisDragState = timeAxisPointerDragStateRef.current;
+      if (timeAxisDragState) {
+        timeAxisDragState.startOffset = reduceTradingViewNativeChartRuntime(
+          {
+            ...runtimeAfterInitialMeasure,
+            viewport: {
+              ...runtimeAfterInitialMeasure.viewport,
+              offset: timeAxisDragState.startOffset,
+              zoomScale: timeAxisDragState.startZoomScale,
+            },
+          },
+          runtimeEvent,
+        ).viewport.offset;
+      }
       const nextRuntimeState = reduceTradingViewNativeChartRuntime(
         runtimeAfterInitialMeasure,
         runtimeEvent,
@@ -417,12 +446,22 @@ export const TradingViewNativeChart = memo(
       };
       runtimeStateRef.current = nextRuntimeState;
       const dragState = pointerPanDragStateRef.current;
-      if (viewportRequest.preserveVisibleAnchor && dragState) {
-        dragState.startClientX = dragState.currentClientX;
-        dragState.startOffset = nextViewport.offset;
-        dragState.zoomScale = nextViewport.zoomScale;
+      const timeAxisDragState = timeAxisPointerDragStateRef.current;
+      if (viewportRequest.preserveVisibleAnchor) {
+        if (dragState) {
+          dragState.startClientX = dragState.currentClientX;
+          dragState.startOffset = nextViewport.offset;
+          dragState.zoomScale = nextViewport.zoomScale;
+        }
+        if (timeAxisDragState) {
+          timeAxisDragState.chartWidth = measuredChartWidth;
+          timeAxisDragState.startOffset = nextViewport.offset;
+          timeAxisDragState.startX = timeAxisDragState.currentX;
+          timeAxisDragState.startZoomScale = nextViewport.zoomScale;
+        }
       } else {
         pointerPanDragStateRef.current = null;
+        timeAxisPointerDragStateRef.current = null;
       }
       setViewportState(nextViewport);
       onViewportRequestApplied?.(viewportRequest.requestId);
@@ -704,7 +743,11 @@ export const TradingViewNativeChart = memo(
     );
 
     const handlePointerLeave = useCallback(() => {
-      if (pointerPanDragStateRef.current || isPriceScalePointerDragging()) {
+      if (
+        pointerPanDragStateRef.current ||
+        timeAxisPointerDragStateRef.current ||
+        isPriceScalePointerDragging()
+      ) {
         return;
       }
       handlePriceScalePointerLeave();
@@ -746,6 +789,97 @@ export const TradingViewNativeChart = memo(
         }
       },
       [onSubIndicatorSettingsPress],
+    );
+
+    const handleTimeAxisPointerDown = useCallback(
+      (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.button !== 0 || measuredChartWidth <= 0) {
+          return;
+        }
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // Pointer capture is optional; dragging still works while the pointer remains over the axis.
+        }
+        event.preventDefault();
+        const targetRect = event.currentTarget.getBoundingClientRect();
+        const startX = event.clientX - targetRect.left;
+        const runtime = renderWithCrosshairHidden();
+        timeAxisPointerDragStateRef.current = {
+          chartWidth: measuredChartWidth,
+          currentX: startX,
+          isActive: false,
+          pointerId: event.pointerId,
+          startOffset: runtime.viewport.offset,
+          startX,
+          startZoomScale: runtime.viewport.zoomScale,
+        };
+      },
+      [measuredChartWidth, renderWithCrosshairHidden],
+    );
+
+    const handleTimeAxisPointerMove = useCallback(
+      (event: ReactPointerEvent<HTMLDivElement>) => {
+        const dragState = timeAxisPointerDragStateRef.current;
+        if (!dragState || dragState.pointerId !== event.pointerId) {
+          return;
+        }
+        event.preventDefault();
+        const targetRect = event.currentTarget.getBoundingClientRect();
+        const currentX = event.clientX - targetRect.left;
+        dragState.currentX = currentX;
+        const nextZoomScale = getTradingViewNativeTimeAxisPointerZoomScale({
+          chartWidth: dragState.chartWidth,
+          currentX,
+          isActive: dragState.isActive,
+          startX: dragState.startX,
+          startZoomScale: dragState.startZoomScale,
+        });
+        if (nextZoomScale === null) {
+          return;
+        }
+        dragState.isActive = true;
+        const chartWidth = measuredChartWidth;
+        const nextRuntimeState = reduceTradingViewNativeChartRuntime(
+          runtimeStateRef.current,
+          {
+            anchorX: chartWidth,
+            baseViewport: {
+              offset: dragState.startOffset,
+              zoomScale: dragState.startZoomScale,
+            },
+            chartWidth,
+            hideCrosshair: true,
+            nextZoomScale,
+            pointCount,
+            type: 'zoomed',
+          },
+        );
+        runtimeStateRef.current = nextRuntimeState;
+        renderChart(nextRuntimeState);
+        setViewportState((currentState) =>
+          currentState.offset === nextRuntimeState.viewport.offset &&
+          currentState.zoomScale === nextRuntimeState.viewport.zoomScale
+            ? currentState
+            : nextRuntimeState.viewport,
+        );
+      },
+      [measuredChartWidth, pointCount, renderChart],
+    );
+
+    const finishTimeAxisPointerDrag = useCallback(
+      (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (
+          timeAxisPointerDragStateRef.current?.pointerId !== event.pointerId
+        ) {
+          return;
+        }
+        timeAxisPointerDragStateRef.current = null;
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      },
+      [],
     );
 
     const handleWheel = useCallback(
@@ -880,6 +1014,28 @@ export const TradingViewNativeChart = memo(
             width: '100%',
           }}
         />
+        {measuredChartWidth > 0 ? (
+          <div
+            data-testid={testID ? `${testID}-time-axis-interaction` : undefined}
+            onLostPointerCapture={finishTimeAxisPointerDrag}
+            onPointerCancel={finishTimeAxisPointerDrag}
+            onPointerDown={handleTimeAxisPointerDown}
+            onPointerEnter={renderWithCrosshairHidden}
+            onPointerMove={handleTimeAxisPointerMove}
+            onPointerUp={finishTimeAxisPointerDrag}
+            style={{
+              bottom: 0,
+              cursor: 'ew-resize',
+              height: TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT,
+              left: CHART_HORIZONTAL_PADDING,
+              position: 'absolute',
+              touchAction: 'none',
+              userSelect: 'none',
+              width: measuredChartWidth,
+              zIndex: 1,
+            }}
+          />
+        ) : null}
         {chartSettings.options.yAxis && measuredPriceAxisWidth > 0 ? (
           <div
             data-testid={

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.test.ts
@@ -1,4 +1,7 @@
-import { getTradingViewNativePointerDragIntent } from './chartPointerInteraction';
+import {
+  getTradingViewNativePointerDragIntent,
+  getTradingViewNativeTimeAxisPointerZoomScale,
+} from './chartPointerInteraction';
 
 describe('TradingViewNative pointer drag intent', () => {
   it('keeps small legend movement pending without starting a pan', () => {
@@ -35,5 +38,46 @@ describe('TradingViewNative pointer drag intent', () => {
         startClientY: 10,
       }),
     ).toBe('pan');
+  });
+});
+
+describe('TradingViewNative time-axis pointer scaling', () => {
+  const input = {
+    chartWidth: 200,
+    isActive: false,
+    startX: 100,
+    startZoomScale: 1,
+  };
+
+  it('waits for horizontal movement beyond the drag threshold', () => {
+    expect(
+      getTradingViewNativeTimeAxisPointerZoomScale({
+        ...input,
+        currentX: 104,
+      }),
+    ).toBeNull();
+    expect(
+      getTradingViewNativeTimeAxisPointerZoomScale({
+        ...input,
+        currentX: 105,
+      }),
+    ).not.toBeNull();
+  });
+
+  it('zooms in to the right and out to the left after activation', () => {
+    expect(
+      getTradingViewNativeTimeAxisPointerZoomScale({
+        ...input,
+        currentX: 150,
+        isActive: true,
+      }),
+    ).toBeGreaterThan(1);
+    expect(
+      getTradingViewNativeTimeAxisPointerZoomScale({
+        ...input,
+        currentX: 50,
+        isActive: true,
+      }),
+    ).toBeLessThan(1);
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.test.ts
@@ -1,6 +1,7 @@
 import {
   getTradingViewNativePointerDragIntent,
-  getTradingViewNativeTimeAxisPointerZoomScale,
+  getTradingViewNativeTimeAxisPointerDragUpdate,
+  shouldStartTradingViewNativeViewportPointerDrag,
 } from './chartPointerInteraction';
 
 describe('TradingViewNative pointer drag intent', () => {
@@ -44,40 +45,86 @@ describe('TradingViewNative pointer drag intent', () => {
 describe('TradingViewNative time-axis pointer scaling', () => {
   const input = {
     chartWidth: 200,
+    currentY: 50,
     isActive: false,
     startX: 100,
+    startY: 50,
     startZoomScale: 1,
   };
 
   it('waits for horizontal movement beyond the drag threshold', () => {
     expect(
-      getTradingViewNativeTimeAxisPointerZoomScale({
+      getTradingViewNativeTimeAxisPointerDragUpdate({
         ...input,
         currentX: 104,
       }),
-    ).toBeNull();
+    ).toEqual({ type: 'pending' });
     expect(
-      getTradingViewNativeTimeAxisPointerZoomScale({
+      getTradingViewNativeTimeAxisPointerDragUpdate({
         ...input,
         currentX: 105,
       }),
-    ).not.toBeNull();
+    ).toMatchObject({ type: 'scale' });
+  });
+
+  it('cancels a vertical drag before horizontal scaling activates', () => {
+    expect(
+      getTradingViewNativeTimeAxisPointerDragUpdate({
+        ...input,
+        currentX: 103,
+        currentY: 63,
+      }),
+    ).toEqual({ type: 'cancel' });
+    expect(
+      getTradingViewNativeTimeAxisPointerDragUpdate({
+        ...input,
+        currentX: 101,
+        currentY: 100,
+        isActive: true,
+      }),
+    ).toMatchObject({ type: 'scale' });
   });
 
   it('zooms in to the right and out to the left after activation', () => {
+    const zoomIn = getTradingViewNativeTimeAxisPointerDragUpdate({
+      ...input,
+      currentX: 150,
+      isActive: true,
+    });
+    const zoomOut = getTradingViewNativeTimeAxisPointerDragUpdate({
+      ...input,
+      currentX: 50,
+      isActive: true,
+    });
+
+    expect(zoomIn.type).toBe('scale');
+    expect(zoomOut.type).toBe('scale');
+    if (zoomIn.type === 'scale' && zoomOut.type === 'scale') {
+      expect(zoomIn.zoomScale).toBeGreaterThan(1);
+      expect(zoomOut.zoomScale).toBeLessThan(1);
+    }
+  });
+});
+
+describe('TradingViewNative viewport pointer drag arbitration', () => {
+  it('starts only a primary-button drag without an active peer drag', () => {
     expect(
-      getTradingViewNativeTimeAxisPointerZoomScale({
-        ...input,
-        currentX: 150,
-        isActive: true,
+      shouldStartTradingViewNativeViewportPointerDrag({
+        button: 0,
+        hasActiveDrag: false,
       }),
-    ).toBeGreaterThan(1);
+    ).toBe(true);
     expect(
-      getTradingViewNativeTimeAxisPointerZoomScale({
-        ...input,
-        currentX: 50,
-        isActive: true,
+      shouldStartTradingViewNativeViewportPointerDrag({
+        button: 0,
+        hasActiveDrag: true,
       }),
-    ).toBeLessThan(1);
+    ).toBe(false);
+    expect(
+      shouldStartTradingViewNativeViewportPointerDrag({
+        button: 1,
+        hasActiveDrag: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.test.ts
@@ -85,23 +85,23 @@ describe('TradingViewNative time-axis pointer scaling', () => {
     ).toMatchObject({ type: 'scale' });
   });
 
-  it('zooms in to the right and out to the left after activation', () => {
-    const zoomIn = getTradingViewNativeTimeAxisPointerDragUpdate({
+  it('compresses to the right and expands to the left after activation', () => {
+    const compressed = getTradingViewNativeTimeAxisPointerDragUpdate({
       ...input,
       currentX: 150,
       isActive: true,
     });
-    const zoomOut = getTradingViewNativeTimeAxisPointerDragUpdate({
+    const expanded = getTradingViewNativeTimeAxisPointerDragUpdate({
       ...input,
       currentX: 50,
       isActive: true,
     });
 
-    expect(zoomIn.type).toBe('scale');
-    expect(zoomOut.type).toBe('scale');
-    if (zoomIn.type === 'scale' && zoomOut.type === 'scale') {
-      expect(zoomIn.zoomScale).toBeGreaterThan(1);
-      expect(zoomOut.zoomScale).toBeLessThan(1);
+    expect(compressed.type).toBe('scale');
+    expect(expanded.type).toBe('scale');
+    if (compressed.type === 'scale' && expanded.type === 'scale') {
+      expect(compressed.zoomScale).toBeLessThan(1);
+      expect(expanded.zoomScale).toBeGreaterThan(1);
     }
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.ts
@@ -1,6 +1,9 @@
 import { TRADING_VIEW_NATIVE_SUB_INDICATOR_LEGEND_TAP_MAX_DISTANCE } from '../chartConstants';
+import { getTradingViewNativeTimeAxisZoomScaleAfterDrag } from '../utils/timeAxisScale';
 
 export type ITradingViewNativePointerDragIntent = 'pan' | 'pendingLegendTap';
+
+const TIME_AXIS_DRAG_ACTIVATION_DISTANCE = 4;
 
 export function getTradingViewNativePointerDragIntent({
   clientX,
@@ -20,4 +23,32 @@ export function getTradingViewNativePointerDragIntent({
       TRADING_VIEW_NATIVE_SUB_INDICATOR_LEGEND_TAP_MAX_DISTANCE
     ? 'pendingLegendTap'
     : 'pan';
+}
+
+export function getTradingViewNativeTimeAxisPointerZoomScale({
+  chartWidth,
+  currentX,
+  isActive,
+  startX,
+  startZoomScale,
+}: {
+  chartWidth: number;
+  currentX: number;
+  isActive: boolean;
+  startX: number;
+  startZoomScale: number;
+}) {
+  if (
+    !isActive &&
+    Math.abs(currentX - startX) <= TIME_AXIS_DRAG_ACTIVATION_DISTANCE
+  ) {
+    return null;
+  }
+
+  return getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+    chartWidth,
+    currentX,
+    startX,
+    startZoomScale,
+  });
 }

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartPointerInteraction.ts
@@ -2,8 +2,23 @@ import { TRADING_VIEW_NATIVE_SUB_INDICATOR_LEGEND_TAP_MAX_DISTANCE } from '../ch
 import { getTradingViewNativeTimeAxisZoomScaleAfterDrag } from '../utils/timeAxisScale';
 
 export type ITradingViewNativePointerDragIntent = 'pan' | 'pendingLegendTap';
+export type ITradingViewNativeTimeAxisPointerDragUpdate =
+  | { type: 'cancel' }
+  | { type: 'pending' }
+  | { type: 'scale'; zoomScale: number };
 
-const TIME_AXIS_DRAG_ACTIVATION_DISTANCE = 4;
+const TIME_AXIS_DRAG_ACTIVATION_DISTANCE_X = 4;
+const TIME_AXIS_DRAG_FAILURE_DISTANCE_Y = 12;
+
+export function shouldStartTradingViewNativeViewportPointerDrag({
+  button,
+  hasActiveDrag,
+}: {
+  button: number;
+  hasActiveDrag: boolean;
+}) {
+  return button === 0 && !hasActiveDrag;
+}
 
 export function getTradingViewNativePointerDragIntent({
   clientX,
@@ -25,30 +40,43 @@ export function getTradingViewNativePointerDragIntent({
     : 'pan';
 }
 
-export function getTradingViewNativeTimeAxisPointerZoomScale({
+export function getTradingViewNativeTimeAxisPointerDragUpdate({
   chartWidth,
   currentX,
+  currentY,
   isActive,
   startX,
+  startY,
   startZoomScale,
 }: {
   chartWidth: number;
   currentX: number;
+  currentY: number;
   isActive: boolean;
   startX: number;
+  startY: number;
   startZoomScale: number;
-}) {
+}): ITradingViewNativeTimeAxisPointerDragUpdate {
   if (
     !isActive &&
-    Math.abs(currentX - startX) <= TIME_AXIS_DRAG_ACTIVATION_DISTANCE
+    Math.abs(currentY - startY) > TIME_AXIS_DRAG_FAILURE_DISTANCE_Y
   ) {
-    return null;
+    return { type: 'cancel' };
+  }
+  if (
+    !isActive &&
+    Math.abs(currentX - startX) <= TIME_AXIS_DRAG_ACTIVATION_DISTANCE_X
+  ) {
+    return { type: 'pending' };
   }
 
-  return getTradingViewNativeTimeAxisZoomScaleAfterDrag({
-    chartWidth,
-    currentX,
-    startX,
-    startZoomScale,
-  });
+  return {
+    type: 'scale',
+    zoomScale: getTradingViewNativeTimeAxisZoomScaleAfterDrag({
+      chartWidth,
+      currentX,
+      startX,
+      startZoomScale,
+    }),
+  };
 }


### PR DESCRIPTION
## Summary

- add shared time-axis hit testing and horizontal drag scaling
- connect the interaction to React Native gestures and the web pointer layer
- compress the time axis when dragging right and expand it when dragging left
- keep the right edge anchored and rebase active drags across data and viewport updates

## Review follow-up

- keep native crosshair recognizers out of the time-axis interaction region
- make drag scaling position-independent, including right-edge drag starts
- serialize Web viewport and time-axis pointer drags
- preserve vertical touch scrolling before horizontal time-axis scaling activates
- avoid retaining drag state when pointer capture fails

## Validation

- yarn agent:check --profile commit
- yarn agent:check --profile pr (all local checks passed; remote checks still running)
- targeted Jest regression run: 9 suites, 71 tests passed
- iOS simulator: confirmed the native chart renders and measured the bottom time-axis hit region; a pre-existing Dialog Animation LogBox warning prevented a clean end-to-end drag screenshot