### PR TITLE
fix: align Market slippage and Home Swap flows (OK-61276, OK-61079, OK-61219, OK-61220)

### DIFF
--- a/packages/kit/src/components/TokenListView/TokenActionsView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -9,11 +9,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
 import { buildSwapSelectedTokensColdStartAccountKey } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
 import tokenRebaseUtils from '@onekeyhq/shared/src/utils/tokenRebaseUtils';
-import {
-  buildTokenListMapKey,
-  equalTokenNoCaseSensitive,
-  sortTokensCommon,
-} from '@onekeyhq/shared/src/utils/tokenUtils';
+import { sortTokensCommon } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   ESwapSource,
   ESwapTabSwitchType,
@@ -28,17 +24,12 @@ import { useAggregateSubTokenFiat } from '../../states/jotai/contexts/tokenList/
 
 import {
   buildTokenActionSwapFromToken,
-  findTokenActionAggregateKey,
   getResolvedTokenActionToken,
-  getTokenActionSameNetworkSwapToToken,
   getTokenActionSwapToToken,
   isResolvedTokenActionReady,
 } from './TokenActionsView.utils';
 import { useTokenListViewContext } from './TokenListViewContext';
-import {
-  useTokenBalanceMultiplier,
-  useTokenBalanceParsedRaw,
-} from './useTokenFiatField';
+import { useTokenBalanceMultiplier } from './useTokenFiatField';
 
 import type { XStackProps } from 'tamagui';
 
@@ -82,21 +73,10 @@ function TokenActionsView(props: IProps) {
   });
   const networkId =
     resolvedActiveToken?.networkId ?? activeAccount?.network?.id ?? '';
-  const accountAddress = account?.addressDetail?.address;
-  // RAW basis: this value only seeds the Swap modal's fallback balance
-  // (never rendered here), and the Swap boundary expects on-chain-raw
-  // amounts uniformly today — mixing in the display-multiplied basis would
-  // desync it from the `aggregateFromTokenFiat?.balanceParsed` (raw) branch
-  // of the `??` fallback below.
-  const fromTokenBalance = useTokenBalanceParsedRaw(
-    resolvedActiveToken?.$key ?? '',
-  );
   const aggregateFromTokenFiat = useAggregateSubTokenFiat(
     token.isAggregateToken ? token.$key : '',
     resolvedActiveToken?.networkId,
   );
-  const fromTokenBalanceSeed =
-    aggregateFromTokenFiat?.balanceParsed ?? fromTokenBalance;
   const fromTokenBalanceMultiplier = useTokenBalanceMultiplier(
     resolvedActiveToken?.$key ?? '',
   );
@@ -112,48 +92,6 @@ function TokenActionsView(props: IProps) {
       fromTokenBalanceMultiplier,
       resolvedActiveToken?.balanceMultiplier,
     ].find(tokenRebaseUtils.isScalingBalanceMultiplier) !== undefined;
-  const sameNetworkToToken = useMemo(() => {
-    if (!resolvedActiveToken || !networkId) {
-      return undefined;
-    }
-    return getTokenActionSameNetworkSwapToToken({
-      fromToken: buildTokenActionSwapFromToken({
-        token: resolvedActiveToken,
-        networkId,
-        networkLogoURI: network?.logoURI ?? activeAccount?.network?.logoURI,
-      }),
-    });
-  }, [
-    activeAccount?.network?.logoURI,
-    network?.logoURI,
-    networkId,
-    resolvedActiveToken,
-  ]);
-  const sameNetworkToTokenKey =
-    sameNetworkToToken && accountAddress
-      ? buildTokenListMapKey({
-          networkId: sameNetworkToToken.networkId,
-          accountAddress,
-          tokenAddress: sameNetworkToToken.contractAddress ?? '',
-        })
-      : '';
-  // RAW basis — same rationale as `fromTokenBalance` above: only used as the
-  // Swap modal's `importToToken.balanceParsed` seed, never rendered here.
-  const sameNetworkToTokenBalance = useTokenBalanceParsedRaw(
-    sameNetworkToTokenKey,
-  );
-  const sameNetworkToTokenAggregateKey = useMemo(
-    () =>
-      findTokenActionAggregateKey({
-        ownedAggregateTokenListMap,
-        targetToken: sameNetworkToToken,
-      }),
-    [ownedAggregateTokenListMap, sameNetworkToToken],
-  );
-  const sameNetworkToTokenAggregateFiat = useAggregateSubTokenFiat(
-    sameNetworkToTokenAggregateKey ?? '',
-    sameNetworkToToken?.networkId,
-  );
 
   useEffect(() => {
     let isStale = false;
@@ -233,8 +171,6 @@ function TokenActionsView(props: IProps) {
       const importAccountKey =
         buildSwapSelectedTokensColdStartAccountKey(activeAccount);
       const importFromToken = buildTokenActionSwapFromToken({
-        accountAddress,
-        balanceParsed: fromTokenBalanceSeed,
         token: resolvedActiveToken,
         networkId,
         networkLogoURI: network?.logoURI ?? activeAccount?.network?.logoURI,
@@ -255,22 +191,6 @@ function TokenActionsView(props: IProps) {
         } catch {
           // Keep the existing Swap fallback if capability refresh fails.
         }
-      }
-      if (
-        importToToken &&
-        sameNetworkToToken &&
-        equalTokenNoCaseSensitive({
-          token1: importToToken,
-          token2: sameNetworkToToken,
-        })
-      ) {
-        importToToken = {
-          ...importToToken,
-          accountAddress,
-          balanceParsed:
-            sameNetworkToTokenAggregateFiat?.balanceParsed ??
-            sameNetworkToTokenBalance,
-        };
       }
 
       defaultLogger.wallet.walletActions.actionTrade({
@@ -295,8 +215,6 @@ function TokenActionsView(props: IProps) {
     })();
   }, [
     activeAccount,
-    accountAddress,
-    fromTokenBalanceSeed,
     isSoftwareWalletOnlyUser,
     navigation,
     network,
@@ -305,9 +223,6 @@ function TokenActionsView(props: IProps) {
     isScaledUiSwapBlocked,
     networkId,
     resolvedActiveToken,
-    sameNetworkToToken,
-    sameNetworkToTokenAggregateFiat?.balanceParsed,
-    sameNetworkToTokenBalance,
   ]);
 
   if (!token) {

--- a/packages/kit/src/components/TokenListView/TokenActionsView.utils.test.ts
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.utils.test.ts
@@ -3,7 +3,6 @@ import type { IAccountToken } from '@onekeyhq/shared/types/token';
 
 import {
   buildTokenActionSwapFromToken,
-  findTokenActionAggregateKey,
   getResolvedTokenActionToken,
   getTokenActionSameNetworkSwapToToken,
   getTokenActionSwapToToken,
@@ -187,6 +186,16 @@ describe('getTokenActionSwapToToken', () => {
     ).toEqual(expect.objectContaining({ networkId: 'evm--1', symbol: 'ETH' }));
   });
 
+  it('leaves account-scoped balances to Swap after the Home handoff', () => {
+    const fromToken = buildTokenActionSwapFromToken({
+      token: buildAccountToken(),
+      networkId: 'btc--0',
+    });
+
+    expect(fromToken).not.toHaveProperty('accountAddress');
+    expect(fromToken).not.toHaveProperty('balanceParsed');
+  });
+
   it.each([
     undefined,
     { isSupportCrossChain: true, isSupportSwap: false },
@@ -279,33 +288,5 @@ describe('getTokenActionSwapToToken', () => {
         },
       }),
     ).toEqual(expect.objectContaining({ networkId: 'evm--1', symbol: 'ETH' }));
-  });
-});
-
-describe('findTokenActionAggregateKey', () => {
-  it('finds the network-scoped member behind an aggregate Home token', () => {
-    expect(
-      findTokenActionAggregateKey({
-        ownedAggregateTokenListMap: {
-          aggregate_USDC_: {
-            tokens: [
-              buildAccountToken({
-                $key: 'bsc-usdc',
-                address: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
-                isNative: false,
-                networkId: 'evm--56',
-                symbol: 'USDC',
-              }),
-            ],
-          },
-        },
-        targetToken: buildSwapToken({
-          contractAddress: '0x8AC76A51CC950D9822D68B83FE1AD97B32CD580D',
-          isNative: false,
-          networkId: 'evm--56',
-          symbol: 'USDC',
-        }),
-      }),
-    ).toBe('aggregate_USDC_');
   });
 });

--- a/packages/kit/src/components/TokenListView/TokenActionsView.utils.ts
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.utils.ts
@@ -12,29 +12,17 @@ type ITokenActionSwapSupport = {
   isSupportSwap?: boolean;
 };
 
-type IOwnedAggregateTokenListMap = Record<
-  string,
-  {
-    tokens: IAccountToken[];
-  }
->;
-
 export function buildTokenActionSwapFromToken({
-  accountAddress,
-  balanceParsed,
   token,
   networkId,
   networkLogoURI,
 }: {
-  accountAddress?: string;
-  balanceParsed?: string;
   token: IAccountToken;
   networkId: string;
   networkLogoURI?: string;
 }): ISwapToken {
+  // Home owns the token selection intent; Swap resolves address-scoped balance.
   return {
-    accountAddress,
-    balanceParsed,
     contractAddress: token.isNative ? '' : token.address,
     symbol: token.symbol,
     networkId,
@@ -79,29 +67,6 @@ export function getTokenActionSameNetworkSwapToToken({
     return defaultTokens.fromToken;
   }
   return undefined;
-}
-
-export function findTokenActionAggregateKey({
-  ownedAggregateTokenListMap,
-  targetToken,
-}: {
-  ownedAggregateTokenListMap?: IOwnedAggregateTokenListMap;
-  targetToken?: ISwapToken;
-}) {
-  if (!ownedAggregateTokenListMap || !targetToken) {
-    return undefined;
-  }
-  return Object.entries(ownedAggregateTokenListMap).find(([, entry]) =>
-    entry.tokens.some((token) =>
-      equalTokenNoCaseSensitive({
-        token1: {
-          networkId: token.networkId,
-          contractAddress: token.isNative ? '' : token.address,
-        },
-        token2: targetToken,
-      }),
-    ),
-  )?.[0];
 }
 
 export function getResolvedTokenActionToken({

--- a/packages/kit/src/components/TokenListView/useTokenFiatField.ts
+++ b/packages/kit/src/components/TokenListView/useTokenFiatField.ts
@@ -109,12 +109,6 @@ const selectBalanceParsed = (f: ITokenFiat | undefined): string | undefined =>
     balanceMultiplier: f?.balanceMultiplier,
   });
 
-// RAW variant (no balanceMultiplier applied) — for non-display consumers
-// (e.g. swap seeds) that need the on-chain basis, not the display basis.
-const selectBalanceParsedRaw = (
-  f: ITokenFiat | undefined,
-): string | undefined => f?.balanceParsed;
-
 // Raw `balanceMultiplier` field — for consumers that gate scaled-UI-unaware
 // flows (e.g. the swap entry), not for display math.
 const selectBalanceMultiplier = (
@@ -157,19 +151,10 @@ const selectValueSlice = (f: ITokenFiat | undefined): ITokenValueSlice => ({
  * `balanceParsed` only — does NOT re-render on a price tick.
  *
  * Returns the DISPLAY basis (balanceParsed × balanceMultiplier; a no-op for
- * every non-rebase token). For non-display consumers that need the raw
- * on-chain basis (e.g. swap seeds), use `useTokenBalanceParsedRaw` instead.
+ * every non-rebase token).
  */
 export function useTokenBalanceParsed($key: string): string | undefined {
   return useTokenFiatField($key, selectBalanceParsed);
-}
-
-/**
- * RAW `balanceParsed` (no balanceMultiplier applied). For values handed to
- * non-display consumers (e.g. swap seeds) that expect on-chain basis.
- */
-export function useTokenBalanceParsedRaw($key: string): string | undefined {
-  return useTokenFiatField($key, selectBalanceParsedRaw);
 }
 
 /**

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -44,6 +44,7 @@ import {
   EMarketPresetKey,
   EMarketPresetTradeSide,
   getMarketNonPresetSlippageValue,
+  resolveMarketQuoteSlippageMode,
   shouldShowMarketPresetReviewCustomNetworkFeeOption,
 } from './hooks/marketPresetSettings';
 import { useMarketPresetSettings } from './hooks/useMarketPresetSettings';
@@ -214,9 +215,19 @@ function SwapPanelWrapContent({ onCloseDialog }: ISwapPanelWrapProps) {
     tokenDetail?.symbol,
   ]);
 
+  const nonPresetSlippage = getMarketNonPresetSlippageValue({
+    mode: swapSlippagePercentageMode,
+    customValue: swapSlippagePercentageCustomValue,
+    defaultSlippage: speedConfig?.slippage,
+  });
   const effectiveSlippage = marketPresetSettings.enabled
     ? marketPresetSettings.selectedSlippageValue
-    : slippage;
+    : (nonPresetSlippage ?? slippage);
+  const effectiveSlippageMode = resolveMarketQuoteSlippageMode({
+    presetEnabled: marketPresetSettings.enabled,
+    selectedPresetKey: marketPresetSettings.selectedPresetKey,
+    nonPresetMode: swapSlippagePercentageMode,
+  });
   const effectiveNetworkFeeLevel = marketPresetSettings.enabled
     ? marketPresetSettings.selectedNetworkFeeLevel
     : ESwapNetworkFeeLevel.MEDIUM;
@@ -236,7 +247,10 @@ function SwapPanelWrapContent({ onCloseDialog }: ISwapPanelWrapProps) {
       ? paymentAmount.toFixed()
       : sellAmount.toFixed();
   const useSpeedSwapActionsParams = {
-    slippage: effectiveSlippage,
+    slippageItem: {
+      key: effectiveSlippageMode,
+      value: effectiveSlippage,
+    },
     // Market status never gates quoting. A live open-state flip only refreshes
     // the current provider quote so a server-reported closed error can recover.
     stockIsOpen: tokenDetail?.stock?.isOpen,
@@ -487,21 +501,10 @@ function SwapPanelWrapContent({ onCloseDialog }: ISwapPanelWrapProps) {
       return;
     }
 
-    const savedSlippage = getMarketNonPresetSlippageValue({
-      mode: swapSlippagePercentageMode,
-      customValue: swapSlippagePercentageCustomValue,
-      defaultSlippage: speedConfig?.slippage,
-    });
-    if (savedSlippage !== undefined) {
-      setSlippage(savedSlippage);
+    if (nonPresetSlippage !== undefined) {
+      setSlippage(nonPresetSlippage);
     }
-  }, [
-    marketPresetSettings.enabled,
-    setSlippage,
-    speedConfig?.slippage,
-    swapSlippagePercentageCustomValue,
-    swapSlippagePercentageMode,
-  ]);
+  }, [marketPresetSettings.enabled, nonPresetSlippage, setSlippage]);
 
   const saveMarketSlippageForFutureOrders = useCallback(
     async (slippagePercentage: number) => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
@@ -58,6 +58,7 @@ import {
   isInvalidMarketPresetDirectionSettings,
   isInvalidMarketPresetPriorityFeeSettings,
   isInvalidMarketPresetSlippageSettings,
+  isMarketPresetAutoSlippage,
   isMarketPresetConfirmDisabled,
   normalizeMarketPresetDirectionSettings,
   shouldShowMarketPresetPriorityFeeTooltip,
@@ -1545,7 +1546,7 @@ export function MarketPresetSelector({
   estimatePriorityFeeFiatValues,
   presetSettings,
   slippageIconName = 'SliderVerOutline',
-  showAutoSlippageLabel = false,
+  showAutoSlippageLabel = true,
   variant,
 }: IMarketPresetSelectorProps) {
   const intl = useIntl();
@@ -1607,9 +1608,7 @@ export function MarketPresetSelector({
   }
 
   const slippageLabel =
-    resolvedVariant === 'compact' &&
-    showAutoSlippageLabel &&
-    selectedDirectionSettings.slippage.key === ESwapSlippageSegmentKey.AUTO
+    showAutoSlippageLabel && isMarketPresetAutoSlippage(selectedPresetKey)
       ? intl.formatMessage({ id: ETranslations.global_auto })
       : `${selectedSlippageValue}%`;
   const priorityFeeLabel = getPriorityFeeLabel({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/SlippageSetting/SlippageSetting.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/SlippageSetting/SlippageSetting.test.tsx
@@ -1,0 +1,135 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ESwapSlippageSegmentKey } from '@onekeyhq/shared/types/swap/types';
+
+import { SlippageSetting } from './SlippageSetting';
+
+type IMockSettings = {
+  swapSlippagePercentageMode: ESwapSlippageSegmentKey;
+  swapSlippagePercentageCustomValue: number;
+};
+
+let mockSettings: IMockSettings;
+const mockSetSettings = jest.fn(
+  (updater: (value: IMockSettings) => IMockSettings) => {
+    mockSettings = updater(mockSettings);
+  },
+);
+const mockDialogShow = jest.fn();
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useSettingsAtom: () => [mockSettings, mockSetSettings],
+}));
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => ({
+  Dialog: {
+    show: (options: unknown) => {
+      mockDialogShow(options);
+    },
+  },
+  Icon: () => null,
+  SizableText: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  XStack: ({
+    children,
+    onPress,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+  }) =>
+    onPress ? (
+      <button onClick={onPress} type="button">
+        {children}
+      </button>
+    ) : (
+      <div>{children}</div>
+    ),
+}));
+
+jest.mock('@onekeyhq/kit/src/components/SlippageSettingDialog', () => ({
+  __esModule: true,
+  default: ({
+    onSave,
+  }: {
+    onSave: (item: { key: ESwapSlippageSegmentKey; value: number }) => void;
+  }) => (
+    <button
+      data-testid="save-custom-slippage"
+      onClick={() =>
+        onSave({
+          key: ESwapSlippageSegmentKey.CUSTOM,
+          value: 2,
+        })
+      }
+      type="button"
+    >
+      save
+    </button>
+  ),
+}));
+
+jest.mock('../InfoItemLabel/InfoItemLabel', () => ({
+  InfoItemLabel: () => <span>Slippage</span>,
+}));
+
+describe('SlippageSetting', () => {
+  beforeEach(() => {
+    mockSettings = {
+      swapSlippagePercentageMode: ESwapSlippageSegmentKey.AUTO,
+      swapSlippagePercentageCustomValue: 0.5,
+    };
+    mockSetSettings.mockClear();
+    mockDialogShow.mockClear();
+  });
+
+  it('reflects an external future-order slippage update', () => {
+    const { rerender } = render(<SlippageSetting autoDefaultValue={0.5} />);
+
+    expect(screen.getByText(/switch_auto \(0\.5%\)/)).toBeTruthy();
+
+    mockSettings = {
+      swapSlippagePercentageMode: ESwapSlippageSegmentKey.CUSTOM,
+      swapSlippagePercentageCustomValue: 2,
+    };
+    rerender(<SlippageSetting autoDefaultValue={0.5} />);
+
+    expect(screen.getByText('2%')).toBeTruthy();
+  });
+
+  it('persists a direct Market slippage edit as custom', () => {
+    const onSlippageChange = jest.fn();
+    render(
+      <SlippageSetting
+        autoDefaultValue={0.5}
+        onSlippageChange={onSlippageChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    const dialogOptions = mockDialogShow.mock.calls[0]?.[0] as {
+      renderContent: ReactNode;
+    };
+    render(dialogOptions.renderContent);
+    fireEvent.click(screen.getByTestId('save-custom-slippage'));
+
+    expect(mockSettings).toEqual({
+      swapSlippagePercentageMode: ESwapSlippageSegmentKey.CUSTOM,
+      swapSlippagePercentageCustomValue: 2,
+    });
+    expect(onSlippageChange).toHaveBeenCalledWith({
+      key: ESwapSlippageSegmentKey.CUSTOM,
+      value: 2,
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/SlippageSetting/SlippageSetting.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/SlippageSetting/SlippageSetting.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import type { IDialogInstance } from '@onekeyhq/components';
 import { Dialog, Icon, SizableText, XStack } from '@onekeyhq/components';
 import SlippageSettingDialog from '@onekeyhq/kit/src/components/SlippageSettingDialog';
+import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { swapSlippageWillAheadMinValue } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type { ISwapSlippageSegmentItem } from '@onekeyhq/shared/types/swap/types';
@@ -24,21 +25,42 @@ export function SlippageSetting({
   onSlippageChange,
 }: ISlippageSettingProps) {
   const intl = useIntl();
-  const [slippageItem, setSlippageItem] = useState<ISwapSlippageSegmentItem>({
-    key: ESwapSlippageSegmentKey.AUTO,
-    value: autoDefaultValue,
-  });
+  const [
+    { swapSlippagePercentageCustomValue, swapSlippagePercentageMode },
+    setSettings,
+  ] = useSettingsAtom();
+  const slippageItem = useMemo<ISwapSlippageSegmentItem>(
+    () => ({
+      key: swapSlippagePercentageMode,
+      value:
+        swapSlippagePercentageMode === ESwapSlippageSegmentKey.CUSTOM
+          ? swapSlippagePercentageCustomValue
+          : autoDefaultValue,
+    }),
+    [
+      autoDefaultValue,
+      swapSlippagePercentageCustomValue,
+      swapSlippagePercentageMode,
+    ],
+  );
 
   const slippageOnSave = useCallback(
     (item: ISwapSlippageSegmentItem, closeFn?: IDialogInstance['close']) => {
       console.log('Slippage saved:', item);
-      setSlippageItem(item);
+      setSettings((prev) => ({
+        ...prev,
+        swapSlippagePercentageMode: item.key,
+        swapSlippagePercentageCustomValue:
+          item.key === ESwapSlippageSegmentKey.CUSTOM
+            ? item.value
+            : prev.swapSlippagePercentageCustomValue,
+      }));
       onSlippageChange?.(item);
       if (closeFn) {
         void closeFn({ flag: 'save' });
       }
     },
-    [onSlippageChange],
+    [onSlippageChange, setSettings],
   );
 
   const onSlippageHandleClick = useCallback(() => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
@@ -23,6 +23,7 @@ import {
   getMarketPresetSlippageValue,
   isMarketPresetConfirmDisabled,
   resolveMarketPresetDirectionSettings,
+  resolveMarketQuoteSlippageMode,
   shouldShowMarketPresetPriorityFeeTooltip,
   shouldShowMarketPresetReviewCustomNetworkFeeOption,
 } from './marketPresetSettings';
@@ -55,6 +56,49 @@ function buildSpeedConfigWithPreset(
 }
 
 describe('marketPresetSettings', () => {
+  it.each([EMarketPresetKey.P1, EMarketPresetKey.P2, EMarketPresetKey.P3])(
+    'quotes the %s preset with custom slippage semantics',
+    (presetKey) => {
+      expect(
+        resolveMarketQuoteSlippageMode({
+          presetEnabled: true,
+          selectedPresetKey: presetKey,
+          nonPresetMode: ESwapSlippageSegmentKey.AUTO,
+        }),
+      ).toBe(ESwapSlippageSegmentKey.CUSTOM);
+    },
+  );
+
+  it('quotes only the Auto preset with automatic slippage semantics', () => {
+    expect(
+      resolveMarketQuoteSlippageMode({
+        presetEnabled: true,
+        selectedPresetKey: EMarketPresetKey.AUTO,
+        nonPresetMode: ESwapSlippageSegmentKey.CUSTOM,
+      }),
+    ).toBe(ESwapSlippageSegmentKey.AUTO);
+  });
+
+  it('preserves manually selected custom slippage without preset support', () => {
+    expect(
+      resolveMarketQuoteSlippageMode({
+        presetEnabled: false,
+        selectedPresetKey: EMarketPresetKey.AUTO,
+        nonPresetMode: ESwapSlippageSegmentKey.CUSTOM,
+      }),
+    ).toBe(ESwapSlippageSegmentKey.CUSTOM);
+  });
+
+  it('preserves automatic slippage without preset support', () => {
+    expect(
+      resolveMarketQuoteSlippageMode({
+        presetEnabled: false,
+        selectedPresetKey: EMarketPresetKey.P1,
+        nonPresetMode: ESwapSlippageSegmentKey.AUTO,
+      }),
+    ).toBe(ESwapSlippageSegmentKey.AUTO);
+  });
+
   it('uses the saved global custom slippage outside preset mode', () => {
     expect(
       getMarketNonPresetSlippageValue({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
@@ -38,6 +38,30 @@ export enum EMarketPresetPriorityFeeType {
   CUSTOM = 'custom',
 }
 
+export function isMarketPresetAutoSlippage(
+  presetKey: EMarketPresetKey,
+): boolean {
+  return presetKey === EMarketPresetKey.AUTO;
+}
+
+export function resolveMarketQuoteSlippageMode({
+  presetEnabled,
+  selectedPresetKey,
+  nonPresetMode,
+}: {
+  presetEnabled: boolean;
+  selectedPresetKey: EMarketPresetKey;
+  nonPresetMode: ESwapSlippageSegmentKey;
+}) {
+  if (!presetEnabled) {
+    return nonPresetMode;
+  }
+
+  return isMarketPresetAutoSlippage(selectedPresetKey)
+    ? ESwapSlippageSegmentKey.AUTO
+    : ESwapSlippageSegmentKey.CUSTOM;
+}
+
 export type IMarketPresetItem = {
   key: EMarketPresetKey;
   // Static technical label for P1/P2/P3. AUTO has no static label and is

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
@@ -2,11 +2,13 @@ import type {
   IFetchBuildTxResponse,
   IFetchQuoteResult,
 } from '@onekeyhq/shared/types/swap/types';
+import { ESwapSlippageSegmentKey } from '@onekeyhq/shared/types/swap/types';
 
 import {
   buildMarketReviewShouldFallback,
   mergeMarketBuildResultWithQuote,
   resolveMarketQuoteActionState,
+  resolveMarketSelectedQuoteSlippage,
 } from './marketSwapBuildUtils';
 
 function createQuoteResult(
@@ -134,6 +136,36 @@ describe('marketSwapBuildUtils', () => {
       isRefreshAction: true,
       isLoading: true,
     });
+  });
+
+  it('uses the server auto suggestion for an automatic Market quote', () => {
+    expect(
+      resolveMarketSelectedQuoteSlippage({
+        quoteResult: createQuoteResult({
+          autoSuggestedSlippage: 1,
+          slippage: 0.5,
+        }),
+        slippageItem: {
+          key: ESwapSlippageSegmentKey.AUTO,
+          value: 0.5,
+        },
+      }),
+    ).toBe(1);
+  });
+
+  it('keeps the fixed value for a custom Market quote', () => {
+    expect(
+      resolveMarketSelectedQuoteSlippage({
+        quoteResult: createQuoteResult({
+          autoSuggestedSlippage: 1,
+          slippage: 2,
+        }),
+        slippageItem: {
+          key: ESwapSlippageSegmentKey.CUSTOM,
+          value: 0.5,
+        },
+      }),
+    ).toBe(0.5);
   });
 
   it('aligns Market fallback logic with Swap fallback networks', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -3,8 +3,12 @@ import BigNumber from 'bignumber.js';
 import type {
   IFetchBuildTxResponse,
   IFetchQuoteResult,
+  ISwapSlippageSegmentItem,
 } from '@onekeyhq/shared/types/swap/types';
-import { SwapBuildShouldFallBackNetworkIds } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapSlippageSegmentKey,
+  SwapBuildShouldFallBackNetworkIds,
+} from '@onekeyhq/shared/types/swap/types';
 
 export function resolveMarketQuoteActionState({
   hasActionableQuote,
@@ -43,6 +47,24 @@ export function resolveMarketQuoteActionState({
     isRefreshAction: canRefresh || (manualRefreshRequest && isLoading),
     isLoading,
   };
+}
+
+export function resolveMarketSelectedQuoteSlippage({
+  quoteResult,
+  slippageItem,
+}: {
+  quoteResult: Pick<IFetchQuoteResult, 'autoSuggestedSlippage' | 'slippage'>;
+  slippageItem: ISwapSlippageSegmentItem;
+}) {
+  if (slippageItem.key === ESwapSlippageSegmentKey.AUTO) {
+    return (
+      quoteResult.autoSuggestedSlippage ??
+      quoteResult.slippage ??
+      slippageItem.value
+    );
+  }
+
+  return slippageItem.value;
 }
 
 export function buildMarketReviewShouldFallback({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -16,6 +16,7 @@ import {
   swapQuoteEventCompletedAtom,
   swapQuoteFetchingAtom,
   swapQuoteListAtom,
+  swapShouldRefreshQuoteAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
 import type {
   ISwapReviewGasInfoEntry,
@@ -36,6 +37,7 @@ import type {
 import {
   EProtocolOfExchange,
   ESwapQuoteSource,
+  ESwapSlippageSegmentKey,
   ESwapStepType,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
@@ -399,7 +401,10 @@ function createHookProps({
     },
     tradeType: ESwapDirection.BUY,
     fromTokenAmount: '0',
-    slippage: 0.5,
+    slippageItem: {
+      key: ESwapSlippageSegmentKey.CUSTOM,
+      value: 0.5,
+    },
     antiMEV: false,
   };
 }
@@ -656,6 +661,91 @@ describe('useSpeedSwapActions', () => {
 
   it.each([
     {
+      autoSlippage: true,
+      key: ESwapSlippageSegmentKey.AUTO,
+    },
+    {
+      autoSlippage: false,
+      key: ESwapSlippageSegmentKey.CUSTOM,
+    },
+  ])(
+    'quotes Market with $key slippage semantics',
+    async ({ autoSlippage, key }) => {
+      mockFetchSwapTokenDetails.mockResolvedValue([]);
+
+      renderSwapHook(() =>
+        useSpeedSwapActions({
+          ...createHookProps(),
+          fromTokenAmount: '1',
+          slippageItem: {
+            key,
+            value: 0.5,
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockFetchQuotesEvents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            autoSlippage,
+            slippagePercentage: 0.5,
+            source: ESwapQuoteSource.MARKET,
+          }),
+        );
+      });
+    },
+  );
+
+  it('preserves automatic slippage when manually refreshing Market quotes', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([]);
+
+    const { result } = renderSwapHook(() =>
+      useSpeedSwapActions({
+        ...createHookProps(),
+        fromTokenAmount: '1',
+        slippageItem: {
+          key: ESwapSlippageSegmentKey.AUTO,
+          value: 0.5,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchQuotesEvents).toHaveBeenCalledTimes(1);
+    });
+    const quoteRequest = mockSwapStore.get(swapQuoteActionLockAtom());
+
+    act(() => {
+      mockSwapStore.set(swapQuoteFetchingAtom(), false);
+      mockSwapStore.set(swapQuoteEventCompletedAtom(), true);
+      mockSwapStore.set(swapQuoteActionLockAtom(), {
+        ...quoteRequest,
+        actionLock: false,
+      });
+      mockSwapStore.set(swapShouldRefreshQuoteAtom(), true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.quoteNeedsRefresh).toBe(true);
+    });
+    act(() => {
+      result.current.refreshMarketQuote();
+    });
+
+    await waitFor(() => {
+      expect(mockFetchQuotesEvents).toHaveBeenCalledTimes(2);
+    });
+    expect(mockFetchQuotesEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        autoSlippage: true,
+        slippagePercentage: 0.5,
+        source: ESwapQuoteSource.MARKET,
+      }),
+    );
+  });
+
+  it.each([
+    {
       direction: 'EVM to native BTC',
       tradeType: ESwapDirection.BUY,
       fromAccountId: 'evm-account',
@@ -787,6 +877,10 @@ describe('useSpeedSwapActions', () => {
       useSpeedSwapActions({
         ...createHookProps(),
         fromTokenAmount: '1',
+        slippageItem: {
+          key: ESwapSlippageSegmentKey.AUTO,
+          value: 0.5,
+        },
       }),
     );
 
@@ -806,6 +900,7 @@ describe('useSpeedSwapActions', () => {
       toTokenInfo: quoteRequest.toToken ?? btcToken,
       fromAmount: '1',
       toAmount: '0.00001',
+      autoSuggestedSlippage: 1.25,
       swapShouldSignedData: {
         unSignedInfo: {
           origin: 'https://app.onekey.so',
@@ -842,6 +937,7 @@ describe('useSpeedSwapActions', () => {
     expect(reviewState?.steps.map((step) => step.type)).toEqual([
       ESwapStepType.SIGN_MESSAGE,
     ]);
+    expect(reviewState?.preSwapData.slippage).toBe(1.25);
 
     mockFetchBuildTx.mockResolvedValue({
       result: {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -112,6 +112,7 @@ import type {
   IFetchQuoteResult,
   ISwapApproveTransaction,
   ISwapNativeTokenReserveGas,
+  ISwapSlippageSegmentItem,
   ISwapToken,
   ISwapTokenBase,
   ISwapTxHistory,
@@ -124,7 +125,6 @@ import {
   ESwapNetworkFeeLevel,
   ESwapQuoteKind,
   ESwapQuoteSource,
-  ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
   ESwapTradeSource,
   ESwapTxHistoryStatus,
@@ -156,6 +156,7 @@ import {
   buildMarketReviewShouldFallback,
   mergeMarketBuildResultWithQuote,
   resolveMarketQuoteActionState,
+  resolveMarketSelectedQuoteSlippage,
 } from './marketSwapBuildUtils';
 import {
   areMarketApproveAmountsEqual,
@@ -395,7 +396,7 @@ export function useSpeedSwapActions(props: {
   tradeToken: ISwapTokenBase;
   tradeType: ESwapDirection;
   fromTokenAmount: string;
-  slippage: number;
+  slippageItem: ISwapSlippageSegmentItem;
   antiMEV: boolean;
   isCustomRpcUnavailable?: boolean;
   isReviewDialogOpen?: boolean;
@@ -412,13 +413,14 @@ export function useSpeedSwapActions(props: {
     fromTokenAmount,
     tradeToken,
     tradeType,
-    slippage,
+    slippageItem,
     antiMEV,
     isCustomRpcUnavailable,
     isReviewDialogOpen,
     // onCloseDialog,
     stockIsOpen,
   } = props;
+  const { key: slippageMode, value: slippage } = slippageItem;
 
   const intl = useIntl();
   const [inAppNotificationAtom, setInAppNotificationAtom] =
@@ -837,7 +839,7 @@ export function useSpeedSwapActions(props: {
 
     void quoteAction(
       {
-        key: ESwapSlippageSegmentKey.CUSTOM,
+        key: slippageMode,
         value: slippage,
       },
       userAddress,
@@ -865,6 +867,7 @@ export function useSpeedSwapActions(props: {
     quoteAction,
     receivingNetworkAccount?.addressDetail.address,
     slippage,
+    slippageMode,
     toToken,
   ]);
 
@@ -1089,6 +1092,7 @@ export function useSpeedSwapActions(props: {
       accountId,
       receivingAddress,
       receivingAccountId,
+      slippagePercentage,
     }: {
       buildRes: IFetchBuildTxResponse;
       quoteResult?: IFetchQuoteResult;
@@ -1099,6 +1103,7 @@ export function useSpeedSwapActions(props: {
       accountId: string;
       receivingAddress: string;
       receivingAccountId: string;
+      slippagePercentage: number;
     }) => {
       const buildResFinal = mergeMarketBuildResultWithQuote({
         buildRes,
@@ -1119,7 +1124,7 @@ export function useSpeedSwapActions(props: {
         fromAmount,
         receivingAccountId,
         userAddress,
-        slippage,
+        slippage: slippagePercentage,
         swapType,
         receivingAddress,
         onBuildOkxSwapEncodedTx: (params) =>
@@ -1130,7 +1135,7 @@ export function useSpeedSwapActions(props: {
           backgroundApiProxy.serviceStaking.buildInternalDappTx(params),
       });
     },
-    [intl, marketDeriveInfoRes.result?.addressEncoding, slippage],
+    [intl, marketDeriveInfoRes.result?.addressEncoding],
   );
 
   const assertLatestFromTokenBalanceSufficient = useCallback(
@@ -1280,12 +1285,20 @@ export function useSpeedSwapActions(props: {
         );
       }
 
+      const selectedQuoteSlippage = resolveMarketSelectedQuoteSlippage({
+        quoteResult: selectedQuote,
+        slippageItem: {
+          key: slippageMode,
+          value: slippage,
+        },
+      });
+
       if (selectedQuote.swapShouldSignedData) {
         const reviewBuildRes: IFetchBuildTxResponse = {
           ...(selectedQuote.quoteId ? { orderId: selectedQuote.quoteId } : {}),
           result: {
             ...selectedQuote,
-            slippage: selectedQuote.slippage ?? slippage,
+            slippage: selectedQuoteSlippage,
           },
         };
         const swapInfo: ISwapTxInfo = {
@@ -1330,7 +1343,7 @@ export function useSpeedSwapActions(props: {
           provider: selectedQuote.info.provider,
           userAddress,
           receivingAddress,
-          slippagePercentage: selectedQuote.slippage ?? slippage,
+          slippagePercentage: selectedQuoteSlippage,
           quoteResultCtx: selectedQuote.quoteResultCtx,
           accountId: fromAccount.id,
           protocol: selectedQuote.protocol ?? EProtocolOfExchange.SWAP,
@@ -1342,10 +1355,17 @@ export function useSpeedSwapActions(props: {
           throw new OneKeyLocalError('Market swap review build failed.');
         }
 
-        const buildResFinal = mergeMarketBuildResultWithQuote({
+        const mergedBuildRes = mergeMarketBuildResultWithQuote({
           buildRes,
           quoteResult: selectedQuote,
         });
+        const buildResFinal: IFetchBuildTxResponse = {
+          ...mergedBuildRes,
+          result: {
+            ...mergedBuildRes.result,
+            slippage: mergedBuildRes.result.slippage ?? selectedQuoteSlippage,
+          },
+        };
 
         const { encodedTx, transferInfo, swapInfo } =
           await buildMarketExecutionFromBuildRes({
@@ -1358,6 +1378,7 @@ export function useSpeedSwapActions(props: {
             accountId: fromAccount.id,
             receivingAddress,
             receivingAccountId: receivingAccount.id,
+            slippagePercentage: selectedQuoteSlippage,
           });
 
         return {
@@ -1377,6 +1398,7 @@ export function useSpeedSwapActions(props: {
       fromNetworkAccount,
       receivingNetworkAccount,
       slippage,
+      slippageMode,
       toToken,
       buildMarketExecutionFromBuildRes,
       assertLatestFromTokenBalanceSufficient,
@@ -2042,6 +2064,7 @@ export function useSpeedSwapActions(props: {
           receivingAccountId:
             snapshot.swapInfo.receiver.accountInfo?.accountId ??
             snapshot.accountId,
+          slippagePercentage,
         });
 
       const nextSnapshot: IMarketReviewExecutionSnapshot = {
@@ -2930,6 +2953,15 @@ export function useSpeedSwapActions(props: {
           accountAddress: snapshot.accountAddress,
           receivingAddress: snapshot.swapInfo.receivingAddress,
         });
+        const signingSlippage =
+          signedQuoteResult.slippage ??
+          resolveMarketSelectedQuoteSlippage({
+            quoteResult: signedQuoteResult,
+            slippageItem: {
+              key: slippageMode,
+              value: slippage,
+            },
+          });
         const buildRes = await backgroundApiProxy.serviceSwap.fetchBuildTx({
           fromToken: snapshot.swapInfo.sender.token,
           toToken: snapshot.swapInfo.receiver.token,
@@ -2940,7 +2972,7 @@ export function useSpeedSwapActions(props: {
           provider: signedQuoteResult.info.provider,
           userAddress: snapshot.accountAddress,
           receivingAddress: snapshot.swapInfo.receivingAddress,
-          slippagePercentage: signedQuoteResult.slippage ?? slippage,
+          slippagePercentage: signingSlippage,
           quoteResultCtx: signedQuoteResult.quoteResultCtx,
           accountId: snapshot.accountId,
           protocol: signedQuoteResult.protocol ?? EProtocolOfExchange.SWAP,
@@ -2952,9 +2984,20 @@ export function useSpeedSwapActions(props: {
           throw new OneKeyLocalError('Market sign build failed.');
         }
 
+        const mergedBuildRes = mergeMarketBuildResultWithQuote({
+          buildRes,
+          quoteResult: signedQuoteResult,
+        });
+        const buildResFinal: IFetchBuildTxResponse = {
+          ...mergedBuildRes,
+          result: {
+            ...mergedBuildRes.result,
+            slippage: mergedBuildRes.result.slippage ?? signingSlippage,
+          },
+        };
         const { encodedTx, transferInfo, swapInfo, skipSendTransAction } =
           await buildMarketExecutionFromBuildRes({
-            buildRes,
+            buildRes: buildResFinal,
             quoteResult: signedQuoteResult,
             currentFromToken: snapshot.swapInfo.sender.token,
             currentToToken: snapshot.swapInfo.receiver.token,
@@ -2966,11 +3009,8 @@ export function useSpeedSwapActions(props: {
             receivingAccountId:
               snapshot.swapInfo.receiver.accountInfo?.accountId ??
               snapshot.accountId,
+            slippagePercentage: signingSlippage,
           });
-        const buildResFinal = mergeMarketBuildResultWithQuote({
-          buildRes,
-          quoteResult: signedQuoteResult,
-        });
         const buildCtx = buildResFinal.ctx as
           | {
               cowSwapOrderId?: string;
@@ -3003,6 +3043,7 @@ export function useSpeedSwapActions(props: {
             fromAmount: reviewedBuildResult.fromAmount,
             toAmount: reviewedBuildResult.toAmount,
             minToAmount: reviewedBuildResult.minToAmount,
+            slippage: reviewedBuildResult.slippage ?? signingSlippage,
           },
           buildUnsignedParams: {
             networkId: snapshot.networkId,
@@ -3062,6 +3103,7 @@ export function useSpeedSwapActions(props: {
       refreshMarketSigningQuoteResult,
       signMarketReviewQuoteResult,
       slippage,
+      slippageMode,
     ],
   );
 
@@ -3562,7 +3604,7 @@ export function useSpeedSwapActions(props: {
     ) {
       void quoteAction(
         {
-          key: ESwapSlippageSegmentKey.CUSTOM,
+          key: slippageMode,
           value: slippage,
         },
         userAddress,
@@ -3602,6 +3644,7 @@ export function useSpeedSwapActions(props: {
     resetQuoteAction,
     setSwapFromTokenAmount,
     slippage,
+    slippageMode,
     stockIsOpen,
     toToken.contractAddress,
     toToken.networkId,

--- a/packages/kit/src/views/Swap/hooks/useSwapLifecycle.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLifecycle.test.ts
@@ -1,3 +1,4 @@
+import { EModalSwapRoutes } from '@onekeyhq/shared/src/routes/swap';
 import {
   ESwapTabSwitchType,
   type ISwapToken,
@@ -10,6 +11,7 @@ import {
 import {
   handleSwapQuoteTabVisibilityChange,
   isSwapQuoteTabEffectivelyVisible,
+  shouldKeepSwapQuoteAliveOnFocusLoss,
 } from './useSwapQuote';
 
 jest.mock('../../../background/instance/backgroundApiProxy', () => ({
@@ -76,6 +78,16 @@ const token = {
 } as ISwapToken;
 
 describe('Swap quote lifecycle visibility', () => {
+  it('keeps modal quoting alive while the provider picker is active', () => {
+    expect(
+      shouldKeepSwapQuoteAliveOnFocusLoss(EModalSwapRoutes.SwapProviderSelect),
+    ).toBe(true);
+    expect(
+      shouldKeepSwapQuoteAliveOnFocusLoss(EModalSwapRoutes.SwapTokenSelect),
+    ).toBe(false);
+    expect(shouldKeepSwapQuoteAliveOnFocusLoss()).toBe(false);
+  });
+
   it.each([
     {
       isFocus: true,

--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { useIsOverlayPage } from '@onekeyhq/components';
+import { rootNavigationRef, useIsOverlayPage } from '@onekeyhq/components';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import {
   useSettingsAtom,
@@ -15,6 +15,7 @@ import { ESwapEventAPIStatus } from '@onekeyhq/shared/src/logger/scopes/swap/sce
 import type { ISwapQuoteProvideResult } from '@onekeyhq/shared/src/logger/scopes/swap/scenes/swapQuote';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalSwapRoutes } from '@onekeyhq/shared/src/routes/swap';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   SWAP_PRO_QUOTE_INPUT_DEBOUNCE_MS,
@@ -73,6 +74,10 @@ export function isSwapQuoteTabEffectivelyVisible({
   isHiddenModel: boolean;
 }) {
   return isFocus && !isHiddenModel;
+}
+
+export function shouldKeepSwapQuoteAliveOnFocusLoss(routeName?: string) {
+  return routeName === EModalSwapRoutes.SwapProviderSelect;
 }
 
 export function handleSwapQuoteTabVisibilityChange({
@@ -983,6 +988,14 @@ export function useSwapQuote() {
     setSwapQuoteResultList,
   ]);
 
+  const isProviderSelectRouteActive = useCallback(
+    () =>
+      shouldKeepSwapQuoteAliveOnFocusLoss(
+        rootNavigationRef.current?.getCurrentRoute()?.name,
+      ),
+    [],
+  );
+
   useListenTabFocusState(
     ETabRoutes.Swap,
     (isFocus: boolean, isHiddenModel: boolean) => {
@@ -1007,18 +1020,19 @@ export function useSwapQuote() {
       if (isFocused) {
         subscribeQuoteEvents();
         refreshPreservedInputQuoteOnFocus();
-      } else {
+      } else if (!isProviderSelectRouteActive()) {
         pauseQuoteOnFocusLoss();
       }
     }
     return () => {
-      if (isModalPage) {
+      if (isModalPage && !isProviderSelectRouteActive()) {
         unsubscribeQuoteEvents();
       }
     };
   }, [
     isFocused,
     isModalPage,
+    isProviderSelectRouteActive,
     pauseQuoteOnFocusLoss,
     refreshPreservedInputQuoteOnFocus,
     subscribeQuoteEvents,

--- a/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Icon,
   IconButton,
+  LottieView,
   Page,
   Popover,
   SectionList,
@@ -16,6 +17,7 @@ import {
   SizableText,
   Stack,
   XStack,
+  YStack,
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import {
@@ -45,6 +47,10 @@ import { ESwapProviderSort } from '@onekeyhq/shared/types/swap/SwapProvider.cons
 import type { IFetchQuoteResult } from '@onekeyhq/shared/types/swap/types';
 
 import SwapProviderListItem from '../../components/SwapProviderListItem';
+import {
+  useSwapQuoteEventFetching,
+  useSwapQuoteLoading,
+} from '../../hooks/useSwapState';
 import { SwapTestIDs } from '../../testIDs';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
@@ -78,6 +84,9 @@ const SwapProviderSelectModal = () => {
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
+  const quoteLoading = useSwapQuoteLoading();
+  const quoteEventFetching = useSwapQuoteEventFetching();
+  const isQuoteFetching = quoteLoading || quoteEventFetching;
   const [quoteActionLock] = useSwapQuoteActionLockAtom();
   const activeFromTokenAmount =
     quoteActionLock.fromTokenAmount ?? fromTokenAmount.value;
@@ -312,6 +321,23 @@ const SwapProviderSelectModal = () => {
         estimatedItemSize="$10"
         renderItem={renderItem}
         sections={sectionData}
+        ListHeaderComponent={
+          sectionData.length === 0 && isQuoteFetching ? (
+            <YStack
+              testID="swap-provider-list-loading"
+              alignItems="center"
+              justifyContent="center"
+              py="$16"
+            >
+              <LottieView
+                source={require('@onekeyhq/kit/assets/animations/swap_loading.json')}
+                autoPlay
+                loop
+                style={{ width: 48, height: 20 }}
+              />
+            </YStack>
+          ) : null
+        }
         renderSectionHeader={({ section: { type, title } }) => {
           if (type === ESwapProviderStatus.AVAILABLE) {
             return (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61276](https://onekeyhq.atlassian.net/browse/OK-61276) [OK-61079](https://onekeyhq.atlassian.net/browse/OK-61079) [OK-61219](https://onekeyhq.atlassian.net/browse/OK-61219) [OK-61220](https://onekeyhq.atlassian.net/browse/OK-61220)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues
- Fixes [OK-61276](https://onekeyhq.atlassian.net/browse/OK-61276)
- [OK-61079](https://onekeyhq.atlassian.net/browse/OK-61079)
- Fixes [OK-61219](https://onekeyhq.atlassian.net/browse/OK-61219)
- Fixes [OK-61220](https://onekeyhq.atlassian.net/browse/OK-61220)

## Summary
- derive Market autoSlippage from the explicit slippage mode: only the Auto preset uses automatic DODO slippage, while P1, P2, and P3 use fixed custom slippage
- keep no-preset Market slippage synchronized with the global Auto or Custom setting, including the Review option that saves the value for future orders
- preserve the resolved slippage through quote refresh, review build, signed orders, and review rebuilds so stale quote values cannot override Custom input
- align the displayed Auto label with the same preset semantic source used by quote requests
- keep Home token actions limited to token-selection intent and let Swap resolve the current address-scoped balance instead of trusting a merged Home balance
- preserve the first-entry balance skeleton and subsequent scoped-cache display with silent refresh
- keep the active Home Swap quote subscription alive while the provider picker route is open, instead of treating that internal navigation as leaving Swap and clearing an in-flight quote
- show the quote loading state in the provider picker until the first provider result arrives

## Test plan
- Focused Jest: 8 Market SwapPanel suites, 113 tests passed
- Focused Jest: TokenActionsView, token merge, and Swap balance display cache suites, 81 tests passed
- Focused Jest: Swap quote lifecycle suite, 17 tests passed
- `yarn agent:check --profile pr`
- `yarn agent:check --profile commit` after rebasing onto the latest `origin/x`
- `yarn agent:check --profile commit` for the OK-61219 follow-up
- `yarn agent:check --profile commit` for the OK-61220 follow-up

## Runtime validation and risk
- Desktop SUI flow verified Custom 2% on the main panel and the next quote request used `slippagePercentage=2` with `autoSlippage=false`; no transaction was sent
- Auto preset still disables persistent future-order saving while retaining current-order editing; no-preset networks continue to support saving Custom slippage for future orders
- Desktop Home BTC entry requested `/swap/v1/token/detail` and settled to the active address-scoped balance instead of the merged Home balance; repeat entry reused the scoped cache while refreshing silently
- Desktop Home BTC Swap opened the provider picker 640 ms after changing the amount; the picker rendered 9 providers immediately and continued receiving the same in-flight quote up to 11 providers 300 ms later, with no blank state
- Returning from the provider picker and changing the amount again produced a new output quote with no page errors; no transaction was sent
- Direct Desktop Swap remained healthy with settled balances and no new console errors; no transaction was sent
- A final post-rebase Desktop replay for the Market path was not completed because the route refresh returned the app to the passcode lock screen; focused checks cover the final rebased Market head


[OK-61276]: https://onekeyhq.atlassian.net/browse/OK-61276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61079]: https://onekeyhq.atlassian.net/browse/OK-61079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61219]: https://onekeyhq.atlassian.net/browse/OK-61219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61220]: https://onekeyhq.atlassian.net/browse/OK-61220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ