### PR TITLE
fix: preserve Swap tokens across Pro tab switches (OK-61322)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -74,6 +74,7 @@ import {
   getSwapSelectedTokensHomeAccountSyncAction,
   isSwapColdStartAllNetworkContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
+  shouldDeferSwapDefaultSelectedTokenSyncForNativePro,
   shouldMarkSwapInitialSelectedTokensSynced,
   shouldPreserveSwapUserInputAmountOnAccountSwitch,
   shouldPreserveSwapUserInputOnAccountSwitch,
@@ -906,6 +907,16 @@ export function useSwapInit(params?: ISwapInitParams) {
   );
 
   const syncDefaultSelectedToken = useCallback(async () => {
+    const shouldDeferForNativePro = () =>
+      shouldDeferSwapDefaultSelectedTokenSyncForNativePro({
+        isNative: Boolean(platformEnv.isNative),
+        swapType: swapTypeSwitchRef.current,
+      });
+    // Native Pro owns separate token atoms. Keep the parked Swap pair intact
+    // until Swap becomes the active owner again.
+    if (shouldDeferForNativePro()) {
+      return;
+    }
     const hasUnconsumedSwapInitParams = Boolean(
       swapInitParamsConsumptionKey &&
       consumedSwapInitParamsKeyRef.current !== swapInitParamsConsumptionKey,
@@ -992,6 +1003,9 @@ export function useSwapInit(params?: ISwapInitParams) {
     }
     const homeAccountSyncResult =
       await syncSwapSelectedAccountFromLatestHomeStorage();
+    if (shouldDeferForNativePro()) {
+      return;
+    }
     if (homeAccountSyncResult.synced) {
       if (homeAccountSyncResult.clearedSelectedTokens) {
         hasSelectedTokens = false;

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -21,6 +21,7 @@ import {
   isSwapTokenSupportedBySwapType,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
   shouldClearSwapSelectedTokensOnHomeAccountUpdate,
+  shouldDeferSwapDefaultSelectedTokenSyncForNativePro,
   shouldHandleSwapColdStartHomeAccountUpdate,
   shouldMarkSwapInitialSelectedTokensSynced,
   shouldPreserveSwapUserInputAmountOnAccountSwitch,
@@ -1531,6 +1532,29 @@ describe('swap cold-start selected token context', () => {
         hasImportParams: true,
         hasSelectedTokens: true,
         initialSelectedTokensSynced: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('defers shared Swap token sync while Native Pro owns the token UI', () => {
+    expect(
+      shouldDeferSwapDefaultSelectedTokenSyncForNativePro({
+        isNative: true,
+        swapType: ESwapTabSwitchType.LIMIT,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDeferSwapDefaultSelectedTokenSyncForNativePro({
+        isNative: false,
+        swapType: ESwapTabSwitchType.LIMIT,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldDeferSwapDefaultSelectedTokenSyncForNativePro({
+        isNative: true,
+        swapType: ESwapTabSwitchType.SWAP,
       }),
     ).toBe(false);
   });

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -807,6 +807,16 @@ export function shouldSkipSwapDefaultSelectedTokenSync({
   return initialSelectedTokensSynced && !hasImportParams && hasSelectedTokens;
 }
 
+export function shouldDeferSwapDefaultSelectedTokenSyncForNativePro({
+  isNative,
+  swapType,
+}: {
+  isNative: boolean;
+  swapType: ESwapTabSwitchType;
+}) {
+  return isNative && swapType === ESwapTabSwitchType.LIMIT;
+}
+
 function buildSwapInitTokenConsumptionKey(token?: ISwapToken) {
   if (!token) {
     return '';


### PR DESCRIPTION
## Summary

- defer shared Swap default-token synchronization while Native Pro owns the token UI
- re-check the active owner after the asynchronous Home-account synchronization
- cover Native Pro, desktop/web Limit, and Native Swap owner boundaries

## Root cause

Native Pro uses the `LIMIT` tab type but owns separate Pro token atoms. `useSwapGlobal` still validated the parked Swap From/To atoms against the active `LIMIT` channel. When a parked Swap token network did not advertise `supportLimit`, the default-token effect treated the valid Swap pair as unsupported and cleared both tokens. The effect timing made the issue intermittent during repeated Pro/Swap tab switches.

## Validation

- `yarn agent:check --profile commit`
- `yarn jest packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts --runInBand`
- `yarn jest packages/kit/src/states/jotai/contexts/swap/actions.test.tsx --runInBand`
- `yarn jest packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.test.tsx --runInBand`
- iOS cold-start regression with Robinhood ETH / Bitcoin Cash BCH: 8 rapid Pro/Swap cycles preserved both tokens
- Hermes destructive-write breakpoint: 16 clear calls before the fix, 0 after the fix for the same run

Jira: https://onekeyhq.atlassian.net/browse/OK-61322
