### PR TITLE
fix: render localized native chart labels OK-60853

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChart.types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChart.types.ts
@@ -30,6 +30,7 @@ export interface ITradingViewNativeChartProps {
   indicatorSeriesSettingsKey: string;
   initialRightOffset?: ITradingViewNativeInitialRightOffset;
   isSwitchingInterval: boolean;
+  locale: string;
   priceAxisFontSize?: number;
   priceAxisTickCount?: number;
   showLegend?: boolean;

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
@@ -103,6 +103,7 @@ const mockUseTradingViewNativeKLine = jest.fn(
 jest.mock('react-intl', () => ({
   useIntl: () => ({
     formatMessage: ({ id }: { id: string }) => id,
+    locale: 'zh-CN',
   }),
 }));
 
@@ -289,6 +290,7 @@ describe('TradingViewNativeContainer', () => {
           low: 'market.low_abbr',
           open: 'market.open_abbr',
         },
+        locale: 'zh-CN',
       }),
     );
   });

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -756,6 +756,7 @@ export const TradingViewNativeContainer = memo(
             indicatorSeriesSettingsKey={mainIndicatorSettingsKey}
             initialRightOffset={initialRightOffset}
             isSwitchingInterval={isSwitchingInterval}
+            locale={intl.locale}
             priceAxisTickCount={
               isCompactDisplayMode
                 ? TRADING_VIEW_NATIVE_COMPACT_PRICE_AXIS_TICK_COUNT

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -207,6 +207,7 @@ export const TradingViewNativeChart = memo(
     );
     const watermarkOpacity =
       themeName === 'dark' ? WATERMARK_DARK_OPACITY : WATERMARK_LIGHT_OPACITY;
+    const legendText = `${candleLabels.open}${candleLabels.high}${candleLabels.low}${candleLabels.close}`;
     const resources = useDerivedValue(
       () =>
         createTradingViewNativeSkiaResources({
@@ -220,6 +221,7 @@ export const TradingViewNativeChart = memo(
             up: chartSettings.candles.body.upColor,
           },
           fontFamily: SYSTEM_FONT_FAMILY,
+          legendText,
           priceAxisFont,
           priceAxisFontSize,
           timeAxisFontSize,
@@ -232,6 +234,7 @@ export const TradingViewNativeChart = memo(
         chartSettings.candles.body.downColor,
         chartSettings.candles.body.upColor,
         grid,
+        legendText,
         line,
         priceAxisFont,
         priceAxisFontSize,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -23,6 +23,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   TRADING_VIEW_NATIVE_SWITCHING_INTERVAL_OPACITY as SWITCHING_INTERVAL_OPACITY,
   TRADING_VIEW_NATIVE_AXIS_FONT_SIZE,
+  TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
   TRADING_VIEW_NATIVE_PAN_DRAG_RATIO,
   TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT,
   TRADING_VIEW_NATIVE_WATERMARK_DARK_OPACITY as WATERMARK_DARK_OPACITY,
@@ -71,9 +72,9 @@ import {
   shouldReplaceTradingViewNativeIndicatorSeries,
 } from './chartRuntimeData';
 import {
+  createTradingViewNativeSkiaFontForText,
   createTradingViewNativeSkiaPicture,
   createTradingViewNativeSkiaResources,
-  getTradingViewNativeSkiaFontFamilyForText,
 } from './chartSkiaRenderer';
 import { TradingViewNativePriceScaleControls } from './TradingViewNativePriceScaleControls';
 import { useTradingViewNativeChartGestures } from './useTradingViewNativeChartGestures';
@@ -105,6 +106,7 @@ export const TradingViewNativeChart = memo(
     indicatorSeriesSettingsKey,
     initialRightOffset,
     isSwitchingInterval,
+    locale,
     priceAxisFontSize = TRADING_VIEW_NATIVE_AXIS_FONT_SIZE,
     priceAxisTickCount,
     showLegend = true,
@@ -209,13 +211,15 @@ export const TradingViewNativeChart = memo(
     const watermarkOpacity =
       themeName === 'dark' ? WATERMARK_DARK_OPACITY : WATERMARK_LIGHT_OPACITY;
     const legendText = `${candleLabels.open}${candleLabels.high}${candleLabels.low}${candleLabels.close}`;
-    const legendFontFamily = useMemo(
+    const legendFont = useMemo(
       () =>
-        getTradingViewNativeSkiaFontFamilyForText({
+        createTradingViewNativeSkiaFontForText({
           fontFamily: SYSTEM_FONT_FAMILY,
+          fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
+          locale,
           requiredText: legendText,
         }),
-      [legendText],
+      [legendText, locale],
     );
     const resources = useDerivedValue(
       () =>
@@ -230,7 +234,7 @@ export const TradingViewNativeChart = memo(
             up: chartSettings.candles.body.upColor,
           },
           fontFamily: SYSTEM_FONT_FAMILY,
-          legendFontFamily,
+          legendFont,
           priceAxisFont,
           priceAxisFontSize,
           timeAxisFontSize,
@@ -243,7 +247,7 @@ export const TradingViewNativeChart = memo(
         chartSettings.candles.body.downColor,
         chartSettings.candles.body.upColor,
         grid,
-        legendFontFamily,
+        legendFont,
         line,
         priceAxisFont,
         priceAxisFontSize,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -73,6 +73,7 @@ import {
 import {
   createTradingViewNativeSkiaPicture,
   createTradingViewNativeSkiaResources,
+  getTradingViewNativeSkiaFontFamilyForText,
 } from './chartSkiaRenderer';
 import { TradingViewNativePriceScaleControls } from './TradingViewNativePriceScaleControls';
 import { useTradingViewNativeChartGestures } from './useTradingViewNativeChartGestures';
@@ -208,6 +209,14 @@ export const TradingViewNativeChart = memo(
     const watermarkOpacity =
       themeName === 'dark' ? WATERMARK_DARK_OPACITY : WATERMARK_LIGHT_OPACITY;
     const legendText = `${candleLabels.open}${candleLabels.high}${candleLabels.low}${candleLabels.close}`;
+    const legendFontFamily = useMemo(
+      () =>
+        getTradingViewNativeSkiaFontFamilyForText({
+          fontFamily: SYSTEM_FONT_FAMILY,
+          requiredText: legendText,
+        }),
+      [legendText],
+    );
     const resources = useDerivedValue(
       () =>
         createTradingViewNativeSkiaResources({
@@ -221,7 +230,7 @@ export const TradingViewNativeChart = memo(
             up: chartSettings.candles.body.upColor,
           },
           fontFamily: SYSTEM_FONT_FAMILY,
-          legendText,
+          legendFontFamily,
           priceAxisFont,
           priceAxisFontSize,
           timeAxisFontSize,
@@ -234,7 +243,7 @@ export const TradingViewNativeChart = memo(
         chartSettings.candles.body.downColor,
         chartSettings.candles.body.upColor,
         grid,
-        legendText,
+        legendFontFamily,
         line,
         priceAxisFont,
         priceAxisFontSize,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
@@ -2,6 +2,7 @@
 import {
   createTradingViewNativeSkiaPicture,
   createTradingViewNativeSkiaResources,
+  getTradingViewNativeSkiaFontFamilyForText,
   getTradingViewNativeSkiaPaintStyleSignature,
 } from './chartSkiaRenderer';
 
@@ -35,21 +36,30 @@ const mockPath = {
 };
 const mockGradientShader = { dispose: jest.fn() };
 let mockFontGlyphsByFamily: Record<string, string> = {};
+let mockFontDisposeByFamily: Record<string, jest.Mock> = {};
 let mockSystemFontFamilies: string[] = [];
+const mockCountFontFamilies = jest.fn(() => mockSystemFontFamilies.length);
+const mockGetFontFamilyName = jest.fn(
+  (index: number) => mockSystemFontFamilies[index],
+);
 const mockSkiaFont = jest.fn(
-  (typeface: { fontFamily: string }, fontSize: number) => ({
-    dispose: jest.fn(),
-    fontFamily: typeface.fontFamily,
-    fontSize,
-    getGlyphIDs: (text: string) =>
-      Array.from(text).map((character) =>
-        character.charCodeAt(0) <= 127 ||
-        mockFontGlyphsByFamily[typeface.fontFamily]?.includes(character)
-          ? 1
-          : 0,
-      ),
-    measureText: (text: string) => ({ width: text.length }),
-  }),
+  (typeface: { fontFamily: string }, fontSize: number) => {
+    const dispose = jest.fn();
+    mockFontDisposeByFamily[typeface.fontFamily] = dispose;
+    return {
+      dispose,
+      fontFamily: typeface.fontFamily,
+      fontSize,
+      getGlyphIDs: (text: string) =>
+        Array.from(text).map((character) =>
+          character.charCodeAt(0) <= 127 ||
+          mockFontGlyphsByFamily[typeface.fontFamily]?.includes(character)
+            ? 1
+            : 0,
+        ),
+      measureText: (text: string) => ({ width: text.length }),
+    };
+  },
 );
 const mockCanvas = {
   clipRect: jest.fn(),
@@ -88,8 +98,8 @@ jest.mock('@shopify/react-native-skia', () => ({
       mockSkiaFont(typeface, fontSize),
     FontMgr: {
       System: () => ({
-        countFamilies: () => mockSystemFontFamilies.length,
-        getFamilyName: (index: number) => mockSystemFontFamilies[index],
+        countFamilies: () => mockCountFontFamilies(),
+        getFamilyName: (index: number) => mockGetFontFamilyName(index),
         matchFamilyStyle: (fontFamily: string) => ({ fontFamily }),
       }),
     },
@@ -137,9 +147,9 @@ function createScene(
 }
 
 function createResources({
-  legendText = '',
+  legendFontFamily = 'System',
 }: {
-  legendText?: string;
+  legendFontFamily?: string;
 } = {}) {
   return createTradingViewNativeSkiaResources({
     colors: {
@@ -149,7 +159,7 @@ function createResources({
       line: '#ffffff',
     },
     fontFamily: 'System',
-    legendText,
+    legendFontFamily,
     priceAxisFont: null,
     priceAxisFontSize: 12,
     timeAxisFontSize: 12,
@@ -187,7 +197,38 @@ describe('TradingViewNative Skia scene renderer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFontGlyphsByFamily = {};
+    mockFontDisposeByFamily = {};
     mockSystemFontFamilies = [];
+  });
+
+  it('keeps the primary font family without scanning when it has every glyph', () => {
+    const legendText = '开高低收';
+    mockFontGlyphsByFamily.System = legendText;
+    mockSystemFontFamilies = ['Fallback'];
+
+    const fontFamily = getTradingViewNativeSkiaFontFamilyForText({
+      fontFamily: 'System',
+      requiredText: legendText,
+    });
+
+    expect(fontFamily).toBe('System');
+    expect(mockCountFontFamilies).not.toHaveBeenCalled();
+    expect(mockFontDisposeByFamily.System).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the primary family when no system font has every glyph', () => {
+    mockSystemFontFamilies = ['Partial', 'Missing'];
+    mockFontGlyphsByFamily.Partial = '开高';
+
+    const fontFamily = getTradingViewNativeSkiaFontFamilyForText({
+      fontFamily: 'System',
+      requiredText: '开高低收',
+    });
+
+    expect(fontFamily).toBe('System');
+    expect(mockFontDisposeByFamily.System).toHaveBeenCalledTimes(1);
+    expect(mockFontDisposeByFamily.Partial).toHaveBeenCalledTimes(1);
+    expect(mockFontDisposeByFamily.Missing).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -208,18 +249,36 @@ describe('TradingViewNative Skia scene renderer', () => {
       legendText: '시고저종',
     },
   ])(
-    'uses $expectedFontFamily for localized legend glyphs',
+    'selects the first complete $expectedFontFamily fallback',
     ({ expectedFontFamily, legendText }) => {
-      mockSystemFontFamilies = [expectedFontFamily];
+      mockSystemFontFamilies = ['Partial', expectedFontFamily, 'Later'];
+      mockFontGlyphsByFamily.Partial = Array.from(legendText)[0] ?? '';
       mockFontGlyphsByFamily[expectedFontFamily] = legendText;
+      mockFontGlyphsByFamily.Later = legendText;
 
-      const resources = createResources({ legendText });
+      const fontFamily = getTradingViewNativeSkiaFontFamilyForText({
+        fontFamily: 'System',
+        requiredText: legendText,
+      });
 
-      expect(resources.fonts.legend).toEqual(
-        expect.objectContaining({ fontFamily: expectedFontFamily }),
+      expect(fontFamily).toBe(expectedFontFamily);
+      expect(mockFontDisposeByFamily.Partial).toHaveBeenCalledTimes(1);
+      expect(mockFontDisposeByFamily[expectedFontFamily]).toHaveBeenCalledTimes(
+        1,
       );
+      expect(mockFontDisposeByFamily.Later).toBeUndefined();
     },
   );
+
+  it('builds resources from the resolved legend family without scanning', () => {
+    const resources = createResources({ legendFontFamily: 'PingFang SC' });
+
+    expect(resources.fonts.legend).toEqual(
+      expect.objectContaining({ fontFamily: 'PingFang SC' }),
+    );
+    expect(mockCountFontFamilies).not.toHaveBeenCalled();
+    expect(mockGetFontFamilyName).not.toHaveBeenCalled();
+  });
 
   it('creates one cached SkPaint per stable custom style', () => {
     const resources = createResources();

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
@@ -1,8 +1,9 @@
 // cspell:ignore Alphaf Skia XYWH
+
 import {
+  createTradingViewNativeSkiaFontForText,
   createTradingViewNativeSkiaPicture,
   createTradingViewNativeSkiaResources,
-  getTradingViewNativeSkiaFontFamilyForText,
   getTradingViewNativeSkiaPaintStyleSignature,
 } from './chartSkiaRenderer';
 
@@ -10,6 +11,7 @@ import type {
   ITradingViewNativeChartScene,
   ITradingViewNativeChartScenePaintStyle,
 } from '../utils/chartScene';
+import type { SkFont } from '@shopify/react-native-skia';
 
 const mockBuildTradingViewNativeChartScene = jest.fn<
   ITradingViewNativeChartScene,
@@ -37,12 +39,30 @@ const mockPath = {
 const mockGradientShader = { dispose: jest.fn() };
 let mockFontGlyphsByFamily: Record<string, string> = {};
 let mockFontDisposeByFamily: Record<string, jest.Mock> = {};
-let mockSystemFontFamilies: string[] = [];
-const mockCountFontFamilies = jest.fn(() => mockSystemFontFamilies.length);
-const mockGetFontFamilyName = jest.fn(
-  (index: number) => mockSystemFontFamilies[index],
+let mockFallbackFontFamilyByRequest: Record<string, string> = {};
+let mockFallbackTypefaceDisposeByFamily: Record<string, jest.Mock> = {};
+const mockCountFontFamilies = jest.fn(() => 0);
+const mockGetFontFamilyName = jest.fn((_index: number) => '');
+const mockMatchFamilyStyleCharacter = jest.fn(
+  (
+    _fontFamily: string,
+    _fontStyle: unknown,
+    bcp47: string[],
+    character: number,
+  ) => {
+    const fallbackFontFamily =
+      mockFallbackFontFamilyByRequest[
+        `${bcp47.at(-1) ?? ''}:${String.fromCodePoint(character)}`
+      ];
+    if (!fallbackFontFamily) {
+      return null;
+    }
+    const dispose = jest.fn();
+    mockFallbackTypefaceDisposeByFamily[fallbackFontFamily] = dispose;
+    return { dispose, fontFamily: fallbackFontFamily };
+  },
 );
-const mockSkiaFont = jest.fn(
+const mockSkiaFont = jest.fn<SkFont, [{ fontFamily: string }, number]>(
   (typeface: { fontFamily: string }, fontSize: number) => {
     const dispose = jest.fn();
     mockFontDisposeByFamily[typeface.fontFamily] = dispose;
@@ -58,7 +78,7 @@ const mockSkiaFont = jest.fn(
             : 0,
         ),
       measureText: (text: string) => ({ width: text.length }),
-    };
+    } as unknown as SkFont;
   },
 );
 const mockCanvas = {
@@ -101,6 +121,18 @@ jest.mock('@shopify/react-native-skia', () => ({
         countFamilies: () => mockCountFontFamilies(),
         getFamilyName: (index: number) => mockGetFontFamilyName(index),
         matchFamilyStyle: (fontFamily: string) => ({ fontFamily }),
+        matchFamilyStyleCharacter: (
+          fontFamily: string,
+          fontStyle: unknown,
+          bcp47: string[],
+          character: number,
+        ) =>
+          mockMatchFamilyStyleCharacter(
+            fontFamily,
+            fontStyle,
+            bcp47,
+            character,
+          ),
       }),
     },
     Paint: () => mockCreatePaint(),
@@ -147,9 +179,9 @@ function createScene(
 }
 
 function createResources({
-  legendFontFamily = 'System',
+  legendFont = mockSkiaFont({ fontFamily: 'System' }, 11),
 }: {
-  legendFontFamily?: string;
+  legendFont?: ReturnType<typeof mockSkiaFont>;
 } = {}) {
   return createTradingViewNativeSkiaResources({
     colors: {
@@ -159,7 +191,7 @@ function createResources({
       line: '#ffffff',
     },
     fontFamily: 'System',
-    legendFontFamily,
+    legendFont,
     priceAxisFont: null,
     priceAxisFontSize: 12,
     timeAxisFontSize: 12,
@@ -198,84 +230,128 @@ describe('TradingViewNative Skia scene renderer', () => {
     jest.clearAllMocks();
     mockFontGlyphsByFamily = {};
     mockFontDisposeByFamily = {};
-    mockSystemFontFamilies = [];
+    mockFallbackFontFamilyByRequest = {};
+    mockFallbackTypefaceDisposeByFamily = {};
   });
 
-  it('keeps the primary font family without scanning when it has every glyph', () => {
+  it('keeps the primary font without requesting a fallback when it has every glyph', () => {
     const legendText = '开高低收';
     mockFontGlyphsByFamily.System = legendText;
-    mockSystemFontFamilies = ['Fallback'];
 
-    const fontFamily = getTradingViewNativeSkiaFontFamilyForText({
+    const font = createTradingViewNativeSkiaFontForText({
       fontFamily: 'System',
+      fontSize: 11,
+      locale: 'zh-CN',
       requiredText: legendText,
     });
 
-    expect(fontFamily).toBe('System');
-    expect(mockCountFontFamilies).not.toHaveBeenCalled();
-    expect(mockFontDisposeByFamily.System).toHaveBeenCalledTimes(1);
+    expect(font).toEqual(expect.objectContaining({ fontFamily: 'System' }));
+    expect(mockMatchFamilyStyleCharacter).not.toHaveBeenCalled();
+    expect(mockFontDisposeByFamily.System).not.toHaveBeenCalled();
   });
 
-  it('falls back to the primary family when no system font has every glyph', () => {
-    mockSystemFontFamilies = ['Partial', 'Missing'];
-    mockFontGlyphsByFamily.Partial = '开高';
-
-    const fontFamily = getTradingViewNativeSkiaFontFamilyForText({
+  it('keeps the primary font when the system has no fallback', () => {
+    const font = createTradingViewNativeSkiaFontForText({
       fontFamily: 'System',
+      fontSize: 11,
+      locale: 'zh-CN',
       requiredText: '开高低收',
     });
 
-    expect(fontFamily).toBe('System');
-    expect(mockFontDisposeByFamily.System).toHaveBeenCalledTimes(1);
-    expect(mockFontDisposeByFamily.Partial).toHaveBeenCalledTimes(1);
-    expect(mockFontDisposeByFamily.Missing).toHaveBeenCalledTimes(1);
+    expect(font).toEqual(expect.objectContaining({ fontFamily: 'System' }));
+    expect(mockMatchFamilyStyleCharacter).toHaveBeenCalledTimes(4);
+    expect(mockFontDisposeByFamily.System).not.toHaveBeenCalled();
   });
 
   it.each([
     {
       expectedFontFamily: 'PingFang SC',
       legendText: '开高低收',
+      locale: 'zh-CN',
     },
     {
       expectedFontFamily: 'PingFang TC',
       legendText: '開高低收',
+      locale: 'zh-TW',
     },
     {
       expectedFontFamily: 'Noto Sans CJK JP',
       legendText: '始高安終',
+      locale: 'ja-JP',
     },
     {
       expectedFontFamily: 'Noto Sans CJK KR',
       legendText: '시고저종',
+      locale: 'ko-KR',
     },
   ])(
-    'selects the first complete $expectedFontFamily fallback',
-    ({ expectedFontFamily, legendText }) => {
-      mockSystemFontFamilies = ['Partial', expectedFontFamily, 'Later'];
-      mockFontGlyphsByFamily.Partial = Array.from(legendText)[0] ?? '';
+    'passes $locale to select the locale-specific $expectedFontFamily fallback',
+    ({ expectedFontFamily, legendText, locale }) => {
+      const firstCharacter = Array.from(legendText)[0] ?? '';
+      mockFallbackFontFamilyByRequest[`${locale}:${firstCharacter}`] =
+        expectedFontFamily;
       mockFontGlyphsByFamily[expectedFontFamily] = legendText;
-      mockFontGlyphsByFamily.Later = legendText;
 
-      const fontFamily = getTradingViewNativeSkiaFontFamilyForText({
+      const font = createTradingViewNativeSkiaFontForText({
         fontFamily: 'System',
+        fontSize: 11,
+        locale,
         requiredText: legendText,
       });
 
-      expect(fontFamily).toBe(expectedFontFamily);
-      expect(mockFontDisposeByFamily.Partial).toHaveBeenCalledTimes(1);
-      expect(mockFontDisposeByFamily[expectedFontFamily]).toHaveBeenCalledTimes(
-        1,
+      expect(font).toEqual(
+        expect.objectContaining({ fontFamily: expectedFontFamily }),
       );
-      expect(mockFontDisposeByFamily.Later).toBeUndefined();
+      expect(mockMatchFamilyStyleCharacter).toHaveBeenCalledWith(
+        'System',
+        expect.any(Object),
+        [locale],
+        firstCharacter.codePointAt(0),
+      );
+      expect(mockFontDisposeByFamily.System).toHaveBeenCalledTimes(1);
+      expect(
+        mockFontDisposeByFamily[expectedFontFamily],
+      ).not.toHaveBeenCalled();
+      expect(
+        mockFallbackTypefaceDisposeByFamily[expectedFontFamily],
+      ).toHaveBeenCalledTimes(1);
     },
   );
 
-  it('builds resources from the resolved legend family without scanning', () => {
-    const resources = createResources({ legendFontFamily: 'PingFang SC' });
+  it('disposes an incomplete fallback before selecting a complete fallback', () => {
+    const legendText = '开高低收';
+    mockFallbackFontFamilyByRequest['zh-CN:开'] = 'Partial';
+    mockFallbackFontFamilyByRequest['zh-CN:高'] = 'Complete';
+    mockFontGlyphsByFamily.Partial = '开高';
+    mockFontGlyphsByFamily.Complete = legendText;
 
-    expect(resources.fonts.legend).toEqual(
-      expect.objectContaining({ fontFamily: 'PingFang SC' }),
+    const font = createTradingViewNativeSkiaFontForText({
+      fontFamily: 'System',
+      fontSize: 11,
+      locale: 'zh_CN',
+      requiredText: legendText,
+    });
+
+    expect(font).toEqual(expect.objectContaining({ fontFamily: 'Complete' }));
+    expect(mockFontDisposeByFamily.Partial).toHaveBeenCalledTimes(1);
+    expect(mockFontDisposeByFamily.Complete).not.toHaveBeenCalled();
+    expect(mockFallbackTypefaceDisposeByFamily.Partial).toHaveBeenCalledTimes(
+      1,
     );
+    expect(mockFallbackTypefaceDisposeByFamily.Complete).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('builds resources with the resolved legend font without another lookup', () => {
+    const legendFont = mockSkiaFont(
+      { fontFamily: 'Anonymous Android fallback' },
+      11,
+    );
+    const resources = createResources({ legendFont });
+
+    expect(resources.fonts.legend).toBe(legendFont);
+    expect(mockMatchFamilyStyleCharacter).not.toHaveBeenCalled();
     expect(mockCountFontFamilies).not.toHaveBeenCalled();
     expect(mockGetFontFamilyName).not.toHaveBeenCalled();
   });

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
@@ -34,6 +34,23 @@ const mockPath = {
   moveTo: jest.fn(),
 };
 const mockGradientShader = { dispose: jest.fn() };
+let mockFontGlyphsByFamily: Record<string, string> = {};
+let mockSystemFontFamilies: string[] = [];
+const mockSkiaFont = jest.fn(
+  (typeface: { fontFamily: string }, fontSize: number) => ({
+    dispose: jest.fn(),
+    fontFamily: typeface.fontFamily,
+    fontSize,
+    getGlyphIDs: (text: string) =>
+      Array.from(text).map((character) =>
+        character.charCodeAt(0) <= 127 ||
+        mockFontGlyphsByFamily[typeface.fontFamily]?.includes(character)
+          ? 1
+          : 0,
+      ),
+    measureText: (text: string) => ({ width: text.length }),
+  }),
+);
 const mockCanvas = {
   clipRect: jest.fn(),
   drawCircle: jest.fn(),
@@ -67,9 +84,14 @@ jest.mock('@shopify/react-native-skia', () => ({
   PaintStyle: { Stroke: 1 },
   Skia: {
     Color: (color: string) => color,
-    Font: () => ({ measureText: () => ({ width: 0 }) }),
+    Font: (typeface: { fontFamily: string }, fontSize: number) =>
+      mockSkiaFont(typeface, fontSize),
     FontMgr: {
-      System: () => ({ matchFamilyStyle: () => ({}) }),
+      System: () => ({
+        countFamilies: () => mockSystemFontFamilies.length,
+        getFamilyName: (index: number) => mockSystemFontFamilies[index],
+        matchFamilyStyle: (fontFamily: string) => ({ fontFamily }),
+      }),
     },
     Paint: () => mockCreatePaint(),
     Path: { Make: () => mockPath },
@@ -114,7 +136,11 @@ function createScene(
   };
 }
 
-function createResources() {
+function createResources({
+  legendText = '',
+}: {
+  legendText?: string;
+} = {}) {
   return createTradingViewNativeSkiaResources({
     colors: {
       axisText: '#999999',
@@ -123,6 +149,7 @@ function createResources() {
       line: '#ffffff',
     },
     fontFamily: 'System',
+    legendText,
     priceAxisFont: null,
     priceAxisFontSize: 12,
     timeAxisFontSize: 12,
@@ -159,7 +186,40 @@ function createPicture(
 describe('TradingViewNative Skia scene renderer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFontGlyphsByFamily = {};
+    mockSystemFontFamilies = [];
   });
+
+  it.each([
+    {
+      expectedFontFamily: 'PingFang SC',
+      legendText: '开高低收',
+    },
+    {
+      expectedFontFamily: 'PingFang TC',
+      legendText: '開高低收',
+    },
+    {
+      expectedFontFamily: 'Noto Sans CJK JP',
+      legendText: '始高安終',
+    },
+    {
+      expectedFontFamily: 'Noto Sans CJK KR',
+      legendText: '시고저종',
+    },
+  ])(
+    'uses $expectedFontFamily for localized legend glyphs',
+    ({ expectedFontFamily, legendText }) => {
+      mockSystemFontFamilies = [expectedFontFamily];
+      mockFontGlyphsByFamily[expectedFontFamily] = legendText;
+
+      const resources = createResources({ legendText });
+
+      expect(resources.fonts.legend).toEqual(
+        expect.objectContaining({ fontFamily: expectedFontFamily }),
+      );
+    },
+  );
 
   it('creates one cached SkPaint per stable custom style', () => {
     const resources = createResources();

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.ts
@@ -69,47 +69,49 @@ function createTradingViewNativeSkiaFont({
   return Skia.Font(typeface, fontSize);
 }
 
-function createTradingViewNativeSkiaFontForText({
+export function getTradingViewNativeSkiaFontFamilyForText({
   fontFamily,
-  fontManager,
-  fontSize,
   requiredText,
 }: {
   fontFamily: string;
-  fontManager: SkFontMgr;
-  fontSize: number;
   requiredText: string;
-}): SkFont {
-  'worklet';
-
+}): string {
+  const fontManager = Skia.FontMgr.System();
   const primaryFont = createTradingViewNativeSkiaFont({
     fontFamily,
     fontManager,
-    fontSize,
+    fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
   });
-  if (doesTradingViewNativeSkiaFontSupportText(primaryFont, requiredText)) {
-    return primaryFont;
+  const primaryFontSupportsText = doesTradingViewNativeSkiaFontSupportText(
+    primaryFont,
+    requiredText,
+  );
+  primaryFont.dispose();
+  if (primaryFontSupportsText) {
+    return fontFamily;
   }
 
-  for (let index = 0; index < fontManager.countFamilies(); index += 1) {
+  const systemFontFamilyCount = fontManager.countFamilies();
+  for (let index = 0; index < systemFontFamilyCount; index += 1) {
     const fallbackFontFamily = fontManager.getFamilyName(index);
     if (fallbackFontFamily && fallbackFontFamily !== fontFamily) {
       const fallbackFont = createTradingViewNativeSkiaFont({
         fontFamily: fallbackFontFamily,
         fontManager,
-        fontSize,
+        fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
       });
-      if (
-        doesTradingViewNativeSkiaFontSupportText(fallbackFont, requiredText)
-      ) {
-        primaryFont.dispose();
-        return fallbackFont;
-      }
+      const fallbackFontSupportsText = doesTradingViewNativeSkiaFontSupportText(
+        fallbackFont,
+        requiredText,
+      );
       fallbackFont.dispose();
+      if (fallbackFontSupportsText) {
+        return fallbackFontFamily;
+      }
     }
   }
 
-  return primaryFont;
+  return fontFamily;
 }
 
 export function getTradingViewNativeSkiaPaintStyleSignature(
@@ -163,7 +165,7 @@ function createTradingViewNativeSkiaPaint(
 export function createTradingViewNativeSkiaResources({
   colors,
   fontFamily,
-  legendText,
+  legendFontFamily,
   priceAxisFont,
   priceAxisFontSize,
   timeAxisFontSize,
@@ -172,7 +174,7 @@ export function createTradingViewNativeSkiaResources({
 }: {
   colors: ITradingViewNativeChartSceneColors;
   fontFamily: string;
-  legendText: string;
+  legendFontFamily: string;
   priceAxisFont: SkFont | null;
   priceAxisFontSize: number;
   timeAxisFontSize: number;
@@ -191,11 +193,10 @@ export function createTradingViewNativeSkiaResources({
     fontManager,
     fontSize: timeAxisFontSize,
   });
-  const legendFont = createTradingViewNativeSkiaFontForText({
-    fontFamily,
+  const legendFont = createTradingViewNativeSkiaFont({
+    fontFamily: legendFontFamily,
     fontManager,
     fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
-    requiredText: legendText,
   });
   const priceAxisFallbackFont = createTradingViewNativeSkiaFont({
     fontFamily,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.ts
@@ -18,7 +18,6 @@ import {
   createPicture,
 } from '@shopify/react-native-skia';
 
-import { TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE } from '../chartConstants';
 import {
   type IBuildTradingViewNativeChartSceneOptions,
   type ITradingViewNativeChartSceneColors,
@@ -49,8 +48,6 @@ function doesTradingViewNativeSkiaFontSupportText(
   font: SkFont,
   text: string,
 ): boolean {
-  'worklet';
-
   return !text || font.getGlyphIDs(text).every((glyphId) => glyphId !== 0);
 }
 
@@ -69,49 +66,59 @@ function createTradingViewNativeSkiaFont({
   return Skia.Font(typeface, fontSize);
 }
 
-export function getTradingViewNativeSkiaFontFamilyForText({
+export function createTradingViewNativeSkiaFontForText({
   fontFamily,
+  fontSize,
+  locale,
   requiredText,
 }: {
   fontFamily: string;
+  fontSize: number;
+  locale: string;
   requiredText: string;
-}): string {
+}): SkFont {
   const fontManager = Skia.FontMgr.System();
   const primaryFont = createTradingViewNativeSkiaFont({
     fontFamily,
     fontManager,
-    fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
+    fontSize,
   });
-  const primaryFontSupportsText = doesTradingViewNativeSkiaFontSupportText(
-    primaryFont,
-    requiredText,
+  const requiredCharacters = Array.from(requiredText);
+  const primaryGlyphIds = primaryFont.getGlyphIDs(requiredText);
+  const missingCharacters = requiredCharacters.filter(
+    (_character, index) => primaryGlyphIds[index] === 0,
   );
-  primaryFont.dispose();
-  if (primaryFontSupportsText) {
-    return fontFamily;
+  if (missingCharacters.length === 0) {
+    return primaryFont;
   }
 
-  const systemFontFamilyCount = fontManager.countFamilies();
-  for (let index = 0; index < systemFontFamilyCount; index += 1) {
-    const fallbackFontFamily = fontManager.getFamilyName(index);
-    if (fallbackFontFamily && fallbackFontFamily !== fontFamily) {
-      const fallbackFont = createTradingViewNativeSkiaFont({
-        fontFamily: fallbackFontFamily,
-        fontManager,
-        fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
-      });
-      const fallbackFontSupportsText = doesTradingViewNativeSkiaFontSupportText(
-        fallbackFont,
-        requiredText,
+  const checkedCodePoints = new Set<number>();
+  const bcp47 = locale ? [locale.replaceAll('_', '-')] : [];
+  for (const missingCharacter of missingCharacters) {
+    const codePoint = missingCharacter.codePointAt(0);
+    if (codePoint !== undefined && !checkedCodePoints.has(codePoint)) {
+      checkedCodePoints.add(codePoint);
+      const fallbackTypeface = fontManager.matchFamilyStyleCharacter(
+        fontFamily,
+        REGULAR_FONT_STYLE,
+        bcp47,
+        codePoint,
       );
-      fallbackFont.dispose();
-      if (fallbackFontSupportsText) {
-        return fallbackFontFamily;
+      if (fallbackTypeface) {
+        const fallbackFont = Skia.Font(fallbackTypeface, fontSize);
+        fallbackTypeface.dispose();
+        const fallbackFontSupportsText =
+          doesTradingViewNativeSkiaFontSupportText(fallbackFont, requiredText);
+        if (fallbackFontSupportsText) {
+          primaryFont.dispose();
+          return fallbackFont;
+        }
+        fallbackFont.dispose();
       }
     }
   }
 
-  return fontFamily;
+  return primaryFont;
 }
 
 export function getTradingViewNativeSkiaPaintStyleSignature(
@@ -165,7 +172,7 @@ function createTradingViewNativeSkiaPaint(
 export function createTradingViewNativeSkiaResources({
   colors,
   fontFamily,
-  legendFontFamily,
+  legendFont,
   priceAxisFont,
   priceAxisFontSize,
   timeAxisFontSize,
@@ -174,7 +181,7 @@ export function createTradingViewNativeSkiaResources({
 }: {
   colors: ITradingViewNativeChartSceneColors;
   fontFamily: string;
-  legendFontFamily: string;
+  legendFont: SkFont;
   priceAxisFont: SkFont | null;
   priceAxisFontSize: number;
   timeAxisFontSize: number;
@@ -192,11 +199,6 @@ export function createTradingViewNativeSkiaResources({
     fontFamily,
     fontManager,
     fontSize: timeAxisFontSize,
-  });
-  const legendFont = createTradingViewNativeSkiaFont({
-    fontFamily: legendFontFamily,
-    fontManager,
-    fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
   });
   const priceAxisFallbackFont = createTradingViewNativeSkiaFont({
     fontFamily,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.ts
@@ -7,6 +7,7 @@ import {
   PaintStyle,
   type SkCanvas,
   type SkFont,
+  type SkFontMgr,
   type SkPaint,
   type SkPicture,
   type SkSVG,
@@ -36,6 +37,79 @@ export interface ITradingViewNativeSkiaResources {
   paints: Record<ITradingViewNativeChartScenePaint, SkPaint>;
   watermarkPaint: SkPaint;
   watermarkSvg: SkSVG | null;
+}
+
+const REGULAR_FONT_STYLE = {
+  slant: FontSlant.Upright,
+  weight: FontWeight.Normal,
+  width: FontWidth.Normal,
+} as const;
+
+function doesTradingViewNativeSkiaFontSupportText(
+  font: SkFont,
+  text: string,
+): boolean {
+  'worklet';
+
+  return !text || font.getGlyphIDs(text).every((glyphId) => glyphId !== 0);
+}
+
+function createTradingViewNativeSkiaFont({
+  fontFamily,
+  fontManager,
+  fontSize,
+}: {
+  fontFamily: string;
+  fontManager: SkFontMgr;
+  fontSize: number;
+}): SkFont {
+  'worklet';
+
+  const typeface = fontManager.matchFamilyStyle(fontFamily, REGULAR_FONT_STYLE);
+  return Skia.Font(typeface, fontSize);
+}
+
+function createTradingViewNativeSkiaFontForText({
+  fontFamily,
+  fontManager,
+  fontSize,
+  requiredText,
+}: {
+  fontFamily: string;
+  fontManager: SkFontMgr;
+  fontSize: number;
+  requiredText: string;
+}): SkFont {
+  'worklet';
+
+  const primaryFont = createTradingViewNativeSkiaFont({
+    fontFamily,
+    fontManager,
+    fontSize,
+  });
+  if (doesTradingViewNativeSkiaFontSupportText(primaryFont, requiredText)) {
+    return primaryFont;
+  }
+
+  for (let index = 0; index < fontManager.countFamilies(); index += 1) {
+    const fallbackFontFamily = fontManager.getFamilyName(index);
+    if (fallbackFontFamily && fallbackFontFamily !== fontFamily) {
+      const fallbackFont = createTradingViewNativeSkiaFont({
+        fontFamily: fallbackFontFamily,
+        fontManager,
+        fontSize,
+      });
+      if (
+        doesTradingViewNativeSkiaFontSupportText(fallbackFont, requiredText)
+      ) {
+        primaryFont.dispose();
+        return fallbackFont;
+      }
+      fallbackFont.dispose();
+    }
+  }
+
+  return primaryFont;
 }
 
 export function getTradingViewNativeSkiaPaintStyleSignature(
@@ -89,6 +163,7 @@ function createTradingViewNativeSkiaPaint(
 export function createTradingViewNativeSkiaResources({
   colors,
   fontFamily,
+  legendText,
   priceAxisFont,
   priceAxisFontSize,
   timeAxisFontSize,
@@ -97,6 +172,7 @@ export function createTradingViewNativeSkiaResources({
 }: {
   colors: ITradingViewNativeChartSceneColors;
   fontFamily: string;
+  legendText: string;
   priceAxisFont: SkFont | null;
   priceAxisFontSize: number;
   timeAxisFontSize: number;
@@ -109,13 +185,23 @@ export function createTradingViewNativeSkiaResources({
     timeAxisBorderWidth,
   });
   const paints = {} as Record<ITradingViewNativeChartScenePaint, SkPaint>;
-  const typeface = Skia.FontMgr.System().matchFamilyStyle(fontFamily, {
-    slant: FontSlant.Upright,
-    weight: FontWeight.Normal,
-    width: FontWidth.Normal,
+  const fontManager = Skia.FontMgr.System();
+  const axisFont = createTradingViewNativeSkiaFont({
+    fontFamily,
+    fontManager,
+    fontSize: timeAxisFontSize,
   });
-  const axisFont = Skia.Font(typeface, timeAxisFontSize);
-  const priceAxisFallbackFont = Skia.Font(typeface, priceAxisFontSize);
+  const legendFont = createTradingViewNativeSkiaFontForText({
+    fontFamily,
+    fontManager,
+    fontSize: TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE,
+    requiredText: legendText,
+  });
+  const priceAxisFallbackFont = createTradingViewNativeSkiaFont({
+    fontFamily,
+    fontManager,
+    fontSize: priceAxisFontSize,
+  });
 
   for (const paintName of Object.keys(
     paintStyles,
@@ -129,7 +215,7 @@ export function createTradingViewNativeSkiaResources({
     customPaints: {},
     fonts: {
       axis: axisFont,
-      legend: Skia.Font(typeface, TRADING_VIEW_NATIVE_LEGEND_FONT_SIZE),
+      legend: legendFont,
       priceAxis: priceAxisFont ?? priceAxisFallbackFont,
     },
     paints,

--- a/patches/@shopify+react-native-skia+2.6.2.patch
+++ b/patches/@shopify+react-native-skia+2.6.2.patch
@@ -1,0 +1,105 @@
+diff --git a/node_modules/@shopify/react-native-skia/cpp/api/JsiSkFontMgr.h b/node_modules/@shopify/react-native-skia/cpp/api/JsiSkFontMgr.h
+index aec7f26..72d2ae5 100644
+--- a/node_modules/@shopify/react-native-skia/cpp/api/JsiSkFontMgr.h
++++ b/node_modules/@shopify/react-native-skia/cpp/api/JsiSkFontMgr.h
+@@ -69,13 +69,43 @@ public:
+         runtime, hostObjectInstance, getContext());
+   }
+ 
++  // OneKey patch: expose Skia's locale-aware system fallback lookup.
++  JSI_HOST_FUNCTION(matchFamilyStyleCharacter) {
++    auto name = arguments[0].asString(runtime).utf8(runtime);
++    auto resolvedName = getContext()->resolveFontFamily(name);
++    auto fontStyle = JsiSkFontStyle::fromValue(runtime, arguments[1]);
++    auto jsiBcp47 = arguments[2].asObject(runtime).asArray(runtime);
++    auto bcp47Count = static_cast<int>(jsiBcp47.size(runtime));
++    std::vector<std::string> bcp47Strings;
++    bcp47Strings.reserve(bcp47Count);
++    for (int index = 0; index < bcp47Count; index += 1) {
++      bcp47Strings.push_back(jsiBcp47.getValueAtIndex(runtime, index)
++                                 .asString(runtime)
++                                 .utf8(runtime));
++    }
++    std::vector<const char *> bcp47;
++    bcp47.reserve(bcp47Strings.size());
++    for (const auto &locale : bcp47Strings) {
++      bcp47.push_back(locale.c_str());
++    }
++    auto character = static_cast<SkUnichar>(arguments[3].asNumber());
++    auto typeface = getObject()->matchFamilyStyleCharacter(
++        resolvedName.c_str(), *fontStyle, bcp47.data(), bcp47Count, character);
++    if (!typeface) {
++      return jsi::Value::null();
++    }
++    return JsiSkTypeface::toValue(runtime, getContext(), std::move(typeface));
++  }
++
+   size_t getMemoryPressure() const override { return 2048; }
+ 
+   std::string getObjectType() const override { return "JsiSkFontMgr"; }
+ 
+   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkFontMgr, countFamilies),
+                        JSI_EXPORT_FUNC(JsiSkFontMgr, getFamilyName),
+-                       JSI_EXPORT_FUNC(JsiSkFontMgr, matchFamilyStyle))
++                       JSI_EXPORT_FUNC(JsiSkFontMgr, matchFamilyStyle),
++                       JSI_EXPORT_FUNC(JsiSkFontMgr,
++                                       matchFamilyStyleCharacter))
+ 
+ private:
+   std::vector<std::string> _systemFontFamilies;
+diff --git a/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/types/Font/FontMgr.d.ts b/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/types/Font/FontMgr.d.ts
+index eb436ae..887c298 100644
+--- a/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/types/Font/FontMgr.d.ts
++++ b/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/types/Font/FontMgr.d.ts
+@@ -5,4 +5,6 @@ export interface SkFontMgr extends SkJSIInstance<"FontMgr"> {
+     countFamilies(): number;
+     getFamilyName(index: number): string;
+     matchFamilyStyle(name: string, style: FontStyle): SkTypeface;
++    /** OneKey patch: expose locale-aware system fallback matching on native. */
++    matchFamilyStyleCharacter(name: string, style: FontStyle, bcp47: string[], character: number): SkTypeface | null;
+ }
+diff --git a/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/web/JsiSkFontMgr.d.ts b/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/web/JsiSkFontMgr.d.ts
+index cbba94c..60a1b8d 100644
+--- a/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/web/JsiSkFontMgr.d.ts
++++ b/node_modules/@shopify/react-native-skia/lib/typescript/src/skia/web/JsiSkFontMgr.d.ts
+@@ -7,4 +7,6 @@ export declare class JsiSkFontMgr extends HostObject<FontMgr, "FontMgr"> impleme
+     countFamilies(): number;
+     getFamilyName(index: number): string;
+     matchFamilyStyle(_familyName: string, _fontStyle: FontStyle): SkTypeface;
++    /** OneKey patch: keep the native-only fallback API explicit on web. */
++    matchFamilyStyleCharacter(_familyName: string, _fontStyle: FontStyle, _bcp47: string[], _character: number): SkTypeface;
+ }
+diff --git a/node_modules/@shopify/react-native-skia/src/skia/types/Font/FontMgr.ts b/node_modules/@shopify/react-native-skia/src/skia/types/Font/FontMgr.ts
+index 7dce039..808e458 100644
+--- a/node_modules/@shopify/react-native-skia/src/skia/types/Font/FontMgr.ts
++++ b/node_modules/@shopify/react-native-skia/src/skia/types/Font/FontMgr.ts
+@@ -7,4 +7,11 @@ export interface SkFontMgr extends SkJSIInstance<"FontMgr"> {
+   countFamilies(): number;
+   getFamilyName(index: number): string;
+   matchFamilyStyle(name: string, style: FontStyle): SkTypeface;
++  // OneKey patch: expose locale-aware system fallback matching on native.
++  matchFamilyStyleCharacter(
++    name: string,
++    style: FontStyle,
++    bcp47: string[],
++    character: number
++  ): SkTypeface | null;
+ }
+diff --git a/node_modules/@shopify/react-native-skia/src/skia/web/JsiSkFontMgr.ts b/node_modules/@shopify/react-native-skia/src/skia/web/JsiSkFontMgr.ts
+index 79a3448..e2b11ce 100644
+--- a/node_modules/@shopify/react-native-skia/src/skia/web/JsiSkFontMgr.ts
++++ b/node_modules/@shopify/react-native-skia/src/skia/web/JsiSkFontMgr.ts
+@@ -24,4 +24,13 @@ export class JsiSkFontMgr
+   matchFamilyStyle(_familyName: string, _fontStyle: FontStyle) {
+     return throwNotImplementedOnRNWeb<SkTypeface>();
+   }
++  // OneKey patch: keep the native-only fallback API explicit on web.
++  matchFamilyStyleCharacter(
++    _familyName: string,
++    _fontStyle: FontStyle,
++    _bcp47: string[],
++    _character: number
++  ) {
++    return throwNotImplementedOnRNWeb<SkTypeface>();
++  }
+ }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60853](https://onekeyhq.atlassian.net/browse/OK-60853)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- fix missing-glyph boxes in localized OHLC labels on the native Skia chart
- use Skia's locale-aware character fallback so Simplified Chinese, Traditional Chinese, Japanese, and Korean select the correct regional glyphs
- support Android system fallback typefaces that do not expose a family name
- resolve the legend font once on the JS thread by label text and locale, then reuse the same `SkFont` for measurement, drawing, and Skia resource rebuilds
- expose Skia's existing `matchFamilyStyleCharacter` API through a minimal RN Skia patch

## Root cause

The native chart created a Skia font from a single `System` / `sans-serif` typeface. Unlike React Native `Text`, Skia `drawText` does not perform per-glyph platform font fallback, so localized CJK abbreviations resolved to missing glyphs. The RN Skia JS API also did not expose Skia's locale-aware character fallback, and enumerating named families cannot reach Android's anonymous fallback typefaces or reliably select regional CJK glyph variants.

## Test plan

- `yarn jest packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts --runInBand`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- compile the Android arm64 `rnskia` native target after applying the JSI patch
- apply the generated patch to a pristine RN Skia 2.6.2 package and verify it contains no `android/build` artifacts

Issue: OK-60853

[OK-60853]: https://onekeyhq.atlassian.net/browse/OK-60853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ