### PR TITLE
fix: render air-gap QR codes in line style (OK-61349)

### DIFF
--- a/packages/components/src/content/QRCode/QRCode.stories.tsx
+++ b/packages/components/src/content/QRCode/QRCode.stories.tsx
@@ -35,8 +35,9 @@ export const WithLogo: Story = {
   },
 };
 
-// 'line' is the pre-OK-59643 style, kept as a rollback escape hatch. No
-// production caller passes it any more.
+// 'line' is the pre-OK-59643 style. Static codes stay dot, but air-gap UR
+// codes default back to line because some hardware scanners cannot reliably
+// decode dots.
 export const LineStyle: Story = {
   args: {
     drawType: 'line',

--- a/packages/components/src/content/QRCode/index.tsx
+++ b/packages/components/src/content/QRCode/index.tsx
@@ -228,6 +228,7 @@ export function QRCode({
   padding = 10,
   quietZoneModules = 0,
   onRenderReady,
+  drawType,
   ...props
 }: IQRCodeProps) {
   const [partValue, setPartValue] = useState<string>(value || '');
@@ -345,6 +346,10 @@ export function QRCode({
         <BasicQRCode
           value={displayValue}
           {...props}
+          // Air-gap UR frames are read by hardware-wallet cameras, and some
+          // device scanners cannot reliably decode the dot style, so UR-driven
+          // codes default to line while static codes stay dot.
+          drawType={drawType ?? (valueUr ? 'line' : 'dot')}
           size={qrCodeSize}
           logoSize={scaledLogoSize}
           logoMargin={scaledLogoMargin}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61349](https://onekeyhq.atlassian.net/browse/OK-61349)

----------

<!-- github-pr-monitor:jira-links:end -->


## What

Air-gap UR QR codes (the animated codes hardware wallets scan from the app screen, shown in the "Confirm on device" toast) now render in the classic line style again. Every other QR code in the app keeps the dot style introduced by #12859 (OK-59643).

## Why

Some of the hardware products currently in development have weaker QR scanning modules and decode the dot style unreliably. The air-gap scanning scenario is the one place where a hardware camera is the audience, so it goes back to the line style that scanners were originally validated against.

## How

Single decision point in the `QRCode` component: when the code is driven by `valueUr` (air-gap UR frames), `drawType` now defaults to `'line'`; static codes keep the `'dot'` default, and an explicit `drawType` prop still overrides both. Since every production air-gap surface funnels through `ServiceQrWallet` → `ShowAirGapQrcode` → `SecureQRToast` with a required `valueUr`, no call-site changes are needed, and the two dev gallery pages that render UR codes directly are covered as well. The line renderer was kept as an escape hatch in #12859, so this only changes the default, not the rendering code.

## Notes for reviewers

- The `SecureQRToast` gallery story feeds a plain `value` (no UR), so it intentionally still shows dots; production always passes `valueUr`.
- Verified on hardware: the new device scans the line-style animated code successfully, and existing devices show no regression.
- `yarn agent:check --profile commit` green; the 13 existing QRCode geometry tests pass.

[OK-61349]: https://onekeyhq.atlassian.net/browse/OK-61349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ