### PR TITLE
fix: scope prime transfer c2c rate-limit state per connection

### DIFF
--- a/packages/kit-bg/src/services/ServicePrimeTransfer/e2ee/JsBridgeE2EEClientToClient.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/e2ee/JsBridgeE2EEClientToClient.ts
@@ -12,6 +12,11 @@ import type { Socket } from 'socket.io';
 
 const RATE_LIMIT_INTERVAL_MS = 3500;
 
+// Upper bound on distinct methods tracked per connection. `method` comes from
+// the remote peer, so without a cap a single peer could grow this map forever.
+// Well above the number of methods a real peer calls.
+const RATE_LIMIT_MAX_TRACKED_METHODS = 64;
+
 // Rate limiting whitelist - methods that are exempt from rate limiting
 const RATE_LIMIT_WHITELIST = new Set([
   'changeTransferDirection',
@@ -46,11 +51,14 @@ export class JsBridgeE2EEClientToClient extends JsBridgeBase {
   // reconnect (which mints a fresh id) leaked one entry per method for the
   // lifetime of the process. Dropping socket.id from the key keeps the map
   // bounded by method name and stable across reconnects, and the map is freed
-  // with the instance. We deliberately do NOT attach a socket 'disconnect'
-  // listener to clear it (as the server does): the client socket is long-lived
-  // and this bridge is re-created on it (e.g. QR refresh -> joinRoom), where
-  // setup() detaches the superseded instance's c2c listener so it can be GC'd -
-  // a disconnect listener would pin that old instance and reintroduce a leak.
+  // with the instance. `method` is still peer-controlled, so the entry count is
+  // additionally capped at RATE_LIMIT_MAX_TRACKED_METHODS, reclaiming expired
+  // windows only (see pruneRateLimitState). We deliberately do NOT attach a
+  // socket 'disconnect' listener to clear it (as the server does): the client
+  // socket is long-lived and this bridge is re-created on it (e.g. QR refresh
+  // -> joinRoom), where setup() detaches the superseded instance's c2c listener
+  // so it can be GC'd - a disconnect listener would pin that old instance and
+  // reintroduce a leak.
   private rateLimitState = new Map<string, number>();
 
   override sendAsString = false;
@@ -65,26 +73,60 @@ export class JsBridgeE2EEClientToClient extends JsBridgeBase {
     sendErrorResponse: () => void;
   }) {
     // Rate limiting check
-    const req: IJsonRpcRequest = payload.data as IJsonRpcRequest;
+    const req = payload?.data as IJsonRpcRequest | undefined;
+    const method = typeof req?.method === 'string' ? req.method : '';
 
     // Check if method is in whitelist
-    if (RATE_LIMIT_WHITELIST.has(req.method)) {
+    if (RATE_LIMIT_WHITELIST.has(method)) {
       return false;
     }
 
     // no socket id in the key: this map already belongs to this connection
-    const rateLimitKey = `${eventName}:${req.method}`;
+    const rateLimitKey = `${eventName}:${method}`;
 
     const now = Date.now();
-    const lastTime = this.rateLimitState.get(rateLimitKey) || 0;
+    const lastTime = this.rateLimitState.get(rateLimitKey);
 
-    if (now - lastTime < RATE_LIMIT_INTERVAL_MS) {
+    if (lastTime !== undefined && now - lastTime < RATE_LIMIT_INTERVAL_MS) {
       sendErrorResponse();
       return true;
     }
 
+    if (
+      lastTime === undefined &&
+      this.rateLimitState.size >= RATE_LIMIT_MAX_TRACKED_METHODS
+    ) {
+      this.pruneRateLimitState(now);
+
+      if (this.rateLimitState.size >= RATE_LIMIT_MAX_TRACKED_METHODS) {
+        // Every tracked window is still live, so this peer is flooding distinct
+        // method names. Refuse to track a new one and treat it as limited: the
+        // flood throttles itself and the existing windows - the expensive calls
+        // it is trying to reset - stay intact.
+        sendErrorResponse();
+        return true;
+      }
+    }
+
     this.rateLimitState.set(rateLimitKey, now);
     return false;
+  }
+
+  /**
+   * Reclaim entries whose window has already passed - they cannot rate limit
+   * anything any more.
+   *
+   * This only ever drops expired entries. Live windows are never touched: since
+   * `method` is peer-controlled, wiping the map on a flood would let the
+   * flooder reset the windows of the calls it was just blocked on, turning the
+   * bound into a rate-limit bypass.
+   */
+  private pruneRateLimitState(now: number): void {
+    Array.from(this.rateLimitState.entries()).forEach(([key, time]) => {
+      if (now - time >= RATE_LIMIT_INTERVAL_MS) {
+        this.rateLimitState.delete(key);
+      }
+    });
   }
 
   sendPayload(payload: IJsBridgeMessagePayload): void {

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/e2ee/JsBridgeE2EEClientToClient.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/e2ee/JsBridgeE2EEClientToClient.ts
@@ -11,7 +11,6 @@ import type {
 import type { Socket } from 'socket.io';
 
 const RATE_LIMIT_INTERVAL_MS = 3500;
-const lastRequestTime: Map<string, number> = new Map();
 
 // Rate limiting whitelist - methods that are exempt from rate limiting
 const RATE_LIMIT_WHITELIST = new Set([
@@ -42,6 +41,18 @@ export class JsBridgeE2EEClientToClient extends JsBridgeBase {
 
   isProxySide: boolean;
 
+  // Rate limit state held per bridge instance instead of a module-level map.
+  // The old map was keyed by socket.id and never pruned, so every socket.io
+  // reconnect (which mints a fresh id) leaked one entry per method for the
+  // lifetime of the process. Dropping socket.id from the key keeps the map
+  // bounded by method name and stable across reconnects, and the map is freed
+  // with the instance. We deliberately do NOT attach a socket 'disconnect'
+  // listener to clear it (as the server does): the client socket is long-lived
+  // and this bridge is re-created on it (e.g. QR refresh -> joinRoom), where
+  // setup() detaches the superseded instance's c2c listener so it can be GC'd -
+  // a disconnect listener would pin that old instance and reintroduce a leak.
+  private rateLimitState = new Map<string, number>();
+
   override sendAsString = false;
 
   checkIsRateLimited({
@@ -61,17 +72,18 @@ export class JsBridgeE2EEClientToClient extends JsBridgeBase {
       return false;
     }
 
-    const rateLimitKey = `${this.socket.id}:${eventName}:${req.method}`;
+    // no socket id in the key: this map already belongs to this connection
+    const rateLimitKey = `${eventName}:${req.method}`;
 
     const now = Date.now();
-    const lastTime = lastRequestTime.get(rateLimitKey) || 0;
+    const lastTime = this.rateLimitState.get(rateLimitKey) || 0;
 
     if (now - lastTime < RATE_LIMIT_INTERVAL_MS) {
       sendErrorResponse();
       return true;
     }
 
-    lastRequestTime.set(rateLimitKey, now);
+    this.rateLimitState.set(rateLimitKey, now);
     return false;
   }
 


### PR DESCRIPTION
## Summary
Part of a security review of the Prime Transfer E2EE flow (server-side changes live in the e2ee-server repo). This fixes a client-side memory leak in the client-to-client bridge&#39;s rate limiter.

## Change
`JsBridgeE2EEClientToClient` kept rate-limit state in a **module-level** `Map` keyed by `${socket.id}:${event}:${method}`, never pruned. socket.io assigns a fresh `socket.id` on every reconnect, so the map grew by one entry per method on every reconnect for the lifetime of the process.

Moved the state onto the bridge instance and dropped `socket.id` from the key, so it is bounded by method name, stable across reconnects, and freed with the instance. No socket `disconnect` listener is added (unlike the server): the client socket is long-lived and the bridge is re-created on it (e.g. QR refresh → joinRoom), where `setup()` already detaches the superseded instance&#39;s listener so it can be GC&#39;d — a disconnect listener would pin the old instance instead.

Follow-ups from review of that same function:

- **Per-instance bound on the map.** The key still ends in `req.method`, which arrives from the remote peer over the c2c channel, so a peer could grow the map without limit by varying the method name. Tracked methods are now capped at 64 per bridge instance (`RATE_LIMIT_MAX_TRACKED_METHODS`), mirroring the server side of this same bridge. On overflow only entries whose window has already expired are reclaimed (`pruneRateLimitState`); if every window is still live the call is treated as rate limited instead of tracking a new one. Pruning expired entries only is deliberate — wiping the map on a flood would let the flooder reset the windows of the calls it was just blocked on, turning the bound into a rate-limit bypass. `lastTime` is now read with an `undefined` check rather than `|| 0` so &quot;never seen&quot; is distinguishable from &quot;seen&quot; (behaviourally identical otherwise, since `Date.now()` is never 0).
- **Null-safe method extraction.** The function read `payload.data.method` directly, so a room peer emitting `e2ee-c2c-request` with missing or non-object `data` made the property read throw inside an async socket.io listener — an unhandled rejection on the client. The method is now extracted as `typeof req?.method === 'string' ? req.method : ''` and that local is used for both the whitelist check and the key.

Interval (3.5s), whitelist contents and rate-limit semantics for well-formed traffic are unchanged.

## Testing
Repo checks (`yarn agent:check --profile commit`) could not be run in this environment — `node_modules` is not installed there — so CI lint, typecheck and the unit-test matrix are the authoritative validation for this push.

What was verified locally:
- The changed file type-checks clean under an isolated `tsc --noEmit` harness using the real `@onekeyfe/cross-inpage-provider-*` and `socket.io` type definitions (from a sibling checkout) with the repo&#39;s compiler options; only the two `@onekeyhq/shared` locale imports were stubbed.
- A standalone Node script re-running the final rate-limit logic: a repeat call inside the window is limited and sends the error response; a call after the window elapses is not (and 1 ms before the window ends still is); a flood of 500 distinct method names keeps the map at ≤ 64 entries, throttles itself, and leaves the live window of a previously blocked method intact; once all windows expire, pruning frees the map and new methods are accepted again; nine malformed payload shapes (`data` missing/null/string/number/array, `method` missing/number/object/null) do not throw and collapse onto a single empty-method key; whitelisted methods are still never limited or tracked. All 20 checks passed.

Rate-limiter behavior is unchanged (per-connection, per-method, 3.5s window). No functional change to pairing or transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuowqYp863fJaNNjEKvhPT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuowqYp863fJaNNjEKvhPT)_