### PR TITLE
fix: remove 0x token tax metadata(OK-61351)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -13,6 +13,7 @@ import {
   shouldShowSwapAccountUnsupportedAlert,
 } from '@onekeyhq/kit/src/views/Swap/utils/swapNoWalletWarningGuard';
 import { buildSwapRateDifference } from '@onekeyhq/kit/src/views/Swap/utils/swapRateDifferenceUtils';
+import { getSwapQuoteTokenTaxPercentages } from '@onekeyhq/kit/src/views/Swap/utils/swapTokenTaxUtils';
 import {
   isUSMarketStatusStockTokenSource,
   shouldCheckSwapWarningUSMarketClosed,
@@ -143,7 +144,6 @@ import {
   swapToTokenAmountAtom,
   swapTokenFetchingAtom,
   swapTokenMapAtom,
-  swapTokenMetadataAtom,
   swapTypeSwitchAtom,
   swapWarningRequestIdAtom,
 } from './atoms';
@@ -1720,7 +1720,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const networks = get(swapNetworks());
       const swapSupportAllNetworks = get(swapNetworksIncludeAllNetworkAtom());
       const quoteResult = get(swapQuoteCurrentSelectAtom());
-      const tokenMetadata = get(swapTokenMetadataAtom());
       const quoteLoading =
         get(swapQuoteFetchingAtom()) || get(swapSilenceQuoteLoading());
       const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
@@ -2186,89 +2185,64 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         });
       }
 
-      if (tokenMetadata?.swapTokenMetadata) {
-        const { buyToken, sellToken } = tokenMetadata.swapTokenMetadata;
-        const buyTokenBuyTaxBN = new BigNumber(
-          buyToken?.buyTaxBps ? buyToken?.buyTaxBps : 0,
-        );
-        const buyTokenSellTaxBN = new BigNumber(
-          buyToken?.sellTaxBps ? buyToken?.sellTaxBps : 0,
-        );
-        const sellTokenBuyTaxBN = new BigNumber(
-          sellToken?.buyTaxBps ? sellToken?.buyTaxBps : 0,
-        );
-        const sellTokenSellTaxBN = new BigNumber(
-          sellToken?.sellTaxBps ? sellToken?.sellTaxBps : 0,
-        );
-        if (buyTokenBuyTaxBN.gt(0) || buyTokenSellTaxBN.gt(0)) {
-          // eslint-disable-next-line onekey/no-app-locale-main-thread
-          const actionLabel = appLocale.intl.formatMessage({
-            id: buyTokenSellTaxBN.gt(buyTokenBuyTaxBN)
-              ? ETranslations.swap_page_alert_tax_detected_sell
-              : ETranslations.swap_page_alert_tax_detected_buy,
-          });
+      const { buyTaxPercentage, sellTaxPercentage } =
+        getSwapQuoteTokenTaxPercentages(quoteResult);
+      if (buyTaxPercentage) {
+        // eslint-disable-next-line onekey/no-app-locale-main-thread
+        const actionLabel = appLocale.intl.formatMessage({
+          id: ETranslations.swap_page_alert_tax_detected_buy,
+        });
+        alertsRes = [
+          ...alertsRes,
+          {
+            icon: 'HandCoinsOutline',
+            // eslint-disable-next-line onekey/no-app-locale-main-thread
+            title: appLocale.intl.formatMessage(
+              {
+                id: ETranslations.swap_page_alert_tax_detected_title,
+              },
+              {
+                percentage: `${buyTaxPercentage}%`,
+                token: toToken?.symbol ?? '',
+                action: actionLabel,
+              },
+            ),
+            // eslint-disable-next-line onekey/no-app-locale-main-thread
+            message: appLocale.intl.formatMessage({
+              id: ETranslations.swap_page_alert_tax_detected,
+            }),
+            alertLevel: ESwapAlertLevel.INFO,
+          },
+        ];
+      }
 
-          const showTax = BigNumber.maximum(
-            buyTokenSellTaxBN,
-            buyTokenBuyTaxBN,
-          );
-          alertsRes = [
-            ...alertsRes,
-            {
-              icon: 'HandCoinsOutline',
-              // eslint-disable-next-line onekey/no-app-locale-main-thread
-              title: appLocale.intl.formatMessage(
-                {
-                  id: ETranslations.swap_page_alert_tax_detected_title,
-                },
-                {
-                  percentage: `${showTax.dividedBy(100).toNumber()}%`,
-                  token: toToken?.symbol ?? '',
-                  action: actionLabel,
-                },
-              ),
-              // eslint-disable-next-line onekey/no-app-locale-main-thread
-              message: appLocale.intl.formatMessage({
-                id: ETranslations.swap_page_alert_tax_detected,
-              }),
-              alertLevel: ESwapAlertLevel.INFO,
-            },
-          ];
-        }
-        if (sellTokenBuyTaxBN.gt(0) || sellTokenSellTaxBN.gt(0)) {
-          // eslint-disable-next-line onekey/no-app-locale-main-thread
-          const actionLabel = appLocale.intl.formatMessage({
-            id: sellTokenSellTaxBN.gt(sellTokenBuyTaxBN)
-              ? ETranslations.swap_page_alert_tax_detected_sell
-              : ETranslations.swap_page_alert_tax_detected_buy,
-          });
-          const showTax = BigNumber.maximum(
-            sellTokenBuyTaxBN,
-            sellTokenSellTaxBN,
-          );
-          alertsRes = [
-            ...alertsRes,
-            {
-              icon: 'HandCoinsOutline',
-              // eslint-disable-next-line onekey/no-app-locale-main-thread
-              title: appLocale.intl.formatMessage(
-                {
-                  id: ETranslations.swap_page_alert_tax_detected_title,
-                },
-                {
-                  percentage: `${showTax.dividedBy(100).toNumber()}%`,
-                  token: fromToken?.symbol ?? '',
-                  action: actionLabel,
-                },
-              ),
-              // eslint-disable-next-line onekey/no-app-locale-main-thread
-              message: appLocale.intl.formatMessage({
-                id: ETranslations.swap_page_alert_tax_detected,
-              }),
-              alertLevel: ESwapAlertLevel.INFO,
-            },
-          ];
-        }
+      if (sellTaxPercentage) {
+        // eslint-disable-next-line onekey/no-app-locale-main-thread
+        const actionLabel = appLocale.intl.formatMessage({
+          id: ETranslations.swap_page_alert_tax_detected_sell,
+        });
+        alertsRes = [
+          ...alertsRes,
+          {
+            icon: 'HandCoinsOutline',
+            // eslint-disable-next-line onekey/no-app-locale-main-thread
+            title: appLocale.intl.formatMessage(
+              {
+                id: ETranslations.swap_page_alert_tax_detected_title,
+              },
+              {
+                percentage: `${sellTaxPercentage}%`,
+                token: fromToken?.symbol ?? '',
+                action: actionLabel,
+              },
+            ),
+            // eslint-disable-next-line onekey/no-app-locale-main-thread
+            message: appLocale.intl.formatMessage({
+              id: ETranslations.swap_page_alert_tax_detected,
+            }),
+            alertLevel: ESwapAlertLevel.INFO,
+          },
+        ];
       }
 
       // check limit native should wrapped

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -47,7 +47,6 @@ import type {
   ISwapTips,
   ISwapToken,
   ISwapTokenCatch,
-  ISwapTokenMetadata,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { createJotaiContext } from '../../utils/createJotaiContext';
@@ -427,19 +426,6 @@ export const {
       swapTypeSwitch === ESwapTabSwitchType.STOCK,
   });
 });
-
-export const { atom: swapTokenMetadataAtom, use: useSwapTokenMetadataAtom } =
-  contextAtomComputed<{
-    swapTokenMetadata?: ISwapTokenMetadata;
-  }>((get) => {
-    const quoteList = get(swapQuoteListAtom());
-    const swapTokenMetadata = quoteList.find(
-      (item) => item.tokenMetadata,
-    )?.tokenMetadata;
-    return {
-      swapTokenMetadata,
-    };
-  });
 
 export const { atom: swapQuoteFetchingAtom, use: useSwapQuoteFetchingAtom } =
   contextAtom<boolean>(false);

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -23,7 +23,6 @@ import {
   useSwapQuoteListAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
-  useSwapTokenMetadataAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import {
@@ -46,8 +45,7 @@ import {
   ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
   type IFetchQuoteResult,
-  type ISwapToken,
-  type ISwapTokenMetadata,
+  type ISwapTokenBase,
 } from '@onekeyhq/shared/types/swap/types';
 
 import LimitExpirySelect from '../../components/LimitExpirySelect';
@@ -63,6 +61,7 @@ import {
   useSwapQuoteProgressState,
 } from '../../hooks/useSwapState';
 import { SwapTestIDs } from '../../testIDs';
+import { getSwapQuoteTokenTaxPercentages } from '../../utils/swapTokenTaxUtils';
 
 import SwapApproveAllowanceSelectContainer from './SwapApproveAllowanceSelectContainer';
 import SwapSlippageTriggerContainer from './SwapSlippageTriggerContainer';
@@ -85,7 +84,6 @@ const SwapQuoteResult = ({
   const [toToken] = useSwapSelectToTokenAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
-  const [swapTokenMetadata] = useSwapTokenMetadataAtom();
   const [swapQuoteList] = useSwapQuoteListAtom();
 
   const [
@@ -134,13 +132,7 @@ const SwapQuoteResult = ({
   }, [slippageItem.key, slippageItem.value]);
 
   const calculateTaxItem = useCallback(
-    (
-      tokenBuyTaxBps: BigNumber,
-      tokenSellTaxBps: BigNumber,
-      tokenInfo?: ISwapToken,
-    ) => {
-      const showTax = BigNumber.maximum(tokenBuyTaxBps, tokenSellTaxBps);
-      const finalShowTax = showTax.dividedBy(100).toNumber();
+    (taxPercentage: string, tokenInfo?: ISwapTokenBase) => {
       return (
         <SwapCommonInfoItem
           title={intl.formatMessage(
@@ -151,7 +143,7 @@ const SwapQuoteResult = ({
           )}
           isLoading={swapQuoteLoading}
           valueComponent={
-            <SizableText size="$bodyMdMedium">{`${finalShowTax}%`}</SizableText>
+            <SizableText size="$bodyMdMedium">{`${taxPercentage}%`}</SizableText>
           }
         />
       );
@@ -159,51 +151,8 @@ const SwapQuoteResult = ({
     [intl, swapQuoteLoading],
   );
 
-  const tokenMetadataParse = useCallback(
-    (
-      tokenMetadata: ISwapTokenMetadata,
-      fromTokenInfo?: ISwapToken,
-      toTokenInfo?: ISwapToken,
-    ) => {
-      const buyToken = tokenMetadata?.buyToken;
-      const sellToken = tokenMetadata?.sellToken;
-      let buyTaxItem = null;
-      let sellTaxItem = null;
-      const buyTokenBuyTaxBps = new BigNumber(
-        buyToken?.buyTaxBps ? buyToken?.buyTaxBps : 0,
-      );
-      const buyTokenSellTaxBps = new BigNumber(
-        buyToken?.sellTaxBps ? buyToken?.sellTaxBps : 0,
-      );
-      const sellTokenBuyTaxBps = new BigNumber(
-        sellToken?.buyTaxBps ? sellToken?.buyTaxBps : 0,
-      );
-      const sellTokenSellTaxBps = new BigNumber(
-        sellToken?.sellTaxBps ? sellToken?.sellTaxBps : 0,
-      );
-      if (buyTokenBuyTaxBps.gt(0) || buyTokenSellTaxBps.gt(0)) {
-        buyTaxItem = calculateTaxItem(
-          buyTokenBuyTaxBps,
-          buyTokenSellTaxBps,
-          toTokenInfo,
-        );
-      }
-      if (sellTokenBuyTaxBps.gt(0) || sellTokenSellTaxBps.gt(0)) {
-        sellTaxItem = calculateTaxItem(
-          sellTokenBuyTaxBps,
-          sellTokenSellTaxBps,
-          fromTokenInfo,
-        );
-      }
-      return (
-        <>
-          {sellTaxItem}
-          {buyTaxItem}
-        </>
-      );
-    },
-    [calculateTaxItem],
-  );
+  const { buyTaxPercentage, sellTaxPercentage } =
+    getSwapQuoteTokenTaxPercentages(quoteResultForDisplay);
 
   const quoting = isWaitingActionableQuote;
 
@@ -482,11 +431,16 @@ const SwapQuoteResult = ({
                   }
                 />
               ) : null}
-              {swapTokenMetadata?.swapTokenMetadata
-                ? tokenMetadataParse(
-                    swapTokenMetadata?.swapTokenMetadata,
-                    fromToken,
-                    toToken,
+              {sellTaxPercentage
+                ? calculateTaxItem(
+                    sellTaxPercentage,
+                    quoteResultForDisplay?.fromTokenInfo,
+                  )
+                : null}
+              {buyTaxPercentage
+                ? calculateTaxItem(
+                    buyTaxPercentage,
+                    quoteResultForDisplay?.toTokenInfo,
                   )
                 : null}
             </Accordion.Content>

--- a/packages/kit/src/views/Swap/utils/swapTokenTaxUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapTokenTaxUtils.test.ts
@@ -1,0 +1,48 @@
+import {
+  formatSwapTokenTaxPercentage,
+  getSwapQuoteTokenTaxPercentages,
+} from './swapTokenTaxUtils';
+
+describe('formatSwapTokenTaxPercentage', () => {
+  it('formats a quote tax ratio as a percentage', () => {
+    expect(formatSwapTokenTaxPercentage(0.03)).toBe('3');
+    expect(formatSwapTokenTaxPercentage(0.0497)).toBe('4.97');
+    expect(formatSwapTokenTaxPercentage(0.0305)).toBe('3.05');
+  });
+
+  it('hides missing, zero, and invalid tax rates', () => {
+    expect(formatSwapTokenTaxPercentage()).toBeUndefined();
+    expect(formatSwapTokenTaxPercentage(0)).toBeUndefined();
+    expect(formatSwapTokenTaxPercentage(-0.03)).toBeUndefined();
+    expect(formatSwapTokenTaxPercentage(Number.NaN)).toBeUndefined();
+  });
+});
+
+describe('getSwapQuoteTokenTaxPercentages', () => {
+  it('uses tax fields from the selected quote', () => {
+    expect(
+      getSwapQuoteTokenTaxPercentages({ buyTax: 0.03, sellTax: 0.0497 }),
+    ).toEqual({
+      buyTaxPercentage: '3',
+      sellTaxPercentage: '4.97',
+    });
+  });
+
+  it('ignores legacy provider metadata', () => {
+    const quoteWithLegacyProviderMetadata = {
+      buyTax: 0,
+      sellTax: 0,
+      tokenMetadata: {
+        buyToken: { buyTaxBps: '300', sellTaxBps: '300' },
+        sellToken: { buyTaxBps: '300', sellTaxBps: '300' },
+      },
+    };
+
+    expect(
+      getSwapQuoteTokenTaxPercentages(quoteWithLegacyProviderMetadata),
+    ).toEqual({
+      buyTaxPercentage: undefined,
+      sellTaxPercentage: undefined,
+    });
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapTokenTaxUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapTokenTaxUtils.ts
@@ -1,0 +1,20 @@
+import BigNumber from 'bignumber.js';
+
+import type { IFetchQuoteResult } from '@onekeyhq/shared/types/swap/types';
+
+export function formatSwapTokenTaxPercentage(taxRate?: number) {
+  const taxRateBN = new BigNumber(taxRate ?? 0);
+  if (!taxRateBN.isFinite() || taxRateBN.lte(0)) {
+    return undefined;
+  }
+  return taxRateBN.multipliedBy(100).toFixed();
+}
+
+export function getSwapQuoteTokenTaxPercentages(
+  quoteResult?: Pick<IFetchQuoteResult, 'buyTax' | 'sellTax'>,
+) {
+  return {
+    buyTaxPercentage: formatSwapTokenTaxPercentage(quoteResult?.buyTax),
+    sellTaxPercentage: formatSwapTokenTaxPercentage(quoteResult?.sellTax),
+  };
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -434,17 +434,6 @@ export interface IQuoteRoutePath {
   subRoutes?: IQuoteRouteDataInfo[][];
 }
 
-export interface ISwapTokenMetadata {
-  buyToken: {
-    buyTaxBps: string;
-    sellTaxBps: string;
-  };
-  sellToken: {
-    buyTaxBps: string;
-    sellTaxBps: string;
-  };
-}
-
 export interface IQuoteTip {
   icon?: string;
   title?: string;
@@ -715,12 +704,13 @@ export interface IFetchQuoteResult {
   supportUrl?: string;
   orderSupportUrl?: string;
   isAntiMEV?: boolean;
-  tokenMetadata?: ISwapTokenMetadata;
   quoteShowTip?: IQuoteTip;
   valueDropPercent?: number;
   gasLimit?: number;
   slippage?: number;
   providerDisableBatchTransfer?: boolean;
+  buyTax?: number;
+  sellTax?: number;
 }
 
 export interface IAllowanceResult {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61351](https://onekeyhq.atlassian.net/browse/OK-61351)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Remove the legacy 0x `tokenMetadata` tax path from Swap quote state, warnings, and quote details.
- Read `buyTax` and `sellTax` only from the currently selected quote and format backend tax ratios as percentages.
- Add regression coverage that prevents legacy provider metadata from triggering token-tax UI.

## Intent & Context
Fix [OK-61351](https://onekeyhq.atlassian.net/browse/OK-61351). Swap could display a 3% token tax from a 0x quote even when another provider was selected and the backend GoPlus token tax was zero. The tax information should remain available, but its source must be the backend fields attached to the active quote rather than provider-specific 0x metadata.

## Root Cause
`swapTokenMetadataAtom` scanned the full quote list with `find(item => item.tokenMetadata)` and exposed the first provider metadata it found. Both the quote detail UI and Swap warnings consumed that detached value, so the displayed tax did not belong to the selected quote.

## Design Decisions
- Treat the selected quote as the state owner for token tax data.
- Map `buyTax` to the target token buy action and `sellTax` to the source token sell action.
- Convert backend tax ratios to percentages with `BigNumber`; missing, invalid, zero, and negative values are not displayed.
- Do not fall back to legacy 0x metadata when the backend fields are absent.
- Bind quote-detail tax labels to the same quote token objects as the tax values to avoid refresh-time mismatches.

## Changes Detail
- Remove the legacy token metadata type and computed atom.
- Update Swap warning and quote-detail consumers to use root quote tax fields.
- Add a focused tax formatting and legacy-metadata regression utility test.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Risk Areas**: Backend tax-field availability, buy/sell direction mapping, and quote refresh state.
- **Runtime Boundary**: Extension and Mobile receive the primitive tax fields through the background quote event path; Desktop and Web use the same quote data in a single runtime. No storage or native resource changes are involved.

## Test plan
- [x] `NODE_OPTIONS=--max-old-space-size=8192 yarn agent:check --profile commit`
- [x] `yarn jest packages/kit/src/views/Swap/utils/swapTokenTaxUtils.test.ts packages/kit/src/states/jotai/contexts/swap/quoteProgress.test.ts --runInBand`
- [ ] Reproduce OK-61351 and verify the old 3% 0x tax is not displayed when root quote tax fields are zero.
- [ ] Verify a quote with `buyTax: 0.0497` displays a 4.97% target-token buy tax.
- [ ] Switch providers and refresh quotes to confirm tax values and token labels stay scoped to the displayed quote.


[OK-61351]: https://onekeyhq.atlassian.net/browse/OK-61351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ