### PR TITLE
fix: send app version for market seed request

### DIFF
--- a/apps/web/scripts/fetch-market-home-token-seed.js
+++ b/apps/web/scripts/fetch-market-home-token-seed.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const webDir = path.resolve(__dirname, '..');
+const envVersionFile = path.resolve(webDir, '../..', '.env.version');
 const defaultBootstrapDataOutFile = path.join(
   webDir,
   '.generated/bootstrap-data.json',
@@ -45,6 +46,20 @@ const maxBootstrapDataBytes = Number(
 );
 
 class MarketHomeTokenSeedError extends Error {}
+
+function readAppVersion() {
+  const envVersion = fs.readFileSync(envVersionFile, 'utf8');
+  const versionLine = envVersion
+    .split(/\r?\n/)
+    .find((line) => line.trim().startsWith('VERSION='));
+  const version = versionLine?.slice(versionLine.indexOf('=') + 1).trim();
+  if (!version) {
+    throw new MarketHomeTokenSeedError(
+      `VERSION is missing from ${envVersionFile}.`,
+    );
+  }
+  return version;
+}
 
 const TOKEN_STRING_FIELDS = [
   'address',
@@ -366,9 +381,11 @@ async function fetchJson(url) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    const appVersion = readAppVersion();
     const response = await fetch(url, {
       headers: {
         Accept: 'application/json',
+        'X-Onekey-Request-Version': appVersion,
       },
       signal: controller.signal,
     });
@@ -421,13 +438,20 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  removeGeneratedBootstrapData();
-  const message = error instanceof Error ? error.message : String(error);
-  if (seedRequired) {
-    console.error(`[fetch-market-home-token-seed] failed: ${message}`);
-    process.exitCode = 1;
-    return;
-  }
-  warnAndSkip(message);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    removeGeneratedBootstrapData();
+    const message = error instanceof Error ? error.message : String(error);
+    if (seedRequired) {
+      console.error(`[fetch-market-home-token-seed] failed: ${message}`);
+      process.exitCode = 1;
+      return;
+    }
+    warnAndSkip(message);
+  });
+}
+
+module.exports = {
+  fetchJson,
+  readAppVersion,
+};

--- a/apps/web/scripts/fetch-market-home-token-seed.test.js
+++ b/apps/web/scripts/fetch-market-home-token-seed.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const { fetchJson, readAppVersion } = require('./fetch-market-home-token-seed');
+
+describe('fetch-market-home-token-seed', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('reads the app version from .env.version', () => {
+    const envVersionFile = path.resolve(__dirname, '../../..', '.env.version');
+    const expectedVersion = fs
+      .readFileSync(envVersionFile, 'utf8')
+      .match(/^VERSION=(.+)$/m)?.[1]
+      ?.trim();
+
+    expect(readAppVersion()).toBe(expectedVersion);
+  });
+
+  test('sends the app version header when fetching the seed', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      body: undefined,
+      headers: {
+        get: () => null,
+      },
+      ok: true,
+      text: async () => '{"data":{"list":[]}}',
+    });
+
+    await expect(fetchJson('https://utility.example.test')).resolves.toEqual({
+      data: { list: [] },
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://utility.example.test',
+      expect.objectContaining({
+        headers: {
+          Accept: 'application/json',
+          'X-Onekey-Request-Version': readAppVersion(),
+        },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Read the Web app version from the repository `.env.version` file.
- Send `X-Onekey-Request-Version` when fetching the Market home bootstrap seed.
- Add targeted coverage for version loading and request headers.

## Intent & Context
The `web-bundle / test-web` release job failed before Rspack because the headerless seed request was routed to the Utility legacy Market path and returned `code: 40000` with `data: null`. The same endpoint succeeds through the current Market path when the app version header is present.

## Root Cause
`fetch-market-home-token-seed.js` only sent `Accept: application/json`. Utility uses `X-Onekey-Request-Version` to select the Market implementation, so the build-time request did not follow the same route as current app traffic.

## Design Decisions
- Use `.env.version` as the source of truth, matching the requested release version and avoiding a duplicated hardcoded version.
- Keep the header addition inside the seed fetch helper so test and production Web release jobs share the same behavior.
- Preserve required/optional seed failure semantics.

## Changes Detail
- `apps/web/scripts/fetch-market-home-token-seed.js`: parse `VERSION` from `.env.version` and attach it as `X-Onekey-Request-Version`.
- `apps/web/scripts/fetch-market-home-token-seed.test.js`: verify the version source and outgoing request header.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web
- **Risk Areas**: Web release-time Market bootstrap seed generation

## Test plan
- [x] `yarn jest apps/web/scripts/fetch-market-home-token-seed.test.js --runInBand`
- [x] `yarn agent:check --profile commit`
- [x] Run the seed script against `utility.onekeytest.com` with `MARKET_HOME_TOKEN_SEED_REQUIRED=1` and confirm 20 tokens are written.
- [x] `MARKET_HOME_TOKEN_SEED_ENV=test MARKET_HOME_TOKEN_SEED_REQUIRED=1 NODE_OPTIONS=--max_old_space_size=8192 yarn app:web:build`