### PR TITLE
fix: restore tamagui web css behavior

### DIFF
--- a/packages/components/src/forms/TextArea/TamaguiInput.tsx
+++ b/packages/components/src/forms/TextArea/TamaguiInput.tsx
@@ -117,10 +117,7 @@ export function useInputProps(props: IInputProps, ref: any) {
     theme[selectionColorProp as any]?.get() ?? selectionColorProp;
   const style = (
     isWeb && selectionColor
-      ? {
-          ...(props.style as Record<string, unknown>),
-          '--t_selectionColor': selectionColor,
-        }
+      ? [props.style, { '--t_selectionColor': selectionColor }]
       : props.style
   ) as IInputProps['style'];
 

--- a/packages/components/src/forms/TextArea/TamaguiInput.tsx
+++ b/packages/components/src/forms/TextArea/TamaguiInput.tsx
@@ -117,7 +117,10 @@ export function useInputProps(props: IInputProps, ref: any) {
     theme[selectionColorProp as any]?.get() ?? selectionColorProp;
   const style = (
     isWeb && selectionColor
-      ? [props.style, { '--t_selectionColor': selectionColor }]
+      ? [
+          ...(Array.isArray(props.style) ? props.style : [props.style]),
+          { '--t_selectionColor': selectionColor },
+        ]
       : props.style
   ) as IInputProps['style'];
 

--- a/packages/components/src/forms/TextArea/TamaguiInput.tsx
+++ b/packages/components/src/forms/TextArea/TamaguiInput.tsx
@@ -111,12 +111,26 @@ export function useInputProps(props: IInputProps, ref: any) {
     theme[placeholderColorProp as any]?.get() ??
     placeholderColorProp ??
     theme.placeholderColor?.get();
+  const selectionColorProp = props.selectionColor;
+  const selectionColor =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    theme[selectionColorProp as any]?.get() ?? selectionColorProp;
+  const style = (
+    isWeb && selectionColor
+      ? {
+          ...(props.style as Record<string, unknown>),
+          '--t_selectionColor': selectionColor,
+        }
+      : props.style
+  ) as IInputProps['style'];
 
   return {
     ref: combinedRef,
     readOnly: props.disabled,
     ...props,
     placeholderTextColor,
+    selectionColor,
+    style,
     onChangeText,
   };
 }

--- a/packages/kit/src/views/Notifications/components/NotificationListView.tsx
+++ b/packages/kit/src/views/Notifications/components/NotificationListView.tsx
@@ -766,7 +766,8 @@ export function NotificationListView({
           zIndex={10}
           bg="$bg"
           $platform-web={{
-            position: '-webkit-sticky',
+            // Tamagui's web type still exposes the unsupported legacy value.
+            position: 'sticky' as '-webkit-sticky',
             top: 0,
           }}
         >


### PR DESCRIPTION
## Summary

- restore themed text selection highlights for shared web Input and TextArea components
- restore the sticky notifications header with the Chromium-supported CSS value
- keep native input behavior unchanged

## Verification

- `yarn agent:check --profile commit`
- Desktop CDP: verified Cmd+A selects the full input and renders a non-transparent selection background
- Desktop CDP: verified TextArea selection highlighting
- Desktop CDP: verified the notification header remains fixed after a simulated 240px scroll
