### PR TITLE
fix: restore Reanimated web style updates OK-61366

### DIFF
--- a/patches/react-native-reanimated+4.5.1.patch
+++ b/patches/react-native-reanimated+4.5.1.patch
@@ -126,3 +126,143 @@ index f180dfd..96eeb6a 100644
        Object.keys(component.props).forEach((key) => {
          if (!rawStyles[key]) {
            return;
+diff --git a/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js b/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js
+index 742885f..e375a4e 100644
+--- a/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js
++++ b/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js
+@@ -1,30 +1,40 @@
+ 'use strict';
+ 
++import createReactDOMStyleImport from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle';
++import {
++  createTextShadowValue as createTextShadowValueImport,
++  createTransformValue as createTransformValueImport,
++} from 'react-native-web/dist/exports/StyleSheet/preprocess';
++
++// OneKey patch: Use static imports so Rspack includes these helpers in browser bundles.
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createReactDOMStyle;
++// export let createReactDOMStyle;
++export const createReactDOMStyle = createReactDOMStyleImport;
+ 
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createTransformValue;
++// export let createTransformValue;
++export const createTransformValue = createTransformValueImport;
+ 
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createTextShadowValue;
+-try {
+-  createReactDOMStyle =
+-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+-  require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
+-  // eslint-disable-next-line no-empty
+-} catch (_e) {}
+-try {
+-  // React Native Web 0.19+
+-  createTransformValue =
+-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+-  require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
+-  // eslint-disable-next-line no-empty
+-} catch (_e) {}
+-try {
+-  createTextShadowValue =
+-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+-  require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
+-  // eslint-disable-next-line no-empty
+-} catch (_e) {}
+-//# sourceMappingURL=webUtils.web.js.map
+\ No newline at end of file
++// export let createTextShadowValue;
++export const createTextShadowValue = createTextShadowValueImport;
++// try {
++//   createReactDOMStyle =
++//   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
++//   require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
++//   // eslint-disable-next-line no-empty
++// } catch (_e) {}
++// try {
++//   // React Native Web 0.19+
++//   createTransformValue =
++//   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
++//   require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
++//   // eslint-disable-next-line no-empty
++// } catch (_e) {}
++// try {
++//   createTextShadowValue =
++//   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
++//   require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
++//   // eslint-disable-next-line no-empty
++// } catch (_e) {}
++//# sourceMappingURL=webUtils.web.js.map
+diff --git a/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts b/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
+index e073380..de80f2e 100644
+--- a/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
++++ b/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
+@@ -1,32 +1,42 @@
+ 'use strict';
+ 
+-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createReactDOMStyle: (style: any) => any;
++import createReactDOMStyleImport from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle';
++import {
++  createTextShadowValue as createTextShadowValueImport,
++  createTransformValue as createTransformValueImport,
++} from 'react-native-web/dist/exports/StyleSheet/preprocess';
+ 
++// OneKey patch: Use static imports so Rspack includes these helpers in browser bundles.
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createTransformValue: (transform: any) => any;
++// export let createReactDOMStyle: (style: any) => any;
++export const createReactDOMStyle = createReactDOMStyleImport;
+ 
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createTextShadowValue: (style: any) => void | string;
+-
+-try {
+-  createReactDOMStyle =
+-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+-    require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
+-  // eslint-disable-next-line no-empty
+-} catch (_e) {}
++// export let createTransformValue: (transform: any) => any;
++export const createTransformValue = createTransformValueImport;
+ 
+-try {
+-  // React Native Web 0.19+
+-  createTransformValue =
+-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+-    require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
+-  // eslint-disable-next-line no-empty
+-} catch (_e) {}
++// eslint-disable-next-line @typescript-eslint/no-explicit-any
++// export let createTextShadowValue: (style: any) => void | string;
++export const createTextShadowValue = createTextShadowValueImport;
+ 
+-try {
+-  createTextShadowValue =
+-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+-    require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
+-  // eslint-disable-next-line no-empty
+-} catch (_e) {}
++// try {
++//   createReactDOMStyle =
++//     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
++//     require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
++//   // eslint-disable-next-line no-empty
++// } catch (_e) {}
++//
++// try {
++//   // React Native Web 0.19+
++//   createTransformValue =
++//     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
++//     require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
++//   // eslint-disable-next-line no-empty
++// } catch (_e) {}
++//
++// try {
++//   createTextShadowValue =
++//     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
++//     require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
++//   // eslint-disable-next-line no-empty
++// } catch (_e) {}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61366](https://onekeyhq.atlassian.net/browse/OK-61366)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Restore Reanimated Web DOM style updates by replacing unresolved runtime `require()` calls with static imports in the existing `react-native-reanimated` patch.
- Keep `HeightTransition` and onboarding call sites unchanged from `x`.
- Fix the shared Web renderer path used by Desktop, Web, and Extension instead of bypassing animation on one page.

## Root cause

Rspack left Reanimated's guarded `require('react-native-web/...')` calls in the browser bundle. The browser has no `require`, and the dependency's empty catches left `createReactDOMStyle` undefined. Shared values, mappers, and `withTiming` completed internally, but `_updatePropsJS` could not write the resulting styles to DOM nodes.

## Verification

- `yarn agent:check --profile commit`
- Verified `react-native-reanimated+4.5.1.patch` applies cleanly to a pristine package and contains no `android/build` artifacts.
- Verified the Desktop bundle statically includes the React Native Web style helpers.
- Verified the recovery phrase input reaches 290px and all 12 fields are interactive.
- Verified the Reanimated transition reaches 173px for Private key over approximately 150ms and the textarea is interactive.

## Screenshot

![Recovery phrase inputs after the Reanimated Web fix](https://github.com/user-attachments/assets/876ecfb4-f641-49ce-9a9b-4b318599ad6c)

[OK-61366]: https://onekeyhq.atlassian.net/browse/OK-61366