### PR TITLE
fix: simplify Reanimated web patch OK-61366

### DIFF
--- a/patches/react-native-reanimated+4.5.1.patch
+++ b/patches/react-native-reanimated+4.5.1.patch
@@ -127,10 +127,10 @@ index f180dfd..96eeb6a 100644
          if (!rawStyles[key]) {
            return;
 diff --git a/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js b/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js
-index 742885f..e375a4e 100644
+index 742885f..c144d16 100644
 --- a/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js
 +++ b/node_modules/react-native-reanimated/lib/module/ReanimatedModule/js-reanimated/webUtils.web.js
-@@ -1,30 +1,40 @@
+@@ -1,13 +1,22 @@
  'use strict';
  
 +import createReactDOMStyleImport from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle';
@@ -139,130 +139,65 @@ index 742885f..e375a4e 100644
 +  createTransformValue as createTransformValueImport,
 +} from 'react-native-web/dist/exports/StyleSheet/preprocess';
 +
-+// OneKey patch: Use static imports so Rspack includes these helpers in browser bundles.
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 -export let createReactDOMStyle;
-+// export let createReactDOMStyle;
-+export const createReactDOMStyle = createReactDOMStyleImport;
++export let createReactDOMStyle = createReactDOMStyleImport;
  
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 -export let createTransformValue;
-+// export let createTransformValue;
-+export const createTransformValue = createTransformValueImport;
++export let createTransformValue = createTransformValueImport;
  
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 -export let createTextShadowValue;
--try {
--  createReactDOMStyle =
--  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
--  require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
--  // eslint-disable-next-line no-empty
--} catch (_e) {}
--try {
--  // React Native Web 0.19+
--  createTransformValue =
--  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
--  require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
--  // eslint-disable-next-line no-empty
--} catch (_e) {}
--try {
--  createTextShadowValue =
--  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
--  require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
--  // eslint-disable-next-line no-empty
--} catch (_e) {}
++export let createTextShadowValue = createTextShadowValueImport;
++
++// OneKey patch: Static imports let Rspack include these helpers in browser bundles.
++/*
+ try {
+   createReactDOMStyle =
+   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+@@ -27,4 +36,5 @@ try {
+   require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
+   // eslint-disable-next-line no-empty
+ } catch (_e) {}
 -//# sourceMappingURL=webUtils.web.js.map
 \ No newline at end of file
-+// export let createTextShadowValue;
-+export const createTextShadowValue = createTextShadowValueImport;
-+// try {
-+//   createReactDOMStyle =
-+//   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-+//   require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
-+//   // eslint-disable-next-line no-empty
-+// } catch (_e) {}
-+// try {
-+//   // React Native Web 0.19+
-+//   createTransformValue =
-+//   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-+//   require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
-+//   // eslint-disable-next-line no-empty
-+// } catch (_e) {}
-+// try {
-+//   createTextShadowValue =
-+//   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-+//   require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
-+//   // eslint-disable-next-line no-empty
-+// } catch (_e) {}
++*/
 +//# sourceMappingURL=webUtils.web.js.map
 diff --git a/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts b/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
-index e073380..de80f2e 100644
+index e073380..7885989 100644
 --- a/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
 +++ b/node_modules/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
-@@ -1,32 +1,42 @@
+@@ -1,14 +1,24 @@
  'use strict';
  
--// eslint-disable-next-line @typescript-eslint/no-explicit-any
--export let createReactDOMStyle: (style: any) => any;
 +import createReactDOMStyleImport from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle';
 +import {
 +  createTextShadowValue as createTextShadowValueImport,
 +  createTransformValue as createTransformValueImport,
 +} from 'react-native-web/dist/exports/StyleSheet/preprocess';
++
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-export let createReactDOMStyle: (style: any) => any;
++export let createReactDOMStyle: (style: any) => any = createReactDOMStyleImport;
  
-+// OneKey patch: Use static imports so Rspack includes these helpers in browser bundles.
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 -export let createTransformValue: (transform: any) => any;
-+// export let createReactDOMStyle: (style: any) => any;
-+export const createReactDOMStyle = createReactDOMStyleImport;
++export let createTransformValue: (transform: any) => any =
++  createTransformValueImport;
  
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 -export let createTextShadowValue: (style: any) => void | string;
--
--try {
--  createReactDOMStyle =
--    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
--    require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
--  // eslint-disable-next-line no-empty
--} catch (_e) {}
-+// export let createTransformValue: (transform: any) => any;
-+export const createTransformValue = createTransformValueImport;
++export let createTextShadowValue: (style: any) => void | string =
++  createTextShadowValueImport;
  
--try {
--  // React Native Web 0.19+
--  createTransformValue =
--    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
--    require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
--  // eslint-disable-next-line no-empty
--} catch (_e) {}
-+// eslint-disable-next-line @typescript-eslint/no-explicit-any
-+// export let createTextShadowValue: (style: any) => void | string;
-+export const createTextShadowValue = createTextShadowValueImport;
- 
--try {
--  createTextShadowValue =
--    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
--    require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
--  // eslint-disable-next-line no-empty
--} catch (_e) {}
-+// try {
-+//   createReactDOMStyle =
-+//     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-+//     require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
-+//   // eslint-disable-next-line no-empty
-+// } catch (_e) {}
-+//
-+// try {
-+//   // React Native Web 0.19+
-+//   createTransformValue =
-+//     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-+//     require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
-+//   // eslint-disable-next-line no-empty
-+// } catch (_e) {}
-+//
-+// try {
-+//   createTextShadowValue =
-+//     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-+//     require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
-+//   // eslint-disable-next-line no-empty
-+// } catch (_e) {}
++// OneKey patch: Static imports let Rspack include these helpers in browser bundles.
++/*
+ try {
+   createReactDOMStyle =
+     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
+@@ -30,3 +40,4 @@ try {
+     require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
+   // eslint-disable-next-line no-empty
+ } catch (_e) {}
++*/


### PR DESCRIPTION
## Summary

- Follow up on #13056 by reducing the Reanimated Web patch to the minimal static-import change.
- Preserve the upstream mutable exports while initializing them from statically bundled React Native Web helpers.
- Keep the original dynamic fallback code in one documented block comment, as required by the repository patch-package workflow.

## Verification

- `yarn agent:check --profile commit`
- Patch applies cleanly to a pristine `react-native-reanimated@4.5.1` package.
- Patch contains no `android/build` artifacts.
- Rspack compiles and resolves both React Native Web helpers as bundled modules.
- Electron verification: transition container is `290px`, all 12 phrase inputs render, and the first input receives focus.

## Scope

No runtime behavior change from #13056; this only makes the dependency patch smaller and easier to review.
