### PR TITLE
fix: restore default body font resolution

### DIFF
--- a/packages/components/tamagui.config.ts
+++ b/packages/components/tamagui.config.ts
@@ -571,6 +571,7 @@ const config = createTamagui({
   defaultTheme: 'light',
 
   settings: {
+    defaultFont: '$body',
     styleCompat: isTamaguiNative ? 'react-native' : 'legacy',
     defaultPosition: 'relative',
     shouldAddPrefersColorThemes: false,


### PR DESCRIPTION
## Summary

- configure Tamagui to use `$body` as the global default font
- restore form labels to the intended `$bodyMdMedium` typography after the Tamagui 2 upgrade

## Verification

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn tsc:only`
- Desktop CDP: Import Address labels render at 14px / 20px / 500 with viewport scale 1