### PR TITLE
fix: preserve native Discovery views and tab layout

### DIFF
--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -162,6 +162,7 @@ export function Banner<T extends IBannerData>({
   indicatorContainerStyle,
   showPaginationButton = !platformEnv.isNative,
   showCloseButton = false,
+  autoplayEnabled = true,
   onBannerClose,
   ...props
 }: IStackStyle & {
@@ -175,6 +176,7 @@ export function Banner<T extends IBannerData>({
   emptyComponent?: ReactElement;
   showCloseButton?: boolean;
   showPaginationButton?: boolean;
+  autoplayEnabled?: boolean;
   onBannerClose?: (bannerId: string) => void;
 }) {
   const [isHovering, setIsHovering] = useState(false);
@@ -297,6 +299,7 @@ export function Banner<T extends IBannerData>({
   );
 
   const isFocused = useIsFocused();
+  const shouldAutoplay = isFocused && autoplayEnabled;
 
   if (isNil(isLoading) || isLoading || data.length === 0) {
     return emptyComponent;
@@ -311,9 +314,9 @@ export function Banner<T extends IBannerData>({
     >
       <Swiper
         position="relative"
-        autoplay={isFocused}
-        autoplayLoop={isFocused}
-        autoplayLoopKeepAnimation={isFocused}
+        autoplay={shouldAutoplay}
+        autoplayLoop={shouldAutoplay}
+        autoplayLoopKeepAnimation={shouldAutoplay}
         autoplayDelayMs={3000}
         keyExtractor={keyExtractor}
         data={data}

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -21,6 +21,8 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useThrottledCallback } from 'use-debounce';
 
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
 import { Divider } from '../../content';
 import { ListView, ScrollView } from '../../layouts';
 import { GradientMask, SizableText, XStack, YStack } from '../../primitives';
@@ -67,6 +69,7 @@ const DIRECT_TAB_PRESS_ANIMATION_DURATION = 220;
 const DIRECT_TAB_PRESS_NATIVE_SYNC_TIMEOUT = 900;
 const DIRECT_TAB_PRESS_SETTLE_TIMEOUT = 450;
 const DIRECT_TAB_PRESS_MIN_INTERVAL = 600;
+const TAB_BAR_POSITION = platformEnv.isNative ? 'relative' : 'sticky';
 
 export type ITabBarVariant = 'default' | 'pill' | 'text';
 export type IDirectTabPressAnimationMode = 'timing' | 'instant';
@@ -1368,7 +1371,7 @@ export function TabBar({
 
   return scrollable ? (
     <YStack
-      position={'sticky' as any}
+      position={TAB_BAR_POSITION as any}
       top={0}
       bg="$bgApp"
       zIndex={10}
@@ -1403,7 +1406,7 @@ export function TabBar({
       pointerEvents="box-none"
       bg="$bgApp"
       className="onekey-tabs-header"
-      position={'sticky' as any}
+      position={TAB_BAR_POSITION as any}
       top={0}
       zIndex={10}
       {...containerStyle}

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -407,8 +407,10 @@ function OuterTabPagerViewComponent({
     () =>
       visitedPages[2] ? (
         <View key="browser" style={styles.page}>
-          {/* Keep the mobile Browser native subtree attached across DApp
-          minimization and outer tab switches. */}
+          {/* Keep Browser out of react-freeze so its React subtree survives
+          DApp minimization and outer tab switches. Native attachment still
+          follows OUTER_PAGER_OFFSCREEN_PAGE_LIMIT; Android may detach Browser
+          across Market (index 0) and Browser (index 2). */}
           {browserContent}
         </View>
       ) : (

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -401,14 +401,16 @@ function OuterTabPagerViewComponent({
     () =>
       visitedPages[2] ? (
         <View key="browser" style={styles.page}>
-          <Freeze freeze={shouldFreezePage(2)}>{browserContent}</Freeze>
+          {/* Keep the mobile Browser native subtree attached across DApp
+          minimization and outer tab switches. */}
+          {browserContent}
         </View>
       ) : (
         <View key="browser" style={styles.page}>
           <Stack flex={1} />
         </View>
       ),
-    [visitedPages, shouldFreezePage, browserContent],
+    [visitedPages, browserContent],
   );
 
   return (

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -29,6 +29,9 @@ import type { SharedValue } from 'react-native-reanimated';
 
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
+// ViewPager2 otherwise detaches Browser (index 2) while Market (index 0) is active.
+const OUTER_PAGER_OFFSCREEN_PAGE_LIMIT = 2;
+
 // --- Styles (defined before component to satisfy no-use-before-define) ---
 
 const styles = StyleSheet.create({
@@ -422,7 +425,7 @@ function OuterTabPagerViewComponent({
       overdrag
       overScrollMode="always"
       scrollSensitivity={4}
-      offscreenPageLimit={1}
+      offscreenPageLimit={OUTER_PAGER_OFFSCREEN_PAGE_LIMIT}
       onPageScroll={pageScrollHandler}
       onPageScrollStateChanged={handleOuterPageScrollStateChanged}
       onPageSelected={handleOuterPageSelected}

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -16,6 +16,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { IEarnBorrowPagerViewRef } from '../../Earn/components/EarnBorrowPagerView';
 import type {
@@ -29,8 +30,10 @@ import type { SharedValue } from 'react-native-reanimated';
 
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
-// ViewPager2 otherwise detaches Browser (index 2) while Market (index 0) is active.
-const OUTER_PAGER_OFFSCREEN_PAGE_LIMIT = 2;
+// Keep Android at one retained page to limit ViewPager2 native-view memory.
+// Browser (index 2) may detach while Market (index 0) is active, so changing
+// this trade-off requires Android memory data and the full DApp regression.
+const OUTER_PAGER_OFFSCREEN_PAGE_LIMIT = platformEnv.isNativeAndroid ? 1 : 2;
 
 // --- Styles (defined before component to satisfy no-use-before-define) ---
 

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -533,9 +533,14 @@ function MobileBrowser() {
   const shouldShowRootWebPageLayer = useOuterPager && isBrowserWebPageVisible;
   const browserDashboardContent = (
     <View
+      pointerEvents={showDiscoveryPage ? 'auto' : 'none'}
+      accessibilityElementsHidden={!showDiscoveryPage}
+      importantForAccessibility={
+        showDiscoveryPage ? 'auto' : 'no-hide-descendants'
+      }
       style={{
-        display: showDiscoveryPage ? 'flex' : 'none',
-        flex: showDiscoveryPage ? 1 : undefined,
+        flex: 1,
+        opacity: showDiscoveryPage ? 1 : 0,
       }}
     >
       <DashboardContent onScroll={handleScroll} />

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -536,10 +536,10 @@ function MobileBrowser() {
   const browserDashboardContent = (
     <View
       collapsable={false}
-      pointerEvents={isBrowserDashboardActive ? 'auto' : 'none'}
-      accessibilityElementsHidden={!isBrowserDashboardActive}
+      pointerEvents={showDiscoveryPage ? 'auto' : 'none'}
+      accessibilityElementsHidden={!showDiscoveryPage}
       importantForAccessibility={
-        isBrowserDashboardActive ? 'auto' : 'no-hide-descendants'
+        showDiscoveryPage ? 'auto' : 'no-hide-descendants'
       }
       style={{
         flex: 1,

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -282,6 +282,8 @@ function MobileBrowser() {
   }, [isTabletMainView, isTabletDetailView, displayHomePage, isLandscape]);
   const isBrowserWebPageVisible =
     selectedHeaderTab === ETranslations.global_browser && !showDiscoveryPage;
+  const isBrowserDashboardActive =
+    selectedHeaderTab === ETranslations.global_browser && showDiscoveryPage;
 
   useEffect(() => {
     if (!tabs?.length) {
@@ -533,17 +535,21 @@ function MobileBrowser() {
   const shouldShowRootWebPageLayer = useOuterPager && isBrowserWebPageVisible;
   const browserDashboardContent = (
     <View
-      pointerEvents={showDiscoveryPage ? 'auto' : 'none'}
-      accessibilityElementsHidden={!showDiscoveryPage}
+      collapsable={false}
+      pointerEvents={isBrowserDashboardActive ? 'auto' : 'none'}
+      accessibilityElementsHidden={!isBrowserDashboardActive}
       importantForAccessibility={
-        showDiscoveryPage ? 'auto' : 'no-hide-descendants'
+        isBrowserDashboardActive ? 'auto' : 'no-hide-descendants'
       }
       style={{
         flex: 1,
         opacity: showDiscoveryPage ? 1 : 0,
       }}
     >
-      <DashboardContent onScroll={handleScroll} />
+      <DashboardContent
+        isActive={isBrowserDashboardActive}
+        onScroll={handleScroll}
+      />
     </View>
   );
 
@@ -699,7 +705,10 @@ function MobileBrowser() {
                     flex: showDiscoveryPage ? 1 : undefined,
                   }}
                 >
-                  <DashboardContent onScroll={handleScroll} />
+                  <DashboardContent
+                    isActive={isBrowserDashboardActive}
+                    onScroll={handleScroll}
+                  />
                 </View>
                 {!isTabletMainView ? (
                   <View

--- a/packages/kit/src/views/Discovery/pages/Dashboard/Banner.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/Banner.tsx
@@ -11,9 +11,11 @@ import { DiscoveryTestIDs } from '../../testIDs';
 export function DashboardBanner({
   banners,
   isLoading,
+  autoplayEnabled,
 }: {
   banners: IDiscoveryBanner[];
   isLoading: boolean | undefined;
+  autoplayEnabled: boolean;
 }) {
   const { data, closeAllBanners } = useBannerData(banners);
   const handleWebSite = useWebSiteHandler();
@@ -62,6 +64,7 @@ export function DashboardBanner({
       alignItems="center"
     >
       <Banner
+        autoplayEnabled={autoplayEnabled}
         onBannerClose={closeAllBanners}
         showCloseButton
         showPaginationButton={false}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -26,13 +26,16 @@ import { Welcome } from './Welcome';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
 function DashboardContent({
+  isActive = true,
   onScroll,
   tabId,
 }: {
+  isActive?: boolean;
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   tabId?: string;
 }) {
   const isFocused = useIsFocused();
+  const isContentActive = isFocused && isActive;
 
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -134,6 +137,7 @@ function DashboardContent({
                   key="Banner"
                   banners={homePageData?.banners || []}
                   isLoading={isInitialLoading}
+                  autoplayEnabled={isContentActive}
                 />
               </View>
             ) : null
@@ -172,6 +176,7 @@ function DashboardContent({
       showDiveInDescription,
       refresh,
       hasBookmarks,
+      isContentActive,
       tabId,
     ],
   );
@@ -181,7 +186,7 @@ function DashboardContent({
       <ScrollView
         testID={DiscoveryTestIDs.dashboardPage}
         height="100%"
-        onScroll={isFocused ? (onScroll as any) : undefined}
+        onScroll={isContentActive ? (onScroll as any) : undefined}
         scrollEventThrottle={16}
         refreshControl={
           <RefreshControl refreshing={isRefreshing} onRefresh={refresh} />


### PR DESCRIPTION
## Summary

- keep the Browser dashboard mounted across Dashboard/DApp visibility changes and remove its outer Freeze boundary
- preserve hidden-state semantics with opacity, touch isolation, and accessibility isolation instead of `display: none`
- keep Android ViewPager2 at `offscreenPageLimit={1}` to limit retained native-view memory; iOS keeps the wider retention setting
- pause Dashboard banner autoplay and scroll work whenever Browser Dashboard is not the active visible page
- use normal-flow `relative` positioning for shared Tabs on iOS/Android while preserving `sticky` on every non-native target
- fix three native regressions: Browser dashboard images disappearing, Earn Deposit/Withdraw spacing collapsing, and Market detail sections overlapping

## User-visible regressions

| Area | Regression | Result after this change |
| --- | --- | --- |
| Browser | Enter a DApp, return home, then switch through outer Discovery pages; the banner and DApp icons can become blank | iOS image views remain rendered; Android keeps its lower-memory pager policy and the cross-two-page detach risk is documented below |
| Earn | USDC Deposit/Withdraw content loses its expected spacing/padding | Deposit and Withdraw layouts remain in normal flow |
| Market | Market detail Chart/Overview, chart controls, and the lower table/tabs overlap | Header, chart, controls, and lower content are laid out sequentially |

## Root cause and causal chain

### Shared native TabBar layout

`TabBar` used `position="sticky"` for all platforms and bypassed the type system with `as any`. Sticky positioning is a DOM layout behavior; it is not part of the normal React Native layout contract. On native collapsible tab screens this allowed the tab header to leave the expected normal-flow geometry, so consumers calculated content offsets from the wrong header layout. The visible results were missing spacing in Earn Deposit/Withdraw and overlapping sections on Market detail.

The fix is intentionally scoped by runtime:

- iOS/Android: `relative`, so the header participates in normal native layout and measurement
- web, desktop, and extension: keep the existing `sticky` behavior

### Browser dashboard image lifecycle

The inactive-view behavior was originally a performance design, not dead code:

- [#5281](https://github.com/OneKeyHQ/app-monorepo/pull/5281) introduced the native Discovery tab performance pattern.
- [#10556](https://github.com/OneKeyHQ/app-monorepo/pull/10556) introduced the Market/DeFi/Browser outer PagerView.
- [#10575](https://github.com/OneKeyHQ/app-monorepo/pull/10575) optimized that pager by freezing pages outside the visible transition pair.
- [#10696](https://github.com/OneKeyHQ/app-monorepo/pull/10696) documents the important implementation detail: `react-freeze` v1 uses Suspense with `fallback=null`, which removes native views while frozen.

`display: none` on the Dashboard also had a reasonable local intent: when DApp content is visible, do not draw the inactive Dashboard or let it participate in layout/input. The problem is the composition of two independent native-view removal boundaries:

1. Opening a DApp changes the Dashboard to `display: none`, removing its native image views from the rendered tree.
2. Returning home can initially recreate those views successfully.
3. Switching Market -> DeFi -> Browser then freezes the entire outer Browser page.
4. The outer Freeze removes that native subtree again.
5. When Browser is restored, the Dashboard React elements still exist, but the recreated native image views can remain blank.

This was reproduced twice before the fix. The banner and all eight dashboard icons were visible immediately after DApp -> Home, then became blank only after the additional outer-page cycle and stayed blank for more than five seconds. At the same time, a unique value stored in the active DApp form was still present, which separated the dashboard image-view failure from a WKWebView reload.

Changing only `display: none` to opacity was insufficient: it fixed the direct DApp -> Home path, but the outer Browser Freeze still removed the same subtree later. Both removal boundaries need to be addressed.

After this change:

- the Dashboard remains mounted and uses opacity for visibility
- Dashboard/DApp visibility, touch, and accessibility gating continues to use the synchronous `showDiscoveryPage` state
- the Dashboard host is `collapsable={false}` so Android cannot flatten away the native host used to preserve the image subtree
- the outer Browser React subtree no longer enters the `react-freeze` removal path on iOS or Android
- iOS keeps the wider pager retention setting used by the verified image-lifecycle fix
- Android deliberately keeps `offscreenPageLimit={1}` to reduce retained native-view memory; Browser index 2 may detach while Market index 0 is active
- Dashboard receives a separate activity signal; only background work uses it, so Banner clears its autoplay timer and Dashboard detaches its scroll handler while inactive without delaying input readiness on pager swipes
- Market and Earn retain their existing outer Freeze behavior
- Android retains its existing inner WebPage Freeze (`freeze={showDiscoveryPage}`); this PR removes only the outer Browser page Freeze
- the iOS root WKWebView layer remains outside the outer pager as established by the previous WebView lifecycle work

## Relationship to the previous WebView reload issue

This change deliberately regression-tests the historical [OK-57448](https://onekeyhq.atlassian.net/browse/OK-57448) failure mode instead of assuming that keeping Dashboard images alive cannot affect DApp state.

Relevant history:

- [#12305](https://github.com/OneKeyHQ/app-monorepo/pull/12305) first attempted to keep mobile Discovery WebViews attached; the corresponding QA run [OK-57618](https://onekeyhq.atlassian.net/browse/OK-57618) failed.
- [#12581](https://github.com/OneKeyHQ/app-monorepo/pull/12581) moved iOS phone WKWebViews outside nested `react-freeze` / `display: none` boundaries and used opacity; follow-up QA [OK-58683](https://onekeyhq.atlassian.net/browse/OK-58683) completed successfully.

The important distinction is that this PR fixes the Dashboard/outer Browser page lifecycle on the verified iOS path. It does not move the per-tab WebViews back under a removable iOS boundary, and it does not remove Android's inner WebPage suspension. Android intentionally retains its lower-memory ViewPager2 cache limit, so native detachment across Market index 0 <-> Browser index 2 remains an accepted platform trade-off.

## Regression verification

### Environment

- iPhone 17 Pro simulator
- iOS 26.5
- Android API 36 arm64 emulator
- native `main` UI runtime on both platforms; `bg` remains an independent JS runtime and is unchanged
- UIKit/WKWebView and Android ViewPager2/WebView ownership remains in each platform's foreground native view tree
- no `bg` runtime, persistence, routing, DApp provider, or URL-validation changes

### iOS Browser dashboard and historical DApp state

1. Reload the app and open Browser home; verify the banner and all eight DApp icons render.
2. Open `https://httpbin.org/forms/post` in a live Browser tab.
3. Enter the unique marker `FIX-OK-57448-20260828` into the Customer name field.
4. Use More -> Back to Home.
5. Verify the banner and all eight icons still render.
6. Switch Market -> DeFi -> Browser three complete rounds.
7. Wait five seconds after restoration and verify the images remain rendered.
8. Reopen the live tab and verify the unique marker is unchanged.
9. Switch to a second live `Example Domain` tab and back; verify the marker is still unchanged.

Result: pass. No dashboard image loss and no DApp/WebView state reload were observed.

### iOS inactive Banner work

1. Record the current Browser banner and active pagination dot.
2. Switch to Market and wait eight seconds, longer than two 3000 ms autoplay intervals.
3. Return to Browser and verify the same banner/pagination position is retained.
4. Keep Browser active for eleven seconds and verify the banner advances again.

Result: pass. Autoplay pauses while Browser is inactive and resumes when Browser becomes active; the image subtree stays mounted throughout.

### Android verification and final cache policy

1. Build and install `app-prod-debug.apk` on the API 36 emulator.
2. Open Discover -> Browser and verify Dashboard/banner/trending image content renders.
3. Switch Browser -> Market -> Browser, covering the full ViewPager2 index 2 <-> index 0 distance.
4. Open `https://httpbin.org/forms/post` and verify the live form renders.
5. Minimize the DApp, switch Market -> Browser, and verify Dashboard renders instead of a blank page.
6. Open Browser tabs and restore the existing `httpbin` tab.
7. Verify the same form content renders instead of a blank/recreated Browser surface.

Result on the `offscreenPageLimit={2}` review build: pass. Android retained the Dashboard and live WebView across the exact offscreen-distance path raised in review. The remote banner feed changed/entered placeholders during the timing experiment, so Android screenshots were not deterministic enough to claim a timer-position assertion; timer pause/resume was directly verified on iOS, and Android executes the same shared `isActive -> autoplayEnabled` code path.

Final policy after performance review: Android was restored to `offscreenPageLimit={1}`. The prior API 36 result therefore validates the shared Dashboard/DApp logic but must not be cited as proof that the final Android build retains Browser native views across Market index 0 <-> Browser index 2. That detach/re-attach path is accepted to avoid retaining the additional native page in memory.

### Earn layout

1. Open Discover -> DeFi.
2. Open USDC Earn actions.
3. Verify the Deposit tab, amount card, protocol card, helper actions, and footer spacing.
4. Switch to Withdraw and verify the amount card and protocol selector spacing.

Result: pass. Deposit and Withdraw padding/layout remain intact.

### Market detail layout

1. Open Discover -> Market -> Stocks.
2. Open AAPLon.
3. Verify Chart/Overview tabs, market metrics, timeframe controls, candlestick chart, Transactions/My position/Holders tabs, and action footer.

Result: pass. The chart, overview content, controls, and lower table area do not overlap.

### Static validation

- `yarn agent:check --profile commit` -- pass
- `yarn agent:check --profile pr` -- pass before the final Android cache-policy commit; CI reruns on every pushed commit
- `git diff --check` -- pass
- Android legacy Gradle build -- pass for the earlier `offscreenPageLimit={2}` review build; APK installed and exercised on API 36

## Risk and trade-offs

- iOS retains the Browser dashboard/native host views while the outer page is inactive, trading native memory retention for lifecycle correctness.
- Android keeps only one adjacent ViewPager2 page for memory/performance; when Market index 0 is active, Browser index 2 may detach and the image re-attachment regression can reappear.
- Hidden Dashboard views remain non-interactive and inaccessible; banner timers/animations and Dashboard scroll handling are explicitly paused.
- Market and Earn performance behavior is unchanged because their outer Freeze boundaries remain.
- Non-native TabBar behavior is unchanged because web/desktop/extension continue using `sticky`.
- iPad/split-view was not runtime-tested; the outer pager change is exercised on the phone path.

## Future regression guardrails

1. Do not reintroduce `display: none` around Dashboard image content or an outer `Freeze` around Browser without testing the combined DApp -> Home -> Market -> DeFi -> Browser sequence.
2. An element existing in the React tree is not sufficient. Confirm the banner/icon pixels render after at least five seconds.
3. Always pair Dashboard image verification with a live DApp state marker so image fixes cannot silently reintroduce OK-57448 WebView reload behavior.
4. Keep iOS WebViews outside removable nested visibility boundaries.
5. Android's current outer pager policy is intentionally `offscreenPageLimit={1}`. Do not claim full native keep-alive across Market index 0 <-> Browser index 2; changing the limit requires Android memory data and the full DApp regression.
6. Keep the Dashboard host non-collapsable even with Android's lower pager limit; it still protects the attached-page lifecycle.
7. Any future Browser keep-alive change must retain an explicit inactive-work gate; route focus alone is insufficient inside Discovery.
8. Keep visibility/input gating on synchronous page state; do not bind touch or accessibility readiness to the async persisted selected-tab round trip.
9. Preserve Android hardware Back/current-page gating and its inner WebPage Freeze unless a separate change includes Android runtime coverage and memory/performance evidence.
10. Keep `sticky` restricted to non-native DOM targets; native Tabs must remain in normal layout flow.


[OK-57448]: https://onekeyhq.atlassian.net/browse/OK-57448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ