### PR TITLE
fix: refresh native theme colors OK-61462

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -18170,6 +18170,8 @@
     "packages/components/src/shared/stacks.native.ts": 23475,
     "packages/components/src/shared/tamagui.ts": 17963,
     "packages/components/src/shared/tamaguiOverlay.ts": 17964,
+    "packages/components/src/shared/useNativeThemeNameSubscription.native.ts": 23784,
+    "packages/components/src/shared/useNativeThemeNameSubscription.ts": 23785,
     "packages/components/src/types/index.ts": 17965,
     "packages/components/src/utils/DebugRenderTracker.tsx": 17966,
     "packages/components/src/utils/animationConstants.ts": 17967,

--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -21813,7 +21813,7 @@
     "packages/kit/src/views/Perp/components/PerpMobileNetworkAlert.tsx": 21488,
     "packages/kit/src/views/Perp/components/PerpMobileTopChartProvider.tsx": 23765,
     "packages/kit/src/views/Perp/components/PerpNetworkAlert.tsx": 21489,
-    "packages/kit/src/views/Perp/components/PerpNetworkStatus.tsx": 23777,
+    "packages/kit/src/views/Perp/components/PerpNetworkStatus.tsx": 23783,
     "packages/kit/src/views/Perp/components/PerpOrderBook.tsx": 21490,
     "packages/kit/src/views/Perp/components/PerpOrderBookMobileVerticalShell.tsx": 21491,
     "packages/kit/src/views/Perp/components/PerpSettingsButton.tsx": 21492,

--- a/packages/components/src/shared/tamagui.test.tsx
+++ b/packages/components/src/shared/tamagui.test.tsx
@@ -11,12 +11,18 @@ const mockTheme = {
 };
 const mockUseTamaguiTheme = jest.fn(() => mockTheme);
 const mockUseTamaguiThemeName = jest.fn(() => 'light');
+const mockUseNativeThemeNameSubscription = jest.fn();
 
 jest.mock('@tamagui/web', () => ({
   useTheme: () => mockUseTamaguiTheme(),
   useThemeName: () => mockUseTamaguiThemeName(),
 }));
 jest.mock('@tamagui/core', () => ({}));
+jest.mock('./useNativeThemeNameSubscription', () => ({
+  useNativeThemeNameSubscription: () => {
+    mockUseNativeThemeNameSubscription();
+  },
+}));
 jest.mock('@tamagui/spacer', () => ({}));
 jest.mock('@tamagui/stacks', () => ({}));
 jest.mock('@tamagui/animate-presence', () => ({}));
@@ -43,18 +49,37 @@ jest.mock('@tamagui/form', () => ({}));
 jest.mock('./stacks', () => ({}));
 
 const { useTheme } = require('./tamagui') as typeof import('./tamagui');
+const { useNativeThemeNameSubscription } =
+  require('./useNativeThemeNameSubscription.native') as typeof import('./useNativeThemeNameSubscription.native');
+const { useNativeThemeNameSubscription: useWebThemeNameSubscription } =
+  jest.requireActual<typeof import('./useNativeThemeNameSubscription')>(
+    './useNativeThemeNameSubscription',
+  );
 
 describe('useTheme', () => {
   beforeEach(() => {
     mockUseTamaguiTheme.mockClear();
     mockUseTamaguiThemeName.mockClear();
+    mockUseNativeThemeNameSubscription.mockClear();
   });
 
-  it('subscribes to theme name changes for raw theme value consumers', () => {
+  it('delegates raw theme value refreshes to the platform subscription', () => {
     const { result } = renderHook(() => useTheme());
 
     expect(result.current).toBe(mockTheme);
     expect(mockUseTamaguiTheme).toHaveBeenCalledTimes(1);
+    expect(mockUseNativeThemeNameSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes native consumers to theme name changes', () => {
+    renderHook(() => useNativeThemeNameSubscription());
+
     expect(mockUseTamaguiThemeName).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not add a theme name subscription on web', () => {
+    renderHook(() => useWebThemeNameSubscription());
+
+    expect(mockUseTamaguiThemeName).not.toHaveBeenCalled();
   });
 });

--- a/packages/components/src/shared/tamagui.test.tsx
+++ b/packages/components/src/shared/tamagui.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+
+const mockTheme = {
+  bgApp: {
+    val: '#ffffff',
+  },
+};
+const mockUseTamaguiTheme = jest.fn(() => mockTheme);
+const mockUseTamaguiThemeName = jest.fn(() => 'light');
+
+jest.mock('@tamagui/web', () => ({
+  useTheme: () => mockUseTamaguiTheme(),
+  useThemeName: () => mockUseTamaguiThemeName(),
+}));
+jest.mock('@tamagui/core', () => ({}));
+jest.mock('@tamagui/spacer', () => ({}));
+jest.mock('@tamagui/stacks', () => ({}));
+jest.mock('@tamagui/animate-presence', () => ({}));
+jest.mock('@tamagui/text', () => ({}));
+jest.mock('@tamagui/font-size', () => ({}));
+jest.mock('@tamagui/label', () => ({}));
+jest.mock('@tamagui/group', () => ({}));
+jest.mock('@tamagui/toggle-group', () => ({}));
+jest.mock('@tamagui/accordion', () => ({}));
+jest.mock('@tamagui/dialog', () => ({}));
+jest.mock('@tamagui/sheet', () => ({}));
+jest.mock('@tamagui/portal', () => ({}));
+jest.mock('@tamagui/toast', () => ({}));
+jest.mock('@tamagui/switch', () => ({}));
+jest.mock('@tamagui/slider', () => ({}));
+jest.mock('@tamagui/separator', () => ({}));
+jest.mock('@tamagui/radio-group', () => ({}));
+jest.mock('@tamagui/focusable', () => ({}));
+jest.mock('@tamagui/get-button-sized', () => ({}));
+jest.mock('@tamagui/get-font-sized', () => ({}));
+jest.mock('@tamagui/get-token', () => ({}));
+jest.mock('@tamagui/create-context', () => ({}));
+jest.mock('@tamagui/form', () => ({}));
+jest.mock('./stacks', () => ({}));
+
+const { useTheme } = require('./tamagui') as typeof import('./tamagui');
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    mockUseTamaguiTheme.mockClear();
+    mockUseTamaguiThemeName.mockClear();
+  });
+
+  it('subscribes to theme name changes for raw theme value consumers', () => {
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current).toBe(mockTheme);
+    expect(mockUseTamaguiTheme).toHaveBeenCalledTimes(1);
+    expect(mockUseTamaguiThemeName).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/components/src/shared/tamagui.ts
+++ b/packages/components/src/shared/tamagui.ts
@@ -1,3 +1,8 @@
+import {
+  useTheme as useTamaguiTheme,
+  useThemeName as useTamaguiThemeName,
+} from '@tamagui/web';
+
 import type {
   GestureResponderEvent,
   TextProps as RNTextProps,
@@ -46,9 +51,7 @@ export {
   View,
   getTokens,
   getTokenValue,
-  useTheme,
   useMedia,
-  useThemeName,
   useStyle,
   usePropsAndStyle,
   createStyledContext,
@@ -58,6 +61,19 @@ export {
   useProps,
   withStaticProperties,
 } from '@tamagui/web';
+
+export const useThemeName = useTamaguiThemeName;
+
+export function useTheme() {
+  const theme = useTamaguiTheme();
+
+  // Tamagui theme values do not always notify native `.val` consumers when
+  // the root theme changes. Subscribe to the theme name so native component
+  // props derived from raw colors are recalculated as well.
+  useTamaguiThemeName();
+
+  return theme;
+}
 
 export { Unspaced } from '@tamagui/spacer';
 

--- a/packages/components/src/shared/tamagui.ts
+++ b/packages/components/src/shared/tamagui.ts
@@ -3,6 +3,8 @@ import {
   useThemeName as useTamaguiThemeName,
 } from '@tamagui/web';
 
+import { useNativeThemeNameSubscription } from './useNativeThemeNameSubscription';
+
 import type {
   GestureResponderEvent,
   TextProps as RNTextProps,
@@ -67,10 +69,7 @@ export const useThemeName = useTamaguiThemeName;
 export function useTheme() {
   const theme = useTamaguiTheme();
 
-  // Tamagui theme values do not always notify native `.val` consumers when
-  // the root theme changes. Subscribe to the theme name so native component
-  // props derived from raw colors are recalculated as well.
-  useTamaguiThemeName();
+  useNativeThemeNameSubscription();
 
   return theme;
 }

--- a/packages/components/src/shared/useNativeThemeNameSubscription.native.ts
+++ b/packages/components/src/shared/useNativeThemeNameSubscription.native.ts
@@ -1,0 +1,6 @@
+import { useThemeName } from '@tamagui/web';
+
+export function useNativeThemeNameSubscription() {
+  // Raw theme values passed to native components need a React subscription.
+  useThemeName();
+}

--- a/packages/components/src/shared/useNativeThemeNameSubscription.ts
+++ b/packages/components/src/shared/useNativeThemeNameSubscription.ts
@@ -1,0 +1,1 @@
+export function useNativeThemeNameSubscription() {}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61462](https://onekeyhq.atlassian.net/browse/OK-61462)

----------

<!-- github-pr-monitor:jira-links:end -->



[OK-61462](https://onekeyhq.atlassian.net/browse/OK-61462)

## Root cause

After the React Native, Expo, and Tamagui upgrade, raw Tamagui theme proxy values can change without guaranteeing a React rerender for consumers that only call the shared `useTheme` wrapper. Native consumers such as navigation header colors and the Perps Slider therefore kept the previous resolved color until another render occurred.

The current `x` module ID registry also assigned ID `23777` to both the native text input and `PerpNetworkStatus`. That collision blocked the native startup bundle and the module registry/dev-vendor test suites.

## Summary

- delegate the shared `useTheme` wrapper to a platform-specific theme refresh subscription
- subscribe native raw-color consumers to theme-name changes while keeping web/desktop as a no-op
- add focused regression tests for native subscription and web no-op behavior
- resolve the colliding Perps module ID and register the two new platform modules with stable IDs

## Validation

- `yarn agent:check --profile commit`
- `yarn tsc:only`
- targeted oxlint and oxfmt checks
- 30 focused Jest tests for theme refresh, module registry, and dev-vendor behavior
- strict local iOS union build and `module-id:check` against its generated module map
- local project iOS build with `yarn app:ios --port 8083 --device 485A50DF-A406-4321-B7DF-FECA510E68D4`
- verified Dialog/native navigation header and Perps Slider update immediately in both light and dark themes on an iPhone 17 Pro simulator running iOS 26.5


[OK-61462]: https://onekeyhq.atlassian.net/browse/OK-61462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ