### PR TITLE
fix: refine Perps chart controls (OK-61454)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.test.tsx
@@ -73,26 +73,47 @@ jest.mock('@onekeyhq/components', () => ({
     <div>{children}</div>
   ),
   Stack: ({
+    bg,
     borderBottomColor,
     borderBottomWidth,
     children,
+    flexShrink,
+    h,
+    justifyContent,
+    minHeight,
     pb,
     pt,
     py,
+    testID,
+    w,
   }: {
+    bg?: string;
     borderBottomColor?: string;
     borderBottomWidth?: number;
     children?: ReactNode;
+    flexShrink?: number;
+    h?: number | string;
+    justifyContent?: string;
+    minHeight?: number;
     pb?: string;
     pt?: string;
     py?: string;
+    testID?: string;
+    w?: string;
   }) => (
     <div
+      data-bg={bg}
       data-border-bottom-color={borderBottomColor}
       data-border-bottom-width={borderBottomWidth}
+      data-flex-shrink={flexShrink}
+      data-height={h}
+      data-justify-content={justifyContent}
+      data-min-height={minHeight}
       data-pb={pb}
       data-pt={pt}
       data-py={py}
+      data-testid={testID}
+      data-width={w}
     >
       {children}
     </div>
@@ -105,8 +126,10 @@ jest.mock('@onekeyhq/components', () => ({
     flexShrink,
     onPress,
     gap,
+    pl,
     pr,
     testID,
+    transform,
   }: {
     accessibilityLabel?: string;
     alignSelf?: string;
@@ -115,8 +138,10 @@ jest.mock('@onekeyhq/components', () => ({
     flexShrink?: number;
     gap?: string;
     onPress?: (event: unknown) => void;
+    pl?: string;
     pr?: string;
     testID?: string;
+    transform?: { translateY: number }[];
   }) =>
     onPress ? (
       <button
@@ -125,8 +150,10 @@ jest.mock('@onekeyhq/components', () => ({
         data-flex={flex}
         data-flex-shrink={flexShrink}
         data-gap={gap}
+        data-pl={pl}
         data-pr={pr}
         data-testid={testID}
+        data-translate-y={transform?.[0]?.translateY}
         onClick={onPress}
         type="button"
       >
@@ -139,8 +166,10 @@ jest.mock('@onekeyhq/components', () => ({
         data-flex={flex}
         data-flex-shrink={flexShrink}
         data-gap={gap}
+        data-pl={pl}
         data-pr={pr}
         data-testid={testID}
+        data-translate-y={transform?.[0]?.translateY}
       >
         {children}
       </div>
@@ -331,7 +360,7 @@ describe('TradingView chart controls', () => {
     },
   );
 
-  it('keeps default active interval backgrounds outside compact mode', () => {
+  it('uses text-only active intervals in compact mode', () => {
     const { rerender } = render(<TradingViewChartControls {...BASE_PROPS} />);
 
     expect(mockTradingViewNativeIntervalSelector).toHaveBeenLastCalledWith(
@@ -356,7 +385,7 @@ describe('TradingView chart controls', () => {
         .getAttribute('data-gap'),
     ).toBe('$0');
   });
-  it('tightens vertical padding only for compact mobile charts', () => {
+  it('keeps the original height while filling compact charts without a close control', () => {
     const view = render(
       <TradingViewChartControls {...BASE_PROPS} compactMobileLayout />,
     );
@@ -367,8 +396,20 @@ describe('TradingView chart controls', () => {
     expect(view.container.firstElementChild?.getAttribute('data-pb')).toBe(
       '$0.5',
     );
+    expect(
+      view.container.firstElementChild?.getAttribute('data-min-height'),
+    ).toBeNull();
+    expect(
+      view.container.firstElementChild?.getAttribute('data-justify-content'),
+    ).toBeNull();
+    expect(
+      view.queryByTestId('trading-view-compact-chart-controls-row'),
+    ).toBeNull();
     expect(mockTradingViewNativeIntervalSelector).toHaveBeenLastCalledWith(
-      expect.objectContaining({ compactMobileLayout: true }),
+      expect.objectContaining({
+        compactMobileLayout: true,
+        fullWidth: true,
+      }),
     );
     expect(
       view.container.firstElementChild?.getAttribute(
@@ -391,9 +432,9 @@ describe('TradingView chart controls', () => {
       ),
     ).toBe('0');
   });
-  it('uses the full remaining mobile toolbar area as the close action', () => {
+  it('lets compact intervals fill the space beside the close action', () => {
     const handleClose = jest.fn();
-    const { getByTestId } = render(
+    const { container, getByTestId } = render(
       <TradingViewChartControls
         {...BASE_PROPS}
         compactMobileLayout
@@ -403,14 +444,33 @@ describe('TradingView chart controls', () => {
       />,
     );
 
+    expect(container.firstElementChild?.getAttribute('data-py')).toBeNull();
+    expect(container.firstElementChild?.getAttribute('data-pt')).toBeNull();
+    expect(container.firstElementChild?.getAttribute('data-pb')).toBeNull();
+    expect(container.firstElementChild?.getAttribute('data-min-height')).toBe(
+      '42',
+    );
+    expect(
+      container.firstElementChild?.getAttribute('data-justify-content'),
+    ).toBe('center');
+    expect(
+      getByTestId('trading-view-compact-chart-controls-row').getAttribute(
+        'data-translate-y',
+      ),
+    ).toBe('2');
     fireEvent.click(getByTestId('interval-selector'));
     expect(handleClose).not.toHaveBeenCalled();
     expect(mockTradingViewNativeIntervalSelector).toHaveBeenLastCalledWith(
-      expect.objectContaining({ fullWidth: false }),
+      expect.objectContaining({ fullWidth: true }),
     );
     expect(
       getByTestId('trading-view-chart-ready-controls').getAttribute('data-gap'),
-    ).toBe('$2');
+    ).toBe('$0');
+    expect(
+      getByTestId('trading-view-chart-ready-controls').getAttribute(
+        'data-flex',
+      ),
+    ).toBe('1');
     expect(
       getByTestId('trading-view-chart-ready-controls').getAttribute(
         'data-flex-shrink',
@@ -418,7 +478,7 @@ describe('TradingView chart controls', () => {
     ).toBe('1');
     expect(
       getByTestId('interval-selector').parentElement?.getAttribute('data-flex'),
-    ).toBeNull();
+    ).toBe('1');
     expect(
       getByTestId('interval-selector').parentElement?.getAttribute(
         'data-flex-shrink',
@@ -426,9 +486,16 @@ describe('TradingView chart controls', () => {
     ).toBe('1');
 
     const closeArea = getByTestId('trading-view-native-chart-close');
+    const closeDivider = getByTestId('trading-view-native-chart-close-divider');
+    expect(closeDivider.nextElementSibling).toBe(closeArea);
+    expect(closeDivider.getAttribute('data-height')).toBe('$4');
+    expect(closeDivider.getAttribute('data-width')).toBe('$px');
+    expect(closeDivider.getAttribute('data-bg')).toBe('$borderSubdued');
+    expect(closeDivider.getAttribute('data-flex-shrink')).toBe('0');
     expect(closeArea.getAttribute('aria-label')).toBe('Close chart');
-    expect(closeArea.getAttribute('data-flex')).toBe('1');
+    expect(closeArea.getAttribute('data-flex')).toBeNull();
     expect(closeArea.getAttribute('data-align-self')).toBe('stretch');
+    expect(closeArea.getAttribute('data-pl')).toBe('$2');
     expect(closeArea.getAttribute('data-pr')).toBe('$2');
     fireEvent.click(closeArea);
     expect(handleClose).toHaveBeenCalledTimes(1);

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
@@ -90,12 +90,27 @@ export interface ITradingViewChartControlsProps {
   onRightControlPress?: () => void;
 }
 
-function ToolbarSeparator() {
-  return <Stack h="$6" w="$px" bg="$borderSubdued" flexShrink={0} />;
+function ToolbarSeparator({
+  compact = false,
+  testID,
+}: {
+  compact?: boolean;
+  testID?: string;
+}) {
+  return (
+    <Stack
+      testID={testID}
+      h={compact ? '$4' : '$6'}
+      w="$px"
+      bg="$borderSubdued"
+      flexShrink={0}
+    />
+  );
 }
 
 const DESKTOP_CONTROLS_HEIGHT = 38;
 const DESKTOP_FULLSCREEN_CONTROLS_HEIGHT = 64;
+const COMPACT_MOBILE_CONTROLS_MIN_HEIGHT = 42;
 export const TRADING_VIEW_CHART_CONTROLS_HEIGHT = 48;
 
 export const TradingViewChartControls = memo(
@@ -424,6 +439,9 @@ export const TradingViewChartControls = memo(
       calendarControl ||
       settingsControl,
     );
+    const hasCompactChartCloseControl = Boolean(
+      compactMobileLayout && rightControl && onRightControlPress,
+    );
     const shouldFillIntervalSelector =
       compactMobileLayout &&
       hasVisibleIntervalSelector &&
@@ -431,8 +449,12 @@ export const TradingViewChartControls = memo(
       !priceMarketCapControl &&
       !chartSwitchControl &&
       !fullscreenControl &&
-      !rightControl &&
-      !onRightControlPress;
+      (!rightControl || hasCompactChartCloseControl) &&
+      (!onRightControlPress || hasCompactChartCloseControl);
+    const shouldStretchReadyControls =
+      !onRightControlPress || hasCompactChartCloseControl;
+    const shouldUseTightCompactPadding =
+      compactMobileLayout && !hasCompactChartCloseControl;
     const intervalSelector = hasVisibleIntervalSelector ? (
       <TradingViewNativeIntervalSelector
         compactMobileLayout={compactMobileLayout}
@@ -530,21 +552,35 @@ export const TradingViewChartControls = memo(
         bg={backgroundColor}
         px="$2"
         py={compactMobileLayout ? undefined : '$2'}
-        pt={compactMobileLayout ? '$1.5' : undefined}
-        pb={compactMobileLayout ? '$0.5' : undefined}
+        pt={shouldUseTightCompactPadding ? '$1.5' : undefined}
+        pb={shouldUseTightCompactPadding ? '$0.5' : undefined}
+        minHeight={
+          hasCompactChartCloseControl
+            ? COMPACT_MOBILE_CONTROLS_MIN_HEIGHT
+            : undefined
+        }
+        justifyContent={hasCompactChartCloseControl ? 'center' : undefined}
         borderBottomWidth={compactMobileLayout ? 0.5 : 0}
         borderBottomColor="$borderSubdued"
         zIndex={3}
       >
         <XStack
+          testID={
+            hasCompactChartCloseControl
+              ? 'trading-view-compact-chart-controls-row'
+              : undefined
+          }
           alignItems="center"
           justifyContent="space-between"
           width="100%"
           gap="$2"
+          transform={
+            hasCompactChartCloseControl ? [{ translateY: 2 }] : undefined
+          }
         >
           <XStack
             testID="trading-view-chart-ready-controls"
-            flex={onRightControlPress ? undefined : 1}
+            flex={shouldStretchReadyControls ? 1 : undefined}
             flexShrink={
               compactMobileLayout && onRightControlPress ? 1 : undefined
             }
@@ -555,7 +591,7 @@ export const TradingViewChartControls = memo(
             pointerEvents={isControlsReady ? 'auto' : 'none'}
           >
             <XStack
-              flex={onRightControlPress ? undefined : 1}
+              flex={shouldStretchReadyControls ? 1 : undefined}
               flexShrink={
                 compactMobileLayout && onRightControlPress ? 1 : undefined
               }
@@ -580,17 +616,29 @@ export const TradingViewChartControls = memo(
             </XStack>
           ) : null}
 
+          {hasCompactChartCloseControl ? (
+            <ToolbarSeparator
+              compact
+              testID="trading-view-native-chart-close-divider"
+            />
+          ) : null}
+
           <XStack
             testID={
               onRightControlPress
                 ? 'trading-view-native-chart-close'
                 : undefined
             }
-            flex={onRightControlPress ? 1 : undefined}
+            flex={
+              onRightControlPress && !hasCompactChartCloseControl
+                ? 1
+                : undefined
+            }
             alignSelf={onRightControlPress ? 'stretch' : undefined}
             gap="$2"
             alignItems="center"
             justifyContent="flex-end"
+            pl={compactMobileLayout && onRightControlPress ? '$2' : undefined}
             pr={compactMobileLayout && onRightControlPress ? '$2' : undefined}
             accessibilityRole={onRightControlPress ? 'button' : undefined}
             accessibilityLabel={rightControlLabel}

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/intervalSelector/NativeIntervalSelector.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/intervalSelector/NativeIntervalSelector.test.tsx
@@ -82,6 +82,7 @@ jest.mock('@onekeyhq/components', () => ({
     bg,
     children,
     flex,
+    flexBasis,
     flexShrink,
     h,
     justifyContent,
@@ -92,6 +93,7 @@ jest.mock('@onekeyhq/components', () => ({
     bg?: string;
     children?: ReactNode;
     flex?: number;
+    flexBasis?: number;
     flexShrink?: number;
     h?: number;
     justifyContent?: string;
@@ -102,6 +104,7 @@ jest.mock('@onekeyhq/components', () => ({
     <div
       data-bg={bg}
       data-flex={flex}
+      data-flex-basis={flexBasis}
       data-flex-shrink={flexShrink}
       data-height={h}
       data-justify-content={justifyContent}
@@ -239,10 +242,13 @@ describe('TradingViewNativeIntervalSelector', () => {
     expect(mockSegmentControl).toHaveBeenCalledWith(
       expect.objectContaining({
         flex: 6,
+        flexBasis: 0,
         h: 26,
+        minWidth: 0,
         p: '$0',
         segmentControlItemStyleProps: expect.objectContaining({
           flex: 1,
+          flexBasis: 0,
           h: '100%',
           justifyContent: 'center',
           minWidth: 0,
@@ -275,8 +281,14 @@ describe('TradingViewNativeIntervalSelector', () => {
       '26',
     );
     expect(getByText('More').parentElement?.getAttribute('data-flex')).toBe(
-      '1',
+      '1.2',
     );
+    expect(
+      getByText('More').parentElement?.getAttribute('data-flex-basis'),
+    ).toBe('0');
+    expect(
+      getByText('More').parentElement?.getAttribute('data-min-width'),
+    ).toBe('0');
     expect(getByText('More').parentElement?.getAttribute('data-px')).toBe('$0');
     expect(
       getByText('More').parentElement?.getAttribute('data-justify-content'),

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/intervalSelector/NativeIntervalSelector.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/intervalSelector/NativeIntervalSelector.tsx
@@ -27,6 +27,8 @@ import type {
 
 export type { ITradingViewNativeIntervalControlMode } from '../types';
 
+const FULL_WIDTH_MORE_CONTROL_FLEX = 1.2;
+
 interface ITradingViewNativeIntervalSelectorProps {
   compactMobileLayout?: boolean;
   fullWidth?: boolean;
@@ -76,9 +78,10 @@ function IntervalMoreTrigger({
   return (
     <XStack
       testID="trading-view-native-interval-selector-more-select"
-      flex={fullWidth ? 1 : undefined}
+      flex={fullWidth ? FULL_WIDTH_MORE_CONTROL_FLEX : undefined}
+      flexBasis={fullWidth ? 0 : undefined}
       h={compactMobileLayout ? 26 : 30}
-      minWidth={fullWidth ? 42 : undefined}
+      minWidth={fullWidth ? 0 : undefined}
       px={horizontalPadding}
       gap="$1"
       alignItems="center"
@@ -298,7 +301,9 @@ export const TradingViewNativeIntervalSelector = memo(
         {segmentOptions.length ? (
           <SegmentControl
             flex={fullWidth ? segmentOptions.length : undefined}
+            flexBasis={fullWidth ? 0 : undefined}
             flexShrink={shouldShrinkToSiblings ? 1 : undefined}
+            minWidth={fullWidth ? 0 : undefined}
             value={
               visibleSegmentValueSet.has(activeInterval) ? activeInterval : ''
             }
@@ -347,6 +352,7 @@ export const TradingViewNativeIntervalSelector = memo(
             p="$0"
             segmentControlItemStyleProps={{
               flex: fullWidth ? 1 : undefined,
+              flexBasis: fullWidth ? 0 : undefined,
               minWidth: shouldCompressIntervalItems ? 0 : 42,
               px: horizontalPadding,
               py: '$0',

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
@@ -209,7 +209,7 @@ describe('TradingViewNative chart controls', () => {
     };
     expect(controlsProps.hasVisibleIndicators).toBe(false);
     expect(controlsProps.rightControl.props.name).toBe(
-      'ChevronDownSmallOutline',
+      'ChevronTriangleDownSmallSolid',
     );
     expect(controlsProps.rightControl.props.size).toBe('$5');
     expect(controlsProps.rightControlLabel).toBe('global.close');

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
@@ -195,7 +195,11 @@ export const TradingViewNativeChartControlsContainer = memo(
     const shouldShowChartCloseControl =
       Boolean(onChartClose) && showChartCloseControl;
     const closeControl = shouldShowChartCloseControl ? (
-      <Icon name="ChevronDownSmallOutline" size="$5" color="$iconSubdued" />
+      <Icon
+        name="ChevronTriangleDownSmallSolid"
+        size="$5"
+        color="$iconSubdued"
+      />
     ) : null;
     const closeLabel = intl.formatMessage({ id: ETranslations.global_close });
 

--- a/packages/kit/src/views/Perp/components/PerpMobileChartPanel.test.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMobileChartPanel.test.tsx
@@ -218,11 +218,11 @@ describe('PerpMobileChartPanel', () => {
       toggle.querySelector('[data-icon="TradingViewCandlesOutline"]'),
     ).toBeNull();
     expect(
-      toggle.querySelector('[data-icon="ChevronTopSmallOutline"]'),
+      toggle.querySelector('[data-icon="ChevronTriangleUpSmallSolid"]'),
     ).toBeTruthy();
     expect(
       toggle
-        .querySelector('[data-icon="ChevronTopSmallOutline"]')
+        .querySelector('[data-icon="ChevronTriangleUpSmallSolid"]')
         ?.getAttribute('data-size'),
     ).toBe('$5');
     expect(queryByTestId('perp-mobile-chart-content')).toBeNull();

--- a/packages/kit/src/views/Perp/components/PerpMobileChartPanel.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMobileChartPanel.tsx
@@ -296,11 +296,7 @@ export function PerpMobileChartPanel({
           </SizableText>
           <XStack alignItems="center" gap="$3">
             <Icon
-              name={
-                isExpanded
-                  ? 'ChevronDownSmallOutline'
-                  : 'ChevronTopSmallOutline'
-              }
+              name="ChevronTriangleUpSmallSolid"
               size="$5"
               color="$iconSubdued"
             />

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -624,7 +624,7 @@ export const SizeInput = memo(
                 {inputMode === 'token' ? symbol || tokenFallbackLabel : 'USD'}
               </SizableText>
               <Icon
-                name="ChevronDownSmallOutline"
+                name="ChevronTriangleDownSmallSolid"
                 size="$4"
                 color="$iconSubdued"
               />

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/MobileOrderTypeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/MobileOrderTypeSelector.tsx
@@ -71,7 +71,11 @@ function MobileOrderTypeSelector({
       <SizableText size="$bodyMdMedium">
         {selectedOption?.label ?? ''}
       </SizableText>
-      <Icon name="ChevronDownSmallOutline" color="$iconSubdued" size="$4" />
+      <Icon
+        name="ChevronTriangleDownSmallSolid"
+        color="$iconSubdued"
+        size="$4"
+      />
     </XStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/OrderTypeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/OrderTypeSelector.tsx
@@ -59,7 +59,7 @@ export const OrderTypeSelector = memo<IOrderTypeSelectorProps>(
           >
             <SizableText size="$bodyMdMedium">{label}</SizableText>
             <Icon
-              name="ChevronDownSmallOutline"
+              name="ChevronTriangleDownSmallSolid"
               color="$iconSubdued"
               size="$4"
             />

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/SizeInputModeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/SizeInputModeSelector.tsx
@@ -87,7 +87,11 @@ export function SizeInputModeSelector({
       <SizableText size="$bodyMdMedium" color="$textSubdued">
         {resolvedValue === 'token' ? tokenSymbol || tokenFallbackLabel : 'USD'}
       </SizableText>
-      <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
+      <Icon
+        name="ChevronTriangleDownSmallSolid"
+        size="$4"
+        color="$iconSubdued"
+      />
     </XStack>
   );
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61454](https://onekeyhq.atlassian.net/browse/OK-61454)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issue

[OK-61454](https://onekeyhq.atlassian.net/browse/OK-61454)

## Summary

- Refine the compact mobile chart toolbar layout while preserving the existing height for the top-chart position.
- Center the bottom-chart controls, balance the divider and close-action spacing, and distribute the six preferred intervals evenly with a slightly wider `More` trigger.
- Replace chart expand/collapse and Perps order/size selector chevrons with solid triangle icons across mobile and desktop.
- Update regression coverage for toolbar layout, interval sizing, and icon selection.

## Test Plan

- [x] Focused Jest tests: 6 suites, 40 tests
- [x] `yarn agent:check --profile commit`
- [x] `yarn agent:check --profile pr`
- [ ] Native UI verification (by requester)


[OK-61454]: https://onekeyhq.atlassian.net/browse/OK-61454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ