### PR TITLE
fix: restore horizontal button group layout OK-61467

### DIFF
--- a/packages/components/src/primitives/ButtonGroup/index.tsx
+++ b/packages/components/src/primitives/ButtonGroup/index.tsx
@@ -78,6 +78,7 @@ function BasicButtonGroup({
         type="single"
         disabled={disabled}
         orientation={orientation}
+        flexDirection={orientation === 'horizontal' ? 'row' : 'column'}
         value={undefined}
       >
         {children}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61467](https://onekeyhq.atlassian.net/browse/OK-61467)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- explicitly map `ButtonGroup` orientation to its flex direction
- restore the horizontal pagination layout after the Tamagui 2.7.7 upgrade
- preserve vertical `ButtonGroup` behavior

## Root cause

Tamagui 2.7.7 no longer applies layout direction from `ToggleGroup.orientation`. React Native therefore falls back to a column layout even when the component orientation is horizontal.

## Validation

- `yarn agent:check --profile commit`
- `git diff --check`

Jira: https://onekeyhq.atlassian.net/browse/OK-61467

[OK-61467]: https://onekeyhq.atlassian.net/browse/OK-61467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ