### PR TITLE
fix: preserve background RPC errors OK-61451

### DIFF
--- a/apps/mobile/src/backgroundThread/rpcProtocol.ts
+++ b/apps/mobile/src/backgroundThread/rpcProtocol.ts
@@ -103,7 +103,6 @@ export type IBackgroundThreadResponseErrorPayload = {
   key?: string;
   requestId?: string;
   httpStatusCode?: number;
-  constructorName?: string;
   data?: unknown;
   payload?: unknown;
 };

--- a/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.test.ts
+++ b/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.test.ts
@@ -1,0 +1,150 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+const mockSharedRPCWrite = jest.fn();
+const mockSharedRPCRegisterReadinessKey = jest.fn();
+const mockSharedStoreGet = jest.fn();
+const mockSharedStoreSet = jest.fn();
+const mockNativeLoggerWrite = jest.fn();
+
+let mockInboundMessageHandler:
+  | ((key: string, value: string | number | boolean) => void)
+  | undefined;
+
+function dispatchServiceRequest(callId: string) {
+  mockInboundMessageHandler?.(
+    `onekey:bg:req:${callId}`,
+    JSON.stringify({
+      type: 'service-call',
+      method: 'servicePrime.apiRedeemPrimeCode',
+      params: ['OK61451-INVALID-CODE'],
+      sync: false,
+    }),
+  );
+}
+
+async function flushRequest() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function getResponse(callId: string): unknown {
+  const responseKey = `onekey:bg:res:${callId}`;
+  const responseWrites = mockSharedRPCWrite.mock.calls.filter(
+    ([key]) => key === responseKey,
+  );
+  return JSON.parse(
+    responseWrites[responseWrites.length - 1]?.[1] as string,
+  ) as unknown;
+}
+
+const fallbackResponse = {
+  ok: false,
+  error: {
+    name: 'BackgroundThreadResponseError',
+    message: 'Background response failed',
+  },
+};
+
+jest.mock('@onekeyfe/react-native-background-thread', () => ({
+  getSharedRPC: () => ({
+    write: mockSharedRPCWrite,
+    onWrite: (
+      handler: (key: string, value: string | number | boolean) => void,
+    ) => {
+      mockInboundMessageHandler = handler;
+    },
+    registerReadinessKey: mockSharedRPCRegisterReadinessKey,
+  }),
+  getSharedStore: () => ({
+    get: mockSharedStoreGet,
+    set: mockSharedStoreSet,
+  }),
+}));
+
+jest.mock('@onekeyhq/shared/src/errors', () => ({
+  OneKeyLocalError: class MockOneKeyLocalError extends Error {},
+}));
+
+jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
+  appEventBus: {
+    dispatchInboundFromForeground: jest.fn(),
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    app: {
+      eventBus: {
+        missingOriginNodeId: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock(
+  '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger',
+  () => ({
+    LogLevel: { Error: 'error', Info: 'info' },
+    NativeLogger: { write: mockNativeLoggerWrite },
+  }),
+);
+
+describe('background thread RPC handler', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('writes a minimal error response when the original error is not serializable', async () => {
+    const { setBackgroundThreadRequestExecutor } =
+      await import('./setupBackgroundThreadRPCHandler');
+    const error = new OneKeyLocalError('Original error') as Error & {
+      payload?: unknown;
+    };
+    error.payload = { value: 1n };
+    setBackgroundThreadRequestExecutor(() => Promise.reject(error));
+    mockSharedRPCWrite.mockClear();
+
+    dispatchServiceRequest('1');
+    await flushRequest();
+
+    expect(getResponse('1')).toEqual(fallbackResponse);
+  });
+
+  it('writes a minimal error response when reading error metadata fails', async () => {
+    const { setBackgroundThreadRequestExecutor } =
+      await import('./setupBackgroundThreadRPCHandler');
+    const error = new OneKeyLocalError('Original error');
+    Object.defineProperty(error, 'message', {
+      get: () => {
+        throw new OneKeyLocalError('Message getter failed');
+      },
+    });
+    setBackgroundThreadRequestExecutor(() => Promise.reject(error));
+    mockSharedRPCWrite.mockClear();
+
+    dispatchServiceRequest('2');
+    await flushRequest();
+
+    expect(getResponse('2')).toEqual(fallbackResponse);
+  });
+
+  it('retries a failed response write with the minimal error response', async () => {
+    const { setBackgroundThreadRequestExecutor } =
+      await import('./setupBackgroundThreadRPCHandler');
+    setBackgroundThreadRequestExecutor(() => Promise.resolve({ value: 1 }));
+    mockSharedRPCWrite.mockClear();
+    mockSharedRPCWrite.mockImplementationOnce(() => {
+      throw new OneKeyLocalError('Native write failed');
+    });
+
+    dispatchServiceRequest('3');
+    await flushRequest();
+
+    expect(getResponse('3')).toEqual(fallbackResponse);
+  });
+});

--- a/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.ts
+++ b/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.ts
@@ -147,7 +147,6 @@ function buildErrorPayload(error: unknown) {
     key?: unknown;
     requestId?: unknown;
     httpStatusCode?: unknown;
-    constructorName?: unknown;
     data?: unknown;
     payload?: unknown;
   };
@@ -162,7 +161,6 @@ function buildErrorPayload(error: unknown) {
     key?: string;
     requestId?: string;
     httpStatusCode?: number;
-    constructorName?: string;
     data?: unknown;
     payload?: unknown;
   } = {
@@ -195,9 +193,6 @@ function buildErrorPayload(error: unknown) {
   }
   if (typeof runtimeError?.httpStatusCode === 'number') {
     errorPayload.httpStatusCode = runtimeError.httpStatusCode;
-  }
-  if (typeof runtimeError?.constructorName === 'string') {
-    errorPayload.constructorName = runtimeError.constructorName;
   }
   const safeData = buildSafeBackgroundThreadErrorData(runtimeError?.data);
   if (safeData) {

--- a/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.ts
+++ b/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.ts
@@ -1,4 +1,5 @@
 import {
+  type ISharedRPC,
   getSharedRPC,
   getSharedStore,
 } from '@onekeyfe/react-native-background-thread';
@@ -24,6 +25,7 @@ import {
   type IBackgroundThreadJotaiStateBroadcastBatchPayload,
   type IBackgroundThreadJotaiStateBroadcastPayload,
   type IBackgroundThreadRequest,
+  type IBackgroundThreadResponsePayload,
   type IBackgroundThreadServiceCallRequest,
   WEBEMBED_BRIDGE_RESPONSE_KEY_PREFIX,
   buildBackgroundThreadAppEventKey,
@@ -128,6 +130,84 @@ function logBgRpcTrace(message: string, level: 'info' | 'error' = 'info') {
   } catch {
     /* noop */
   }
+}
+
+function getBackgroundThreadErrorMessage(error: unknown) {
+  try {
+    return (error as Error)?.message || 'unknown';
+  } catch {
+    return 'unreadable error';
+  }
+}
+
+const SERIALIZED_BACKGROUND_THREAD_RESPONSE_FALLBACK =
+  serializeBackgroundThreadResponse({
+    ok: false,
+    error: {
+      name: 'BackgroundThreadResponseError',
+      message: 'Background response failed',
+    },
+  });
+
+function writeBackgroundThreadResponse({
+  sharedRPC,
+  responseKey,
+  buildResponse,
+  callId,
+  requestLabel,
+}: {
+  sharedRPC: ISharedRPC;
+  responseKey: string;
+  buildResponse: () => IBackgroundThreadResponsePayload;
+  callId: string;
+  requestLabel: string;
+}) {
+  let serializedResponse = SERIALIZED_BACKGROUND_THREAD_RESPONSE_FALLBACK;
+  let isFallbackResponse = false;
+  try {
+    serializedResponse = serializeBackgroundThreadResponse(buildResponse());
+  } catch (serializationError) {
+    isFallbackResponse = true;
+    logBgRpcTrace(
+      `serialize-fail callId=${callId}, request=${requestLabel}, error=${getBackgroundThreadErrorMessage(
+        serializationError,
+      )}`,
+      'error',
+    );
+  }
+
+  try {
+    sharedRPC.write(responseKey, serializedResponse);
+    return !isFallbackResponse;
+  } catch (writeError) {
+    logBgRpcTrace(
+      `write-fail callId=${callId}, request=${requestLabel}, error=${getBackgroundThreadErrorMessage(
+        writeError,
+      )}`,
+      'error',
+    );
+  }
+
+  if (!isFallbackResponse) {
+    try {
+      sharedRPC.write(
+        responseKey,
+        SERIALIZED_BACKGROUND_THREAD_RESPONSE_FALLBACK,
+      );
+      logBgRpcTrace(
+        `fallback-write-ok callId=${callId}, request=${requestLabel}`,
+      );
+    } catch (fallbackWriteError) {
+      logBgRpcTrace(
+        `fallback-write-fail callId=${callId}, request=${requestLabel}, error=${getBackgroundThreadErrorMessage(
+          fallbackWriteError,
+        )}`,
+        'error',
+      );
+    }
+  }
+
+  return false;
 }
 
 const bridgeStateMap: Partial<
@@ -477,22 +557,18 @@ async function handleRequest(callId: string, value: string | number | boolean) {
         Date.now() - requestStartedAt
       }`,
     );
-    try {
-      sharedRPC.write(
-        responseKey,
-        serializeBackgroundThreadResponse({
-          ok: true,
-          result,
-        }),
-      );
+    const isOriginalResponseWritten = writeBackgroundThreadResponse({
+      sharedRPC,
+      responseKey,
+      buildResponse: () => ({
+        ok: true,
+        result,
+      }),
+      callId,
+      requestLabel,
+    });
+    if (isOriginalResponseWritten) {
       logBgRpcTrace(`write-ok callId=${callId}, request=${requestLabel}`);
-    } catch (writeError) {
-      logBgRpcTrace(
-        `write-fail callId=${callId}, request=${requestLabel}, error=${
-          (writeError as Error)?.message || 'unknown'
-        }`,
-        'error',
-      );
     }
     if (shouldTracePendingInstallTask) {
       logBgRpcTrace(
@@ -505,22 +581,16 @@ async function handleRequest(callId: string, value: string | number | boolean) {
     logBgRpcTrace(
       `error callId=${callId}, request=${requestLabel}, elapsedMs=${
         Date.now() - requestStartedAt
-      }, message=${(error as Error)?.message || 'unknown'}`,
+      }, message=${getBackgroundThreadErrorMessage(error)}`,
       'error',
     );
-    try {
-      sharedRPC.write(
-        responseKey,
-        serializeBackgroundThreadResponse(buildErrorPayload(error)),
-      );
-    } catch (writeError) {
-      logBgRpcTrace(
-        `error-write-fail callId=${callId}, error=${
-          (writeError as Error)?.message || 'unknown'
-        }`,
-        'error',
-      );
-    }
+    writeBackgroundThreadResponse({
+      sharedRPC,
+      responseKey,
+      buildResponse: () => buildErrorPayload(error),
+      callId,
+      requestLabel,
+    });
   } finally {
     if (traceHeartbeatTimer) {
       clearInterval(traceHeartbeatTimer);

--- a/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.test.ts
+++ b/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.test.ts
@@ -43,6 +43,14 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   },
 }));
 
+jest.mock('@onekeyhq/shared/src/errors', () => ({
+  OneKeyLocalError: class OneKeyLocalError extends Error {
+    get key() {
+      return 'onekey_error';
+    }
+  },
+}));
+
 jest.mock(
   '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger',
   () => ({
@@ -164,5 +172,70 @@ describe('main thread background runner', () => {
       className: 'OneKeyServerApiError',
       code: 404,
     });
+  });
+
+  it('rejects a remote call when error metadata rehydration fails', async () => {
+    await import('./setupMainThreadBackgroundRunner');
+
+    const transport = (
+      globalThis as typeof globalThis & {
+        __onekeyNativeBackgroundThreadTransport?: {
+          callServiceRequest: (
+            request: {
+              type: 'service-call';
+              method: string;
+              params: unknown[];
+              sync: boolean;
+            },
+            localFallback: () => Promise<unknown>,
+          ) => Promise<unknown>;
+        };
+      }
+    ).__onekeyNativeBackgroundThreadTransport;
+
+    const requestPromise = transport!.callServiceRequest(
+      {
+        type: 'service-call',
+        method: 'servicePrime.apiRedeemPrimeCode',
+        params: ['OK61451-INVALID-CODE'],
+        sync: false,
+      },
+      () => Promise.resolve(undefined),
+    );
+    const requestCalls = mockSharedRPCWrite.mock.calls.filter(
+      ([key]) => typeof key === 'string' && key.startsWith('onekey:bg:req:'),
+    );
+    const requestCall = requestCalls[requestCalls.length - 1];
+    const callId = (requestCall?.[0] as string).slice('onekey:bg:req:'.length);
+
+    expect(() =>
+      mockInboundMessageHandler?.(
+        `onekey:bg:res:${callId}`,
+        JSON.stringify({
+          ok: false,
+          error: {
+            name: 'OneKeyServerApiError',
+            message: '/prime/v1/account/profile Not Found',
+            autoToast: true,
+            className: 'OneKeyServerApiError',
+            code: 404,
+            key: 'server_error',
+          },
+        }),
+      ),
+    ).not.toThrow();
+
+    await expect(requestPromise).rejects.toMatchObject({
+      name: 'OneKeyServerApiError',
+      message: '/prime/v1/account/profile Not Found',
+      autoToast: true,
+      className: 'OneKeyServerApiError',
+      code: 404,
+      key: 'onekey_error',
+    });
+    expect(mockNativeLoggerWrite).toHaveBeenCalledWith(
+      'info',
+      expect.stringContaining('failed to rehydrate error metadata'),
+    );
   });
 });

--- a/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.test.ts
+++ b/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.test.ts
@@ -1,0 +1,168 @@
+const mockSharedRPCWrite = jest.fn();
+const mockSharedRPCRegisterReadinessKey = jest.fn();
+const mockSharedStoreSet = jest.fn();
+const mockNativeLoggerWrite = jest.fn();
+const mockAsyncStorageWriteForwarderGlobal: Record<string, unknown> = {};
+
+let mockInboundMessageHandler:
+  | ((key: string, value: string | number | boolean) => void)
+  | undefined;
+
+const mockReadyPayload = JSON.stringify({
+  runtime: 'background',
+  status: 'ready',
+  protocolVersion: '1',
+  bootId: 'test-boot-id',
+  ts: 1,
+});
+
+jest.mock('@onekeyfe/react-native-background-thread', () => ({
+  getSharedRPC: () => ({
+    write: mockSharedRPCWrite,
+    onWrite: (
+      handler: (key: string, value: string | number | boolean) => void,
+    ) => {
+      mockInboundMessageHandler = handler;
+    },
+    registerReadinessKey: mockSharedRPCRegisterReadinessKey,
+  }),
+  getSharedStore: () => ({
+    get: () => mockReadyPayload,
+    set: mockSharedStoreSet,
+  }),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    enableNativeBackgroundThread: true,
+    isNativeAndroid: true,
+    isNativeBackgroundThread: false,
+    isNativeIOS: false,
+    isNativeMainThread: true,
+  },
+}));
+
+jest.mock(
+  '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger',
+  () => ({
+    LogLevel: { Error: 'error', Info: 'info' },
+    NativeLogger: { write: mockNativeLoggerWrite },
+  }),
+);
+
+jest.mock('@onekeyhq/shared/src/appGlobals', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
+  EAppEventBusNames: {
+    LoadWebEmbedWebView: 'LoadWebEmbedWebView',
+    LoadWebEmbedWebViewComplete: 'LoadWebEmbedWebViewComplete',
+  },
+  appEventBus: {
+    dispatchInboundFromBackground: jest.fn(),
+    emit: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+jest.mock(
+  '@onekeyhq/shared/src/storage/asyncStorageWriteForwarderTypes',
+  () => ({
+    buildAsyncStorageWriteForwarderStatusKey: jest.fn(),
+    getAsyncStorageWriteForwarderGlobal: () =>
+      mockAsyncStorageWriteForwarderGlobal,
+    parseAsyncStorageWriteForwarderRequestStatus: jest.fn(),
+    serializeAsyncStorageWriteForwarderRequestStatus: jest.fn(),
+  }),
+);
+
+jest.mock('@onekeyhq/shared/src/utils/imageUtils.embedBridge', () => ({
+  registerImageEmbedBridge: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/apis/backgroundApiPermissions', () => ({
+  isWebEmbedApiAllowedOrigin: jest.fn(() => true),
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/jotaiInitFromUi', () => ({
+  jotaiUpdateFromUiByBgBroadcast: jest.fn(),
+}));
+
+jest.mock('./runtimeState', () => ({
+  setBackgroundThreadReadyPayload: jest.fn(),
+}));
+
+describe('main thread background runner', () => {
+  afterAll(() => {
+    delete (
+      globalThis as typeof globalThis & {
+        __onekeyNativeBackgroundThreadTransport?: unknown;
+      }
+    ).__onekeyNativeBackgroundThreadTransport;
+  });
+
+  it('rejects a remote call when a legacy error contains constructorName', async () => {
+    await import('./setupMainThreadBackgroundRunner');
+
+    const transport = (
+      globalThis as typeof globalThis & {
+        __onekeyNativeBackgroundThreadTransport?: {
+          callServiceRequest: (
+            request: {
+              type: 'service-call';
+              method: string;
+              params: unknown[];
+              sync: boolean;
+            },
+            localFallback: () => Promise<unknown>,
+          ) => Promise<unknown>;
+        };
+      }
+    ).__onekeyNativeBackgroundThreadTransport;
+
+    expect(transport).toBeDefined();
+    expect(mockInboundMessageHandler).toBeDefined();
+
+    const requestPromise = transport!.callServiceRequest(
+      {
+        type: 'service-call',
+        method: 'servicePrime.apiRedeemPrimeCode',
+        params: ['OK61451-INVALID-CODE'],
+        sync: false,
+      },
+      () => Promise.resolve(undefined),
+    );
+    const requestCall = mockSharedRPCWrite.mock.calls.find(
+      ([key]) => typeof key === 'string' && key.startsWith('onekey:bg:req:'),
+    );
+    const callId = (requestCall?.[0] as string).slice('onekey:bg:req:'.length);
+
+    expect(() =>
+      mockInboundMessageHandler?.(
+        `onekey:bg:res:${callId}`,
+        JSON.stringify({
+          ok: false,
+          error: {
+            name: 'OneKeyServerApiError',
+            message: '/prime/v1/account/profile Not Found',
+            autoToast: true,
+            className: 'OneKeyServerApiError',
+            code: 404,
+            constructorName: 'OneKeyServerApiError',
+          },
+        }),
+      ),
+    ).not.toThrow();
+
+    await expect(requestPromise).rejects.toMatchObject({
+      name: 'OneKeyServerApiError',
+      message: '/prime/v1/account/profile Not Found',
+      autoToast: true,
+      className: 'OneKeyServerApiError',
+      code: 404,
+    });
+  });
+});

--- a/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.ts
+++ b/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.ts
@@ -1038,10 +1038,10 @@ function handleBackgroundThreadResponse(
   }
 
   const errorInfo = response.error;
-  const error = createTransportError(
+  const errorMessage =
     errorInfo?.message ||
-      `Background request failed without error payload. callId=${callId}`,
-  ) as Error & {
+    `Background request failed without error payload. callId=${callId}`;
+  let error = new Error(errorMessage) as Error & {
     name?: string;
     stack?: string;
     autoToast?: boolean;
@@ -1051,52 +1051,58 @@ function handleBackgroundThreadResponse(
     key?: string;
     requestId?: string;
     httpStatusCode?: number;
-    constructorName?: string;
     data?: unknown;
     payload?: unknown;
   };
-  if (errorInfo?.name) {
-    error.name = errorInfo.name;
+  try {
+    error = createTransportError(errorMessage);
+    if (errorInfo?.name) {
+      error.name = errorInfo.name;
+    }
+    if (errorInfo?.stack) {
+      error.stack = errorInfo.stack;
+    }
+    // Rehydrate OneKeyError metadata stripped by JSON RPC so downstream
+    // toast / i18n / dedup logic behaves the same as non-split thread mode.
+    if (typeof errorInfo?.autoToast === 'boolean') {
+      error.autoToast = errorInfo.autoToast;
+    }
+    if (typeof errorInfo?.className === 'string') {
+      error.className = errorInfo.className;
+    }
+    if (errorInfo?.$isHardwareError === true) {
+      error.$isHardwareError = true;
+    }
+    if (
+      typeof errorInfo?.code === 'string' ||
+      typeof errorInfo?.code === 'number'
+    ) {
+      error.code = errorInfo.code;
+    }
+    if (typeof errorInfo?.key === 'string') {
+      error.key = errorInfo.key;
+    }
+    if (typeof errorInfo?.requestId === 'string') {
+      error.requestId = errorInfo.requestId;
+    }
+    if (typeof errorInfo?.httpStatusCode === 'number') {
+      error.httpStatusCode = errorInfo.httpStatusCode;
+    }
+    if (errorInfo?.data !== undefined) {
+      error.data = errorInfo.data;
+    }
+    if (errorInfo?.payload !== undefined) {
+      error.payload = errorInfo.payload;
+    }
+  } catch (metadataError) {
+    transportLog(
+      `handleResponse: failed to rehydrate error metadata. callId=${callId}, error=${
+        (metadataError as Error)?.message || String(metadataError)
+      }`,
+    );
+  } finally {
+    pendingCall.reject(error);
   }
-  if (errorInfo?.stack) {
-    error.stack = errorInfo.stack;
-  }
-  // Rehydrate OneKeyError metadata stripped by JSON RPC so downstream
-  // toast / i18n / dedup logic behaves the same as non-split thread mode.
-  if (typeof errorInfo?.autoToast === 'boolean') {
-    error.autoToast = errorInfo.autoToast;
-  }
-  if (typeof errorInfo?.className === 'string') {
-    error.className = errorInfo.className;
-  }
-  if (errorInfo?.$isHardwareError === true) {
-    error.$isHardwareError = true;
-  }
-  if (
-    typeof errorInfo?.code === 'string' ||
-    typeof errorInfo?.code === 'number'
-  ) {
-    error.code = errorInfo.code;
-  }
-  if (typeof errorInfo?.key === 'string') {
-    error.key = errorInfo.key;
-  }
-  if (typeof errorInfo?.requestId === 'string') {
-    error.requestId = errorInfo.requestId;
-  }
-  if (typeof errorInfo?.httpStatusCode === 'number') {
-    error.httpStatusCode = errorInfo.httpStatusCode;
-  }
-  if (typeof errorInfo?.constructorName === 'string') {
-    error.constructorName = errorInfo.constructorName;
-  }
-  if (errorInfo?.data !== undefined) {
-    error.data = errorInfo.data;
-  }
-  if (errorInfo?.payload !== undefined) {
-    error.payload = errorInfo.payload;
-  }
-  pendingCall.reject(error);
 }
 
 function handleBackgroundThreadJotaiStateUpdate(


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61451](https://onekeyhq.atlassian.net/browse/OK-61451)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- stop serializing `constructorName`, which is a getter-only property on the main-runtime error
- always reject the pending RPC call even when error metadata rehydration fails
- add a regression test for legacy responses that still contain `constructorName`

## Verification

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn jest apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.test.ts apps/mobile/src/backgroundThread/rpcProtocol.test.ts --runInBand`
- Android 14 manual verification: an invalid Prime redemption code finishes loading and renders `/prime/v1/account/profile Not Found` in the UI

## Issue

- [OK-61451](https://onekeyhq.atlassian.net/browse/OK-61451)

[OK-61451]: https://onekeyhq.atlassian.net/browse/OK-61451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ