### PR TITLE
fix: disable iOS tab content crossfade OK-61355

### DIFF
--- a/patches/@onekeyfe+react-native-tab-view+3.0.95.patch
+++ b/patches/@onekeyfe+react-native-tab-view+3.0.95.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift b/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift
+index 302f239..386998c 100644
+--- a/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift
++++ b/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift
+@@ -731,6 +731,27 @@ class RCTTabViewContainerView: UIView {
+   }
+ }
+ 
++// OneKey patch: keep native tab selection immediate while suppressing UIKit's content crossfade.
++private final class ImmediateTabTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
++  static let shared = ImmediateTabTransitionAnimator()
++
++  func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
++    0
++  }
++
++  func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
++    guard let toViewController = transitionContext.viewController(forKey: .to),
++          let toView = transitionContext.view(forKey: .to) ?? toViewController.view else {
++      transitionContext.completeTransition(false)
++      return
++    }
++
++    toView.frame = transitionContext.finalFrame(for: toViewController)
++    transitionContext.containerView.addSubview(toView)
++    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
++  }
++}
++
+ // MARK: - UITabBarControllerDelegate proxy
+ 
+ class TabViewDelegateProxy: NSObject, UITabBarControllerDelegate {
+@@ -757,6 +778,19 @@ class TabViewDelegateProxy: NSObject, UITabBarControllerDelegate {
+ 
+     return false
+   }
++
++  func tabBarController(
++    _ tabBarController: UITabBarController,
++    animationControllerForTransitionFrom fromViewController: UIViewController,
++    to toViewController: UIViewController
++  ) -> UIViewControllerAnimatedTransitioning? {
++    guard let containerView = mapping[ObjectIdentifier(tabBarController)],
++          containerView.disablePageAnimations else {
++      return nil
++    }
++
++    return ImmediateTabTransitionAnimator.shared
++  }
+ }
+ 
+ // MARK: - Long press gesture handler


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61355](https://onekeyhq.atlassian.net/browse/OK-61355)

----------

<!-- github-pr-monitor:jira-links:end -->


[OK-61355](https://onekeyhq.atlassian.net/browse/OK-61355)

## Summary

- Keep the user-tap path on UIKit's immediate native tab selection.
- When `disablePageAnimations` is enabled, replace only the tab content transition with a zero-duration native animator.
- Preserve the system tab bar/Liquid Glass selection animation, haptics, reselection, native `preventsDefault`, and the existing programmatic-selection behavior.

## Root cause

On a tab tap, `UITabBarControllerDelegate.shouldSelect` returns synchronously, so UIKit selects the destination controller and starts its default content transition before the later JS navigation-state update. The existing `disablePageAnimations` handling only covered programmatic `selectedIndex` updates; by the time JS committed `selectedPage`, the selected index already matched and that path returned early.

The pages are not unloaded during warm switches: React's visited-scene set only grows, and the native container caches view controllers by tab key. Runtime traces reused the same view-controller identities with a stable four-controller cache. A native-only, single-variable A/B changed the visible result from a multi-frame crossfade to one frame boundary without changing JS bundles or page lifecycle code, isolating the delay and ghosting to UIKit's default content transition.

JS tracing also showed that `navigation.emit` and dispatch return take about 0.05 ms each; native click to JS event was about 14 ms median, React layout commit followed about 3.7 ms later, and the selected-page prop returned to native about 49 ms median. Moving the router to another runtime would not remove this scheduling/commit path.

Runtime scope: iOS main UI runtime. The `UITabBarController`, React navigation state, reconciliation, and Fabric commit belong to the main UI runtime. The independently initialized background Hermes runtime has an isolated JS heap and does not own this UI state. Main/background bundles remain version-locked; no bg behavior or shared native storage is changed.

## Verification

- Rebasing onto current `x` upgraded `@onekeyfe/react-native-tab-view` to 3.0.95. The patch was regenerated from the pristine Yarn archive and independently passed `git apply --check`; it contains no build artifacts.
- A current-SHA production Release build succeeded with Xcode whole-module Swift compilation and split main/background Hermes bundles using `development/scripts/ios-release-build-deploy.sh`.
- Split-bundle integrity passed across 2344 main, 270 bg, and 26 bg-shared segments with zero cross-segment sync violations.
- Same iOS 26.5 simulator, same warm tab scenes, 30 fps diagnostic capture:
  - UIKit default animator: blended content remained visible across about 6-10 frames, roughly 200-330 ms;
  - zero-duration animator: content changed at one captured frame boundary with no blended content frame in either direction.
- The bottom Liquid Glass selection feedback continued animating independently across multiple frames.
- Wallet, Trade, Perps, Discover, repeated switching, and reselection were exercised without a crash; accessibility assertions confirmed each destination selected state.
- Temporary native/JS timing logs were removed; the final Release contained no diagnostic markers.
- `yarn agent:check --profile commit` passed. The PR profile reports all local checks passing, remote CI 25 passed / 0 failed / 0 pending, and no unresolved review threads; approval is still required.

Not covered: physical-device timing validation; the measured A/B was on the same iOS 26.5 simulator and Release configuration.


[OK-61355]: https://onekeyhq.atlassian.net/browse/OK-61355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ