### PR TITLE
fix: keep borrow manage tabs switchable (OK-59797)

### DIFF
--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
@@ -144,26 +144,22 @@ const ManageSectionShell = ({
   const activeIndex = defaultTab === 'withdraw' ? 1 : 0;
   const tabLabels = [primaryLabel, secondaryLabel];
   const activeLabel = activeIndex === 1 ? secondaryLabel : primaryLabel;
-  const hideTypeSwitch = [
-    EManagePositionType.Withdraw,
-    EManagePositionType.Repay,
-  ].includes(type);
   const borrowAction = useMemo(() => {
     if (
       [EManagePositionType.Supply, EManagePositionType.Withdraw].includes(type)
     ) {
-      return hideTypeSwitch || activeIndex === 1 ? 'withdraw' : 'supply';
+      return activeIndex === 1 ? 'withdraw' : 'supply';
     }
     if (
       [EManagePositionType.Borrow, EManagePositionType.Repay].includes(type)
     ) {
-      return hideTypeSwitch || activeIndex === 1 ? 'repay' : 'borrow';
+      return activeIndex === 1 ? 'repay' : 'borrow';
     }
     return undefined;
-  }, [activeIndex, hideTypeSwitch, type]);
+  }, [activeIndex, type]);
 
-  // When the type switcher is visible, the loaded layout has gap $1.5 between
-  // it and the content: in the details panel that comes from
+  // The loaded layout has gap $1.5 between the type switcher and the content:
+  // in the details panel that comes from
   // ManagePositionPart's <YStack gap="$1.5"> wrapping the (fragment)
   // NormalManageContent; in the modal there is no such wrapper. Reproduce that
   // gap deterministically here (a single wrapping YStack means the parent gap
@@ -173,32 +169,30 @@ const ManageSectionShell = ({
 
   return (
     <YStack gap={isInModalContext ? undefined : '$1.5'}>
-      {hideTypeSwitch ? null : (
-        <XStack px="$5">
-          {tabLabels.map((label, index) => {
-            const isFocused = index === activeIndex;
-            return (
-              <XStack
-                key={label}
-                px="$2"
-                py="$1.5"
-                mr="$1"
-                bg={isFocused ? '$bgActive' : '$bg'}
-                borderRadius="$2"
-                borderCurve="continuous"
+      <XStack px="$5">
+        {tabLabels.map((label, index) => {
+          const isFocused = index === activeIndex;
+          return (
+            <XStack
+              key={label}
+              px="$2"
+              py="$1.5"
+              mr="$1"
+              bg={isFocused ? '$bgActive' : '$bg'}
+              borderRadius="$2"
+              borderCurve="continuous"
+            >
+              <SizableText
+                size="$headingMd"
+                color={isFocused ? '$text' : '$textSubdued'}
+                letterSpacing={-0.15}
               >
-                <SizableText
-                  size="$headingMd"
-                  color={isFocused ? '$text' : '$textSubdued'}
-                  letterSpacing={-0.15}
-                >
-                  {label}
-                </SizableText>
-              </XStack>
-            );
-          })}
-        </XStack>
-      )}
+                {label}
+              </SizableText>
+            </XStack>
+          );
+        })}
+      </XStack>
 
       {/* Form body — mirrors StakingFormWrapper (px $5 / py $2.5 / gap $4) so
           the layout is identical when real data lands. */}

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/NormalManageContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/NormalManageContent.tsx
@@ -645,70 +645,59 @@ export function NormalManageContent({
     ],
   );
 
-  // When the model is opened directly in Withdraw / Repay mode, the paired
-  // Supply / Borrow tab is disabled, so the type switcher is pointless — hide
-  // it and keep only the form (HeaderRight stays right-aligned).
-  const hideTypeSwitch = [
-    EManagePositionType.Withdraw,
-    EManagePositionType.Repay,
-  ].includes(type);
-
   return (
     <>
-      <XStack jc={hideTypeSwitch ? 'flex-end' : 'space-between'} px="$5">
-        {hideTypeSwitch ? null : (
-          <Tabs.TabBar
-            divider={false}
-            onTabPress={handleTabChange}
-            tabNames={tabNames}
-            focusedTab={focusedTab}
-            renderItem={({ name, isFocused }) => {
-              const isDisabled =
-                shouldDisablePrimaryTab && name === tabNames[0];
-              let textColor: '$textDisabled' | '$text' | '$textSubdued' =
-                '$textSubdued';
+      <XStack jc="space-between" px="$5">
+        <Tabs.TabBar
+          divider={false}
+          onTabPress={handleTabChange}
+          tabNames={tabNames}
+          focusedTab={focusedTab}
+          renderItem={({ name, isFocused }) => {
+            const isDisabled = shouldDisablePrimaryTab && name === tabNames[0];
+            let textColor: '$textDisabled' | '$text' | '$textSubdued' =
+              '$textSubdued';
 
-              if (isDisabled) {
-                textColor = '$textDisabled';
-              } else if (isFocused) {
-                textColor = '$text';
-              }
+            if (isDisabled) {
+              textColor = '$textDisabled';
+            } else if (isFocused) {
+              textColor = '$text';
+            }
 
-              return (
-                <XStack
-                  px="$2"
-                  py="$1.5"
-                  mr="$1"
-                  bg={isFocused ? '$bgActive' : '$bg'}
-                  borderRadius="$2"
-                  borderCurve="continuous"
-                  opacity={isDisabled ? 0.4 : 1}
-                  hoverStyle={
-                    !isFocused && !isDisabled
-                      ? {
-                          bg: '$bgHover',
-                        }
-                      : null
+            return (
+              <XStack
+                px="$2"
+                py="$1.5"
+                mr="$1"
+                bg={isFocused ? '$bgActive' : '$bg'}
+                borderRadius="$2"
+                borderCurve="continuous"
+                opacity={isDisabled ? 0.4 : 1}
+                hoverStyle={
+                  !isFocused && !isDisabled
+                    ? {
+                        bg: '$bgHover',
+                      }
+                    : null
+                }
+                onPress={() => {
+                  if (isDisabled) {
+                    return;
                   }
-                  onPress={() => {
-                    if (isDisabled) {
-                      return;
-                    }
-                    handleTabChange(name);
-                  }}
+                  handleTabChange(name);
+                }}
+              >
+                <SizableText
+                  size="$headingMd"
+                  color={textColor}
+                  letterSpacing={-0.15}
                 >
-                  <SizableText
-                    size="$headingMd"
-                    color={textColor}
-                    letterSpacing={-0.15}
-                  >
-                    {name}
-                  </SizableText>
-                </XStack>
-              );
-            }}
-          />
-        )}
+                  {name}
+                </SizableText>
+              </XStack>
+            );
+          }}
+        />
         <HeaderRight
           accountId={indicatorAccountId || earnAccount?.accountId}
           networkId={networkId}


### PR DESCRIPTION
## Summary
- Keep the Supply/Withdraw and Borrow/Repay tabs visible when Borrow Manage opens from direct Withdraw or Repay actions.
- Preserve the direct action as the initially selected tab while retaining server-driven disabled states.
- Align the loading shell with the loaded layout so tab visibility does not change while data resolves.

## Issues
- Fixes OK-59797

## Test Plan
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn tsc:only`
- Focused type-aware oxlint, oxfmt, and `git diff --check`

## Risk
- Low: presentation-only tab visibility change; Borrow action routing, API payloads, and server-provided disabled states are unchanged.
- Runtime UI interaction validation was not run.