### PR TITLE
fix: address module ID registry review feedback

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -24,7 +24,7 @@
     "apps/mobile/background.ts": 3,
     "apps/mobile/index.ts": 4,
     "apps/mobile/jsReady.ts": 5,
-    "apps/mobile/node_modules/.cache/tpl/asyncRequire.js": 6,
+    "apps/mobile/node_modules/.cache/tpl/asyncRequire.js": 40491,
     "apps/mobile/plugins/asyncRequireCore.js": 7,
     "apps/mobile/plugins/chunkModuleIdToHashMap.js": 8,
     "apps/mobile/shims/revenueCatBrowserMappings.js": 9,

--- a/apps/mobile/plugins/__tests__/moduleIdRegistry.test.js
+++ b/apps/mobile/plugins/__tests__/moduleIdRegistry.test.js
@@ -193,6 +193,9 @@ describe('moduleIdRegistry', () => {
     expect(getModuleIdDomain('node_modules/react/index.js')).toBe(
       'nodeModules',
     );
+    expect(
+      getModuleIdDomain('packages/example/node_modules/react/index.js'),
+    ).toBe('nodeModules');
     expect(getModuleIdDomain('__prelude__')).toBe('virtual');
 
     expect(

--- a/apps/mobile/plugins/moduleIdRegistry.js
+++ b/apps/mobile/plugins/moduleIdRegistry.js
@@ -96,7 +96,7 @@ function getModuleIdDomain(moduleKey) {
   ) {
     return 'virtual';
   }
-  if (normalizedModuleKey.startsWith('node_modules/')) {
+  if (normalizedModuleKey.split('/').includes('node_modules')) {
     return 'nodeModules';
   }
   return 'workspace';
@@ -138,7 +138,10 @@ function createModuleIdAllocator(moduleIds) {
   };
 }
 
-function collectRegistryErrors(registry, { allowDuplicateIds = false } = {}) {
+function collectRegistryErrors(
+  registry,
+  { allowDuplicateIds = false, allowOutOfDomainIds = false } = {},
+) {
   const errors = [];
   if (!registry || typeof registry !== 'object' || Array.isArray(registry)) {
     return ['Registry must be a JSON object.'];
@@ -236,7 +239,7 @@ function collectRegistryErrors(registry, { allowDuplicateIds = false } = {}) {
       } else {
         if (normalizedModuleKey) {
           const domain = getModuleIdDomain(normalizedModuleKey);
-          if (!isModuleIdInDomain(moduleId, domain)) {
+          if (!allowOutOfDomainIds && !isModuleIdInDomain(moduleId, domain)) {
             const range = MODULE_ID_RANGES[domain];
             errors.push(
               `${sectionName}.${moduleKey} ID ${moduleId} must be in the ${domain} range ${range.start}-${range.end}.`,

--- a/apps/mobile/scripts/__tests__/module-id-registry.test.js
+++ b/apps/mobile/scripts/__tests__/module-id-registry.test.js
@@ -218,6 +218,27 @@ describe('module ID registry CLI helpers', () => {
     expect(result.reassigned).toBe(1);
   });
 
+  it('reassigns new IDs outside their module domains', () => {
+    const base = createRegistry({
+      modules: { 'packages/a.ts': 1 },
+    });
+    const current = createRegistry({
+      modules: {
+        'node_modules/react/index.js': 2,
+        'packages/a.ts': 1,
+        'packages/b.ts': MODULE_ID_RANGES.nodeModules.start,
+      },
+    });
+    const result = reconcileRegistries(base, current);
+
+    expect(result.registry.modules).toEqual({
+      'node_modules/react/index.js': MODULE_ID_RANGES.nodeModules.start,
+      'packages/a.ts': 1,
+      'packages/b.ts': 2,
+    });
+    expect(result.reassigned).toBe(2);
+  });
+
   it('rejects changes to IDs and states inherited from the base registry', () => {
     const base = createRegistry({
       modules: { 'packages/a.ts': 1 },

--- a/apps/mobile/scripts/module-id-registry.js
+++ b/apps/mobile/scripts/module-id-registry.js
@@ -17,6 +17,7 @@ const {
   compareModuleKeys,
   createModuleIdAllocator,
   getModuleIdDomain,
+  isModuleIdInDomain,
   isPositiveSafeInteger,
   loadRegistry,
   toModuleKey,
@@ -196,6 +197,7 @@ function reconcileRegistries(baseRegistry, currentRegistry) {
   assertValidRegistry(baseRegistry);
   const currentErrors = collectRegistryErrors(currentRegistry, {
     allowDuplicateIds: true,
+    allowOutOfDomainIds: true,
   });
   if (currentErrors.length > 0) {
     throw new Error(
@@ -246,7 +248,11 @@ function reconcileRegistries(baseRegistry, currentRegistry) {
   );
 
   for (const entry of sortedNewEntries) {
-    if (usedIds.has(entry.moduleId)) {
+    const domain = getModuleIdDomain(entry.moduleKey);
+    if (
+      usedIds.has(entry.moduleId) ||
+      !isModuleIdInDomain(entry.moduleId, domain)
+    ) {
       pending.push(entry);
     } else {
       usedIds.add(entry.moduleId);


### PR DESCRIPTION
Follow-up to #13081.

## Summary
- classify nested `node_modules` paths in the vendor ID range
- reassign new reconcile entries whose IDs fall outside their module domain
- move the existing nested async-require module into the nodeModules range

Schema v1 migration is intentionally unsupported. Branches based on the old registry must rebase onto `x` and regenerate their registry updates.

## Tests
- `node apps/mobile/scripts/module-id-registry.js check`
- focused Jest suites: 3 passed, 40 tests
- `yarn agent:check --profile commit`