### PR TITLE
feat: show sidebar shortcut hints on modifier hold

### DIFF
--- a/.skillshare/skills/1k-retrospective/references/case-studies.md
+++ b/.skillshare/skills/1k-retrospective/references/case-studies.md
@@ -255,3 +255,17 @@ Cases are appended by AI after each bug fix. Do NOT reorder or delete entries �
 **Root Cause**: Router treated any non-empty nested `managementUrl` as a real portal, including records that never declared a payment channel.
 **Fix**: Only trust a nested management URL when the same row declares a non-Infini, non-redemption channel. Channel-less rows stay on the Infini probe / unsupported toast path.
 **Catchable by**: Section 4: Edge cases — a URL without a declared channel is not a management portal
+
+## Case: Hook barrel export casing broke Linux desktop/web
+**Date**: 2026-08-31 | **Platforms**: Desktop (Linux), Web
+**Symptom**: Rspack/TypeScript on case-sensitive filesystems could not resolve `./modifierHintRevealContext` because the file is `ModifierHintRevealContext.tsx`. Web `index.web-only.tsx` also omitted the new hook/provider exports while `DesktopLeftSideBar` still imported them.
+**Root Cause**: macOS is case-insensitive so the mismatch was invisible locally; web-only barrels are a separate export surface from `index.tsx`.
+**Fix**: Export `./ModifierHintRevealContext` from both barrels; stub `DesktopModifierHintRevealProvider` for non-desktop.
+**Catchable by**: Section 3: Identified which platforms consume modified code; Section 7: `forceConsistentCasingInFileNames` / Linux compile
+
+## Case: Sidebar shortcut hints skipped My OneKey and reserved overflow space
+**Date**: 2026-08-31 | **Platforms**: Desktop
+**Symptom**: Holding Ctrl/⌘ showed badges on visible tabs but not on the bottom My OneKey (Ctrl+8) item. Overflow “More” labels stayed indented because hidden `Shortcut` pills used `opacity: 0`.
+**Root Cause**: DeviceManagement is extracted out of `visibleRoutes` into `SidebarBottomItem` without the badge. Hidden hints stayed mounted.
+**Fix**: Overlay the badge on `SidebarBottomItem`. Unmount the badge when not visible.
+**Catchable by**: Section 4: Shared component modified → checked all consumers of the same tab list; Section 8: overflow/empty layout

--- a/packages/components/src/hooks/ModifierHintRevealContext.tsx
+++ b/packages/components/src/hooks/ModifierHintRevealContext.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo } from 'react';
+
+import { useModifierHintReveal } from './useModifierHintReveal';
+
+type IModifierHintRevealContextValue = {
+  visible: boolean;
+};
+
+const ModifierHintRevealContext =
+  createContext<IModifierHintRevealContextValue>({
+    visible: false,
+  });
+
+export function ModifierHintRevealProvider({
+  children,
+  enabled = true,
+}: {
+  children: ReactNode;
+  enabled?: boolean;
+}) {
+  const visible = useModifierHintReveal(enabled);
+  const value = useMemo(() => ({ visible }), [visible]);
+
+  return (
+    <ModifierHintRevealContext.Provider value={value}>
+      {children}
+    </ModifierHintRevealContext.Provider>
+  );
+}
+
+export function useModifierHintRevealVisible(): boolean {
+  return useContext(ModifierHintRevealContext).visible;
+}

--- a/packages/components/src/hooks/index.tsx
+++ b/packages/components/src/hooks/index.tsx
@@ -20,3 +20,5 @@ export * from './useUpdateEffect';
 export * from './useVisibilityChange';
 export * from './useSplitView';
 export * from './useIsTablet';
+export * from './useModifierHintReveal';
+export * from './modifierHintRevealContext';

--- a/packages/components/src/hooks/index.tsx
+++ b/packages/components/src/hooks/index.tsx
@@ -21,4 +21,4 @@ export * from './useVisibilityChange';
 export * from './useSplitView';
 export * from './useIsTablet';
 export * from './useModifierHintReveal';
-export * from './modifierHintRevealContext';
+export * from './ModifierHintRevealContext';

--- a/packages/components/src/hooks/index.web-only.tsx
+++ b/packages/components/src/hooks/index.web-only.tsx
@@ -19,3 +19,5 @@ export * from './useUpdateEffect';
 export * from './useVisibilityChange';
 export * from './useSplitView';
 export * from './useIsTablet';
+export * from './useModifierHintReveal';
+export * from './ModifierHintRevealContext';

--- a/packages/components/src/hooks/modifierHintRevealHandlers.test.ts
+++ b/packages/components/src/hooks/modifierHintRevealHandlers.test.ts
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
 import {
   MODIFIER_HINT_HOLD_MS,
   createModifierHintRevealHandlers,
@@ -19,6 +21,7 @@ describe('modifierHintRevealHandlers', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     document.body.focus();
+    platformEnv.isDesktopMac = true;
   });
 
   afterEach(() => {
@@ -85,5 +88,35 @@ describe('modifierHintRevealHandlers', () => {
     expect(onVisibleChange).not.toHaveBeenCalledWith(true);
 
     document.body.removeChild(input);
+  });
+
+  it('reveals hints after holding Control for 1000ms on Windows/Linux', () => {
+    platformEnv.isDesktopMac = false;
+    const onVisibleChange = jest.fn();
+    const handlers = createModifierHintRevealHandlers({
+      enabled: true,
+      onVisibleChange,
+    });
+
+    handlers?.onKeyDown(
+      new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true }),
+    );
+    jest.advanceTimersByTime(MODIFIER_HINT_HOLD_MS);
+
+    expect(onVisibleChange).toHaveBeenCalledWith(true);
+
+    handlers?.onKeyUp(new KeyboardEvent('keyup', { key: 'Control' }));
+    expect(onVisibleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not attach handlers when disabled', () => {
+    const onVisibleChange = jest.fn();
+    const handlers = createModifierHintRevealHandlers({
+      enabled: false,
+      onVisibleChange,
+    });
+
+    expect(handlers).toBeUndefined();
+    expect(onVisibleChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/components/src/hooks/modifierHintRevealHandlers.test.ts
+++ b/packages/components/src/hooks/modifierHintRevealHandlers.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  MODIFIER_HINT_HOLD_MS,
+  createModifierHintRevealHandlers,
+} from './modifierHintRevealHandlers';
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDesktop: true,
+    isDesktopMac: true,
+  },
+}));
+
+describe('modifierHintRevealHandlers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.focus();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reveals hints after holding the modifier for 1000ms', () => {
+    const onVisibleChange = jest.fn();
+    const handlers = createModifierHintRevealHandlers({
+      enabled: true,
+      onVisibleChange,
+    });
+
+    expect(handlers).toBeDefined();
+
+    handlers?.onKeyDown(
+      new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }),
+    );
+
+    expect(onVisibleChange).not.toHaveBeenCalledWith(true);
+
+    jest.advanceTimersByTime(MODIFIER_HINT_HOLD_MS);
+
+    expect(onVisibleChange).toHaveBeenCalledWith(true);
+
+    handlers?.onKeyUp(new KeyboardEvent('keyup', { key: 'Meta' }));
+    expect(onVisibleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('cancels reveal when a chord is pressed while modifier is held', () => {
+    const onVisibleChange = jest.fn();
+    const handlers = createModifierHintRevealHandlers({
+      enabled: true,
+      onVisibleChange,
+    });
+
+    handlers?.onKeyDown(
+      new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }),
+    );
+    handlers?.onKeyDown(
+      new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+    );
+    jest.advanceTimersByTime(MODIFIER_HINT_HOLD_MS);
+
+    expect(onVisibleChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('does not reveal when an input is focused', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const onVisibleChange = jest.fn();
+    const handlers = createModifierHintRevealHandlers({
+      enabled: true,
+      onVisibleChange,
+    });
+
+    handlers?.onKeyDown(
+      new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }),
+    );
+    jest.advanceTimersByTime(MODIFIER_HINT_HOLD_MS);
+
+    expect(onVisibleChange).not.toHaveBeenCalledWith(true);
+
+    document.body.removeChild(input);
+  });
+});

--- a/packages/components/src/hooks/modifierHintRevealHandlers.ts
+++ b/packages/components/src/hooks/modifierHintRevealHandlers.ts
@@ -1,0 +1,115 @@
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import {
+  MODIFIER_HINT_HOLD_MS,
+  isEditableFocused,
+  isPrimaryModifierHeld,
+  isPrimaryModifierKeyEvent,
+  shouldCancelModifierHintReveal,
+} from './modifierHintRevealUtils';
+
+export { MODIFIER_HINT_HOLD_MS } from './modifierHintRevealUtils';
+
+export type IModifierHintRevealHandlers = {
+  hide: () => void;
+  onKeyDown: (event: KeyboardEvent) => void;
+  onKeyUp: (event: KeyboardEvent) => void;
+  onBlur: () => void;
+  onVisibilityChange: () => void;
+};
+
+export function createModifierHintRevealHandlers({
+  enabled,
+  onVisibleChange,
+}: {
+  enabled: boolean;
+  onVisibleChange: (visible: boolean) => void;
+}): IModifierHintRevealHandlers | undefined {
+  if (
+    !enabled ||
+    !platformEnv.isDesktop ||
+    typeof globalThis === 'undefined' ||
+    typeof globalThis.addEventListener !== 'function'
+  ) {
+    onVisibleChange(false);
+    return undefined;
+  }
+
+  const isAppleDesktop = !!platformEnv.isDesktopMac;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const hide = () => {
+    clearTimeout(timer);
+    timer = undefined;
+    onVisibleChange(false);
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (isEditableFocused()) {
+      hide();
+      return;
+    }
+
+    if (shouldCancelModifierHintReveal(event, isAppleDesktop)) {
+      hide();
+      return;
+    }
+
+    if (isPrimaryModifierKeyEvent(event, isAppleDesktop) && !event.repeat) {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        onVisibleChange(true);
+      }, MODIFIER_HINT_HOLD_MS);
+    }
+  };
+
+  const onKeyUp = (event: KeyboardEvent) => {
+    if (
+      isPrimaryModifierKeyEvent(event, isAppleDesktop) ||
+      !isPrimaryModifierHeld(event, isAppleDesktop)
+    ) {
+      hide();
+    }
+  };
+
+  const onBlur = () => {
+    hide();
+  };
+
+  const onVisibilityChange = () => {
+    if (globalThis.document.visibilityState !== 'visible') {
+      hide();
+    }
+  };
+
+  return {
+    hide,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
+    onVisibilityChange,
+  };
+}
+
+export function attachModifierHintRevealListeners(
+  handlers: IModifierHintRevealHandlers,
+) {
+  globalThis.addEventListener('keydown', handlers.onKeyDown, true);
+  globalThis.addEventListener('keyup', handlers.onKeyUp, true);
+  globalThis.addEventListener('blur', handlers.onBlur);
+  globalThis.document.addEventListener(
+    'visibilitychange',
+    handlers.onVisibilityChange,
+  );
+
+  return () => {
+    handlers.hide();
+    globalThis.removeEventListener('keydown', handlers.onKeyDown, true);
+    globalThis.removeEventListener('keyup', handlers.onKeyUp, true);
+    globalThis.removeEventListener('blur', handlers.onBlur);
+    globalThis.document.removeEventListener(
+      'visibilitychange',
+      handlers.onVisibilityChange,
+    );
+  };
+}

--- a/packages/components/src/hooks/modifierHintRevealHandlers.ts
+++ b/packages/components/src/hooks/modifierHintRevealHandlers.ts
@@ -28,7 +28,6 @@ export function createModifierHintRevealHandlers({
   if (
     !enabled ||
     !platformEnv.isDesktop ||
-    typeof globalThis === 'undefined' ||
     typeof globalThis.addEventListener !== 'function'
   ) {
     onVisibleChange(false);

--- a/packages/components/src/hooks/modifierHintRevealUtils.test.ts
+++ b/packages/components/src/hooks/modifierHintRevealUtils.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  isEditableFocused,
+  isPrimaryModifierHeld,
+  isPrimaryModifierKeyEvent,
+  shouldCancelModifierHintReveal,
+} from './modifierHintRevealUtils';
+
+describe('modifierHintRevealUtils', () => {
+  describe('isPrimaryModifierKeyEvent', () => {
+    it('detects Meta on Apple desktop', () => {
+      expect(
+        isPrimaryModifierKeyEvent(
+          new KeyboardEvent('keydown', { key: 'Meta' }),
+          true,
+        ),
+      ).toBe(true);
+    });
+
+    it('detects Control on Windows desktop', () => {
+      expect(
+        isPrimaryModifierKeyEvent(
+          new KeyboardEvent('keydown', { key: 'Control' }),
+          false,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('shouldCancelModifierHintReveal', () => {
+    it('cancels when a chord is pressed while modifier is held', () => {
+      expect(
+        shouldCancelModifierHintReveal(
+          new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+          true,
+        ),
+      ).toBe(true);
+    });
+
+    it('does not cancel when only the modifier key is pressed', () => {
+      expect(
+        shouldCancelModifierHintReveal(
+          new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }),
+          true,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('isPrimaryModifierHeld', () => {
+    it('reads metaKey on Apple desktop', () => {
+      expect(
+        isPrimaryModifierHeld(
+          new KeyboardEvent('keydown', { key: '1', metaKey: true }),
+          true,
+        ),
+      ).toBe(true);
+    });
+
+    it('reads ctrlKey on Windows desktop', () => {
+      expect(
+        isPrimaryModifierHeld(
+          new KeyboardEvent('keydown', { key: '1', ctrlKey: true }),
+          false,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('isEditableFocused', () => {
+    it('returns true when an input is focused', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+
+      expect(isEditableFocused()).toBe(true);
+
+      document.body.removeChild(input);
+    });
+
+    it('returns false when body is focused', () => {
+      document.body.focus();
+      expect(isEditableFocused()).toBe(false);
+    });
+  });
+});

--- a/packages/components/src/hooks/modifierHintRevealUtils.ts
+++ b/packages/components/src/hooks/modifierHintRevealUtils.ts
@@ -1,0 +1,52 @@
+export const MODIFIER_HINT_HOLD_MS = 1000;
+
+export function isEditableFocused(): boolean {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  const activeElement = document.activeElement;
+  if (!activeElement) {
+    return false;
+  }
+
+  const tagName = activeElement.tagName.toLowerCase();
+  if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') {
+    return true;
+  }
+
+  if (activeElement instanceof HTMLElement) {
+    if (activeElement.isContentEditable) {
+      return true;
+    }
+    if (activeElement.closest('[contenteditable="true"]')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isPrimaryModifierKeyEvent(
+  event: KeyboardEvent,
+  isAppleDesktop: boolean,
+): boolean {
+  return isAppleDesktop ? event.key === 'Meta' : event.key === 'Control';
+}
+
+export function isPrimaryModifierHeld(
+  event: KeyboardEvent,
+  isAppleDesktop: boolean,
+): boolean {
+  return isAppleDesktop ? event.metaKey : event.ctrlKey;
+}
+
+export function shouldCancelModifierHintReveal(
+  event: KeyboardEvent,
+  isAppleDesktop: boolean,
+): boolean {
+  if (isPrimaryModifierKeyEvent(event, isAppleDesktop)) {
+    return false;
+  }
+  return isPrimaryModifierHeld(event, isAppleDesktop);
+}

--- a/packages/components/src/hooks/useModifierHintReveal.desktop.ts
+++ b/packages/components/src/hooks/useModifierHintReveal.desktop.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import {
+  attachModifierHintRevealListeners,
+  createModifierHintRevealHandlers,
+} from './modifierHintRevealHandlers';
+
+export { MODIFIER_HINT_HOLD_MS } from './modifierHintRevealUtils';
+
+export function useModifierHintReveal(enabled = true): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handlers = createModifierHintRevealHandlers({
+      enabled,
+      onVisibleChange: setVisible,
+    });
+
+    if (!handlers) {
+      return undefined;
+    }
+
+    return attachModifierHintRevealListeners(handlers);
+  }, [enabled]);
+
+  return visible;
+}

--- a/packages/components/src/hooks/useModifierHintReveal.ts
+++ b/packages/components/src/hooks/useModifierHintReveal.ts
@@ -1,0 +1,5 @@
+export function useModifierHintReveal(_enabled = true): boolean {
+  return false;
+}
+
+export { MODIFIER_HINT_HOLD_MS } from './modifierHintRevealUtils';

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -172,10 +172,6 @@ function BasicTabItemView({
           onHoverIn={handleHoverIn}
           onHoverOut={handleHoverOut}
         >
-          <ModifierShortcutHintBadge
-            shortcutKey={getTabRouteShortcutEvent(route.name)}
-            routeName={route.name}
-          />
           <DesktopTabItem
             isContainerHovered={isContainerHovered}
             onPress={handlePress}
@@ -189,6 +185,10 @@ function BasicTabItemView({
             label=""
             actionList={options.actionList}
             testID={route.name.toLowerCase()}
+          />
+          <ModifierShortcutHintBadge
+            shortcutKey={getTabRouteShortcutEvent(route.name)}
+            routeName={route.name}
           />
           <SizableText
             size="$bodyXsMedium"
@@ -307,6 +307,7 @@ function SidebarBottomItem({
     () => (
       <YStack
         p="$2"
+        position="relative"
         borderRadius="$2"
         bg={isActive ? '$bgActive' : undefined}
         hoverStyle={HOVER_STYLE_BG_HOVER}
@@ -319,9 +320,13 @@ function SidebarBottomItem({
           size="$6"
           color={isActive ? '$iconActive' : '$iconSubdued'}
         />
+        <ModifierShortcutHintBadge
+          shortcutKey={getTabRouteShortcutEvent(route.name)}
+          routeName={route.name}
+        />
       </YStack>
     ),
-    [isActive, onPress, iconName],
+    [isActive, onPress, iconName, route.name],
   );
 
   return (

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -27,6 +27,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
+import { getTabRouteShortcutEvent } from '@onekeyhq/shared/src/shortcuts/tabRouteShortcuts';
 import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
 
 import { switchTab } from '../../Navigator/NavigationContainer';
@@ -34,6 +35,7 @@ import { switchTab } from '../../Navigator/NavigationContainer';
 import { BrowserSubmenuColumn } from './BrowserSubmenuColumn';
 import { DesktopTabItem } from './DesktopTabItem';
 import { MenuHamburger } from './Menu';
+import { ModifierShortcutHintBadge } from './ModifierShortcutHintBadge';
 
 import type { ITabNavigatorExtraConfig } from '../../Navigator/types';
 import type {
@@ -165,10 +167,15 @@ function BasicTabItemView({
           gap="$0.5"
           pt={6}
           pb={6}
+          position="relative"
           onPress={handlePress}
           onHoverIn={handleHoverIn}
           onHoverOut={handleHoverOut}
         >
+          <ModifierShortcutHintBadge
+            shortcutKey={getTabRouteShortcutEvent(route.name)}
+            routeName={route.name}
+          />
           <DesktopTabItem
             isContainerHovered={isContainerHovered}
             onPress={handlePress}
@@ -331,6 +338,7 @@ function OverflowMenuItem({
   isActive,
   options,
   onPress,
+  isPopoverOpen,
 }: {
   route: NavigationState['routes'][0];
   isActive: boolean;
@@ -338,6 +346,7 @@ function OverflowMenuItem({
     collapseTabBarLabel?: string;
   };
   onPress: () => void;
+  isPopoverOpen: boolean;
 }) {
   // @ts-expect-error tabBarIcon returns icon name string, not ReactNode
   const iconName = options?.tabBarIcon?.(isActive) as IKeyOfIcons;
@@ -367,9 +376,21 @@ function OverflowMenuItem({
         size="$5"
         color={isActive ? '$iconActive' : '$iconSubdued'}
       />
-      <SizableText size="$bodyMdMedium" color="$text" numberOfLines={1}>
+      <SizableText
+        flex={1}
+        size="$bodyMdMedium"
+        color="$text"
+        numberOfLines={1}
+      >
         {label}
       </SizableText>
+      <ModifierShortcutHintBadge
+        shortcutKey={getTabRouteShortcutEvent(route.name)}
+        routeName={route.name}
+        requiresPopoverOpen
+        isPopoverOpen={isPopoverOpen}
+        placement="inline"
+      />
     </XStack>
   );
 }
@@ -380,6 +401,7 @@ function OverflowMenuItemWithHandler({
   options,
   handleTabPress,
   setIsOpen,
+  isPopoverOpen,
 }: {
   route: NavigationState['routes'][0];
   isActive: boolean;
@@ -396,6 +418,7 @@ function OverflowMenuItemWithHandler({
     },
   ) => void;
   setIsOpen: (value: boolean) => void;
+  isPopoverOpen: boolean;
 }) {
   const handlePress = useCallback(() => {
     handleTabPress(route, isActive, {
@@ -412,6 +435,7 @@ function OverflowMenuItemWithHandler({
       isActive={isActive}
       options={options}
       onPress={handlePress}
+      isPopoverOpen={isPopoverOpen}
     />
   );
 }
@@ -505,6 +529,7 @@ function OverflowMoreButton({
               options={options}
               handleTabPress={handleTabPress}
               setIsOpen={setIsOpen}
+              isPopoverOpen={isOpen}
             />
           );
         })}
@@ -514,6 +539,7 @@ function OverflowMoreButton({
       descriptors,
       extraConfig?.name,
       handleTabPress,
+      isOpen,
       overflowRoutes,
       state.index,
       state.routes,

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/ModifierShortcutHintBadge.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/ModifierShortcutHintBadge.tsx
@@ -38,17 +38,14 @@ function BasicModifierShortcutHintBadge({
     [routeName],
   );
 
-  if (!platformEnv.isDesktop || !shortcutKey) {
+  if (!platformEnv.isDesktop || !shortcutKey || !visible) {
     return null;
   }
 
   const sharedProps = {
     pointerEvents: 'none' as const,
-    opacity: visible ? 1 : 0,
     animation: 'quick' as const,
     enterStyle: { opacity: 0, scale: 0.95 },
-    exitStyle: { opacity: 0, scale: 0.95 },
-    'aria-hidden': !visible,
     'aria-keyshortcuts': ariaKeyShortcut,
   };
 
@@ -61,7 +58,7 @@ function BasicModifierShortcutHintBadge({
   }
 
   return (
-    <Stack position="absolute" top={0} right={0} zIndex={1} {...sharedProps}>
+    <Stack position="absolute" top={0} right={0} zIndex={2} {...sharedProps}>
       <Shortcut shortcutKey={shortcutKey} />
     </Stack>
   );

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/ModifierShortcutHintBadge.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/ModifierShortcutHintBadge.tsx
@@ -1,0 +1,70 @@
+import { memo, useMemo } from 'react';
+
+import { Shortcut } from '@onekeyhq/components/src/actions';
+import { useModifierHintRevealVisible } from '@onekeyhq/components/src/hooks';
+import { Stack } from '@onekeyhq/components/src/primitives';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
+import { getTabRouteAriaKeyShortcut } from '@onekeyhq/shared/src/shortcuts/tabRouteShortcuts';
+
+type IModifierShortcutHintBadgeProps = {
+  shortcutKey?: EShortcutEvents;
+  routeName?: string;
+  requiresPopoverOpen?: boolean;
+  isPopoverOpen?: boolean;
+  placement?: 'overlay' | 'inline';
+};
+
+function BasicModifierShortcutHintBadge({
+  shortcutKey,
+  routeName,
+  requiresPopoverOpen = false,
+  isPopoverOpen = false,
+  placement = 'overlay',
+}: IModifierShortcutHintBadgeProps) {
+  const modifierHintVisible = useModifierHintRevealVisible();
+  const visible = useMemo(() => {
+    if (!modifierHintVisible) {
+      return false;
+    }
+    if (requiresPopoverOpen) {
+      return isPopoverOpen;
+    }
+    return true;
+  }, [isPopoverOpen, modifierHintVisible, requiresPopoverOpen]);
+
+  const ariaKeyShortcut = useMemo(
+    () => (routeName ? getTabRouteAriaKeyShortcut(routeName) : undefined),
+    [routeName],
+  );
+
+  if (!platformEnv.isDesktop || !shortcutKey) {
+    return null;
+  }
+
+  const sharedProps = {
+    pointerEvents: 'none' as const,
+    opacity: visible ? 1 : 0,
+    animation: 'quick' as const,
+    enterStyle: { opacity: 0, scale: 0.95 },
+    exitStyle: { opacity: 0, scale: 0.95 },
+    'aria-hidden': !visible,
+    'aria-keyshortcuts': ariaKeyShortcut,
+  };
+
+  if (placement === 'inline') {
+    return (
+      <Stack {...sharedProps}>
+        <Shortcut shortcutKey={shortcutKey} />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack position="absolute" top={0} right={0} zIndex={1} {...sharedProps}>
+      <Shortcut shortcutKey={shortcutKey} />
+    </Stack>
+  );
+}
+
+export const ModifierShortcutHintBadge = memo(BasicModifierShortcutHintBadge);

--- a/packages/kit/src/provider/Container/DesktopModifierHintRevealProvider.desktop.tsx
+++ b/packages/kit/src/provider/Container/DesktopModifierHintRevealProvider.desktop.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+import { ModifierHintRevealProvider } from '@onekeyhq/components';
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+export function DesktopModifierHintRevealProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [devSettings] = useDevSettingsPersistAtom();
+  const enabled =
+    platformEnv.isDesktop &&
+    !(devSettings.enabled && devSettings.settings?.disableAllShortcuts);
+
+  return (
+    <ModifierHintRevealProvider enabled={enabled}>
+      {children}
+    </ModifierHintRevealProvider>
+  );
+}

--- a/packages/kit/src/provider/Container/DesktopModifierHintRevealProvider.tsx
+++ b/packages/kit/src/provider/Container/DesktopModifierHintRevealProvider.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+import { ModifierHintRevealProvider } from '@onekeyhq/components';
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+export function DesktopModifierHintRevealProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [devSettings] = useDevSettingsPersistAtom();
+  const enabled =
+    platformEnv.isDesktop &&
+    !(devSettings.enabled && devSettings.settings?.disableAllShortcuts);
+
+  return (
+    <ModifierHintRevealProvider enabled={enabled}>
+      {children}
+    </ModifierHintRevealProvider>
+  );
+}

--- a/packages/kit/src/provider/Container/DesktopModifierHintRevealProvider.tsx
+++ b/packages/kit/src/provider/Container/DesktopModifierHintRevealProvider.tsx
@@ -1,22 +1,9 @@
 import type { ReactNode } from 'react';
 
-import { ModifierHintRevealProvider } from '@onekeyhq/components';
-import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
-
 export function DesktopModifierHintRevealProvider({
   children,
 }: {
   children: ReactNode;
 }) {
-  const [devSettings] = useDevSettingsPersistAtom();
-  const enabled =
-    platformEnv.isDesktop &&
-    !(devSettings.enabled && devSettings.settings?.disableAllShortcuts);
-
-  return (
-    <ModifierHintRevealProvider enabled={enabled}>
-      {children}
-    </ModifierHintRevealProvider>
-  );
+  return children;
 }

--- a/packages/kit/src/provider/Container/index.tsx
+++ b/packages/kit/src/provider/Container/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
 import { RootSiblingParent } from 'react-native-root-siblings';
@@ -6,6 +7,7 @@ import { ESplitViewType, SplitViewContext } from '@onekeyhq/components';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import { setSplitViewLayoutDisabled } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import { debugLandingLog } from '@onekeyhq/shared/src/performance/init';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import useAppNavigation from '../../hooks/useAppNavigation';
 import { useShouldUseSplitView } from '../../hooks/useShouldUseSplitView';
@@ -17,6 +19,7 @@ import { AppStateLockContainer } from './AppStateLockContainer';
 import { CloudBackupContainer } from './CloudBackupContainer';
 import { ColdStartByNotification } from './ColdStartByNotification';
 import { CreateAddressContainer } from './CreateAddressContainer';
+import { DesktopModifierHintRevealProvider } from './DesktopModifierHintRevealProvider';
 import { DialogLoadingContainer } from './DialogLoadingContainer';
 import { DiskFullWarningDialogContainer } from './DiskFullWarningDialogContainer';
 import { ErrorToastContainer } from './ErrorToastContainer';
@@ -97,6 +100,17 @@ function MainRouter() {
 const splitMainViewContext = { viewType: ESplitViewType.MAIN };
 const splitSubViewContext = { viewType: ESplitViewType.SUB };
 
+function AppShell({ children }: { children: ReactNode }) {
+  if (platformEnv.isDesktop) {
+    return (
+      <DesktopModifierHintRevealProvider>
+        {children}
+      </DesktopModifierHintRevealProvider>
+    );
+  }
+  return children;
+}
+
 export function Container() {
   if (process.env.NODE_ENV !== 'production') {
     debugLandingLog('Container render');
@@ -113,34 +127,38 @@ export function Container() {
 
   if (shouldUseSplitView) {
     return (
+      <AppShell>
+        <RootSiblingParent>
+          <AppStateLockContainer>
+            {/* Page.Every must register before routers render their active page. */}
+            <GlobalWalletConnectModalContainer />
+            <TableSplitViewContainer
+              mainRouter={
+                <SplitViewContext.Provider value={splitMainViewContext}>
+                  <MainRouter />
+                </SplitViewContext.Provider>
+              }
+              detailRouter={
+                <SplitViewContext.Provider value={splitSubViewContext}>
+                  <DetailRouter />
+                </SplitViewContext.Provider>
+              }
+            />
+            <SplitViewPerpTabSync />
+          </AppStateLockContainer>
+        </RootSiblingParent>
+      </AppShell>
+    );
+  }
+  return (
+    <AppShell>
       <RootSiblingParent>
         <AppStateLockContainer>
           {/* Page.Every must register before routers render their active page. */}
           <GlobalWalletConnectModalContainer />
-          <TableSplitViewContainer
-            mainRouter={
-              <SplitViewContext.Provider value={splitMainViewContext}>
-                <MainRouter />
-              </SplitViewContext.Provider>
-            }
-            detailRouter={
-              <SplitViewContext.Provider value={splitSubViewContext}>
-                <DetailRouter />
-              </SplitViewContext.Provider>
-            }
-          />
-          <SplitViewPerpTabSync />
+          <DetailRouter />
         </AppStateLockContainer>
       </RootSiblingParent>
-    );
-  }
-  return (
-    <RootSiblingParent>
-      <AppStateLockContainer>
-        {/* Page.Every must register before routers render their active page. */}
-        <GlobalWalletConnectModalContainer />
-        <DetailRouter />
-      </AppStateLockContainer>
-    </RootSiblingParent>
+    </AppShell>
   );
 }

--- a/packages/shared/src/shortcuts/tabRouteShortcuts.test.ts
+++ b/packages/shared/src/shortcuts/tabRouteShortcuts.test.ts
@@ -1,0 +1,32 @@
+import { ETabRoutes } from '../routes/tab';
+
+import { EShortcutEvents } from './shortcuts.enum';
+import {
+  getTabRouteAriaKeyShortcut,
+  getTabRouteShortcutEvent,
+} from './tabRouteShortcuts';
+
+describe('tabRouteShortcuts', () => {
+  it.each([
+    [ETabRoutes.Home, EShortcutEvents.TabWallet],
+    [ETabRoutes.Market, EShortcutEvents.TabMarket],
+    [ETabRoutes.Swap, EShortcutEvents.TabSwap],
+    [ETabRoutes.Perp, EShortcutEvents.TabPerps],
+    [ETabRoutes.Earn, EShortcutEvents.TabEarn],
+    [ETabRoutes.ReferFriends, EShortcutEvents.TabReferAFriend],
+    [ETabRoutes.Discovery, EShortcutEvents.TabBrowser],
+    [ETabRoutes.DeviceManagement, EShortcutEvents.TabMyOneKey],
+    [ETabRoutes.Developer, EShortcutEvents.TabDeveloper],
+  ] as const)('maps %s to %s', (route, shortcutEvent) => {
+    expect(getTabRouteShortcutEvent(route)).toBe(shortcutEvent);
+  });
+
+  it('returns undefined for routes without tab shortcuts', () => {
+    expect(getTabRouteShortcutEvent(ETabRoutes.BulkSend)).toBeUndefined();
+  });
+
+  it('returns aria key shortcuts in Control syntax', () => {
+    expect(getTabRouteAriaKeyShortcut(ETabRoutes.Home)).toBe('Control+1');
+    expect(getTabRouteAriaKeyShortcut(ETabRoutes.Developer)).toBe('Control+9');
+  });
+});

--- a/packages/shared/src/shortcuts/tabRouteShortcuts.ts
+++ b/packages/shared/src/shortcuts/tabRouteShortcuts.ts
@@ -1,0 +1,43 @@
+import { ETabRoutes } from '../routes/tab';
+
+import { EShortcutEvents } from './shortcuts.enum';
+
+const tabRouteShortcutMap: Partial<Record<ETabRoutes, EShortcutEvents>> = {
+  [ETabRoutes.Home]: EShortcutEvents.TabWallet,
+  [ETabRoutes.Market]: EShortcutEvents.TabMarket,
+  [ETabRoutes.Swap]: EShortcutEvents.TabSwap,
+  [ETabRoutes.Perp]: EShortcutEvents.TabPerps,
+  [ETabRoutes.Earn]: EShortcutEvents.TabEarn,
+  [ETabRoutes.ReferFriends]: EShortcutEvents.TabReferAFriend,
+  [ETabRoutes.Discovery]: EShortcutEvents.TabBrowser,
+  [ETabRoutes.DeviceManagement]: EShortcutEvents.TabMyOneKey,
+  [ETabRoutes.Developer]: EShortcutEvents.TabDeveloper,
+};
+
+const shortcutEventAriaKeyMap: Partial<Record<EShortcutEvents, string>> = {
+  [EShortcutEvents.TabWallet]: 'Control+1',
+  [EShortcutEvents.TabMarket]: 'Control+2',
+  [EShortcutEvents.TabSwap]: 'Control+3',
+  [EShortcutEvents.TabPerps]: 'Control+4',
+  [EShortcutEvents.TabEarn]: 'Control+5',
+  [EShortcutEvents.TabReferAFriend]: 'Control+6',
+  [EShortcutEvents.TabBrowser]: 'Control+7',
+  [EShortcutEvents.TabMyOneKey]: 'Control+8',
+  [EShortcutEvents.TabDeveloper]: 'Control+9',
+};
+
+export function getTabRouteShortcutEvent(
+  routeName: string,
+): EShortcutEvents | undefined {
+  return tabRouteShortcutMap[routeName as ETabRoutes];
+}
+
+export function getTabRouteAriaKeyShortcut(
+  routeName: string,
+): string | undefined {
+  const shortcutEvent = getTabRouteShortcutEvent(routeName);
+  if (!shortcutEvent) {
+    return undefined;
+  }
+  return shortcutEventAriaKeyMap[shortcutEvent];
+}


### PR DESCRIPTION
## Summary
- Hold ⌘ (macOS) or Ctrl (Windows/Linux) for ~1s to reveal `⌘1`/`Ctrl+1`–`9` badges on the desktop main sidebar tabs
- Quick presses and chords (e.g. ⌘K) do not flash hints; editable focus is ignored
- Overflow “More” items show badges only while the popover is open

## Test plan
- [x] Unit tests for tab route → shortcut mapping
- [x] Unit tests for modifier-hold timing, chord cancel, and input-focus guard
- [x] `yarn agent:check --profile commit`
- [ ] Desktop manual: hold ⌘/Ctrl 1s → badges appear on visible sidebar tabs
- [ ] Desktop manual: quick ⌘K → no badges, search still works
- [ ] Desktop manual: focus an input, hold modifier → no badges
- [ ] Desktop manual: release modifier → badges hide
- [ ] Desktop manual: ⌘/Ctrl+1–9 tab switching unchanged

Affects: Desktop (macOS / Windows / Linux)
Does NOT affect: Mobile, Web, Extension