### PR TITLE
fix: make debounced actions respond immediately OK-61507

### DIFF
--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -568,6 +568,7 @@ const showActionList = (
       </PageContext.Provider>
     </ModalNavigatorContext.Provider>,
   );
+  return ref;
 };
 function ActionListFrame(props: IActionListProps) {
   const isProcessing = useRef(false);
@@ -606,7 +607,12 @@ function ActionListFrame(props: IActionListProps) {
   );
 }
 
-const show = (props: IShowActionListParams) => showActionList(props, undefined);
+// Imperative action lists share one overlay slot; newer calls replace the active one.
+let imperativeActionListRef: ReturnType<typeof showActionList> | undefined;
+const show = (props: IShowActionListParams) => {
+  imperativeActionListRef?.destroy();
+  imperativeActionListRef = showActionList(props, undefined);
+};
 
 export const ActionList = withStaticProperties(ActionListFrame, {
   show,

--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -481,19 +481,26 @@ const showActionList = (
   // Use let so the destroy callback can reference it after assignment
   // eslint-disable-next-line prefer-const
   let ref: { destroy: () => void };
+  let isClosed = false;
 
   // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
   const handleOpenChange = (isOpen: boolean) => {
-    restProps.onOpenChange?.(isOpen);
-    if (!isOpen) {
-      setTimeout(() => {
-        restProps.onClose?.();
-      });
-      // delay the destruction of the reference to allow for the completion of the animation transition.
-      setTimeout(() => {
-        ref.destroy();
-      }, 500);
+    if (isOpen) {
+      restProps.onOpenChange?.(true);
+      return;
     }
+    if (isClosed) {
+      return;
+    }
+    isClosed = true;
+    restProps.onOpenChange?.(false);
+    setTimeout(() => {
+      restProps.onClose?.();
+    });
+    // delay the destruction of the reference to allow for the completion of the animation transition.
+    setTimeout(() => {
+      ref.destroy();
+    }, 500);
   };
 
   // For context menu positioning: compute the optimal placement direction
@@ -568,7 +575,12 @@ const showActionList = (
       </PageContext.Provider>
     </ModalNavigatorContext.Provider>,
   );
-  return ref;
+  return {
+    close: () => {
+      handleOpenChange(false);
+      ref.destroy();
+    },
+  };
 };
 function ActionListFrame(props: IActionListProps) {
   const isProcessing = useRef(false);
@@ -608,10 +620,10 @@ function ActionListFrame(props: IActionListProps) {
 }
 
 // Imperative action lists share one overlay slot; newer calls replace the active one.
-let imperativeActionListRef: ReturnType<typeof showActionList> | undefined;
+let imperativeActionList: ReturnType<typeof showActionList> | undefined;
 const show = (props: IShowActionListParams) => {
-  imperativeActionListRef?.destroy();
-  imperativeActionListRef = showActionList(props, undefined);
+  imperativeActionList?.close();
+  imperativeActionList = showActionList(props, undefined);
 };
 
 export const ActionList = withStaticProperties(ActionListFrame, {

--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -1,7 +1,6 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { debounce } from 'lodash';
 import { useIntl } from 'react-intl';
 import { Dimensions, type GestureResponderEvent } from 'react-native';
 import { useDebouncedCallback } from 'use-debounce';
@@ -570,15 +569,6 @@ const showActionList = (
     </ModalNavigatorContext.Provider>,
   );
 };
-const debouncedShowActionList = debounce(
-  showActionList,
-  PROCESSING_RESET_DELAY,
-  {
-    leading: true,
-    trailing: false,
-  },
-);
-
 function ActionListFrame(props: IActionListProps) {
   const isProcessing = useRef(false);
 
@@ -616,8 +606,7 @@ function ActionListFrame(props: IActionListProps) {
   );
 }
 
-const show = (props: IShowActionListParams) =>
-  debouncedShowActionList(props, undefined);
+const show = (props: IShowActionListParams) => showActionList(props, undefined);
 
 export const ActionList = withStaticProperties(ActionListFrame, {
   show,

--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -573,6 +573,10 @@ const showActionList = (
 const debouncedShowActionList = debounce(
   showActionList,
   PROCESSING_RESET_DELAY,
+  {
+    leading: true,
+    trailing: false,
+  },
 );
 
 function ActionListFrame(props: IActionListProps) {

--- a/packages/components/src/actions/Trigger/index.tsx
+++ b/packages/components/src/actions/Trigger/index.tsx
@@ -54,7 +54,10 @@ function BasicTrigger(
         ? composeEventHandlers(onPress, onPressInTrigger)
         : onPressInTrigger;
       const debounceHandlePress = stopPropagationPress(
-        debounce(handleOpen as () => void, 10),
+        debounce(handleOpen as () => void, 10, {
+          leading: true,
+          trailing: false,
+        }),
       );
       const handlePressWithStatus = disabled ? noop : debounceHandlePress;
 

--- a/packages/components/src/actions/Trigger/index.tsx
+++ b/packages/components/src/actions/Trigger/index.tsx
@@ -1,5 +1,12 @@
 import type { ForwardedRef, PropsWithChildren } from 'react';
-import { Children, cloneElement, forwardRef, isValidElement } from 'react';
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useMemo,
+  useRef,
+} from 'react';
 
 import { debounce } from 'lodash';
 
@@ -41,11 +48,29 @@ const stopPropagationPress = (onPress: (...params: any[]) => void) =>
         return onPress(...params);
       }
     : onPress;
+type IPressHandler = Parameters<typeof stopPropagationPress>[0];
 
 function BasicTrigger(
   { onPress: onPressInTrigger, disabled, children, onLayout, testID }: ITrigger,
   ref: ForwardedRef<IView>,
 ) {
+  const handleOpenRef = useRef<IPressHandler | undefined>(undefined);
+  const debounceHandlePress = useMemo(
+    () =>
+      stopPropagationPress(
+        debounce(
+          (...params: Parameters<IPressHandler>) =>
+            handleOpenRef.current?.(...params),
+          10,
+          {
+            leading: true,
+            trailing: false,
+          },
+        ),
+      ),
+    [],
+  );
+
   if (children) {
     const child = Children.only(children);
     if (isValidElement(child)) {
@@ -53,12 +78,7 @@ function BasicTrigger(
       const handleOpen = onPress
         ? composeEventHandlers(onPress, onPressInTrigger)
         : onPressInTrigger;
-      const debounceHandlePress = stopPropagationPress(
-        debounce(handleOpen as () => void, 10, {
-          leading: true,
-          trailing: false,
-        }),
-      );
+      handleOpenRef.current = handleOpen as IPressHandler;
       const handlePressWithStatus = disabled ? noop : debounceHandlePress;
 
       return (

--- a/packages/components/src/primitives/Button/useEvent.ts
+++ b/packages/components/src/primitives/Button/useEvent.ts
@@ -16,10 +16,13 @@ function debounceEventHandler(
   if (!onPress) {
     return undefined;
   }
-  const debounced = debounce(onPress, onPressDebounce, {
-    leading: true,
-    trailing: false,
-  });
+  const debounced =
+    onPressDebounce > 0
+      ? debounce(onPress, onPressDebounce, {
+          leading: true,
+          trailing: false,
+        })
+      : debounce(onPress, onPressDebounce);
   return function (e: GestureResponderEvent) {
     if (stopPropagation) {
       e.stopPropagation();

--- a/packages/components/src/primitives/Button/useEvent.ts
+++ b/packages/components/src/primitives/Button/useEvent.ts
@@ -16,7 +16,10 @@ function debounceEventHandler(
   if (!onPress) {
     return undefined;
   }
-  const debounced = debounce(onPress, onPressDebounce);
+  const debounced = debounce(onPress, onPressDebounce, {
+    leading: true,
+    trailing: false,
+  });
   return function (e: GestureResponderEvent) {
     if (stopPropagation) {
       e.stopPropagation();

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -309,9 +309,16 @@ const useDesktopEvents = platformEnv.isDesktop
           void onCheckUpdateRef.current();
         });
 
-        const debounceOpenSettings = debounce((isVisible: boolean) => {
-          openSettingsRef.current(isVisible);
-        }, 250);
+        const debounceOpenSettings = debounce(
+          (isVisible: boolean) => {
+            openSettingsRef.current(isVisible);
+          },
+          250,
+          {
+            leading: true,
+            trailing: false,
+          },
+        );
         globalThis.desktopApi.on(
           ipcMessageKeys.APP_OPEN_SETTINGS,
           debounceOpenSettings,

--- a/packages/kit/src/views/Swap/components/SwapRefreshButton.tsx
+++ b/packages/kit/src/views/Swap/components/SwapRefreshButton.tsx
@@ -67,34 +67,41 @@ function BasicSwapRefreshButton({
   });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onRefresh = useCallback(
-    debounce(() => {
-      if (
-        !isFocusedRef.current ||
-        disabledRef.current ||
-        isRefreshQuoteRef.current ||
-        refreshLockedRef.current
-      ) {
-        return;
-      }
-      refreshLockedRef.current = true;
-      loadingAnimRef.current.setValue(0);
-      Animated.timing(loadingAnimRef.current, {
-        toValue: -1,
-        duration: 500,
-        useNativeDriver: true,
-      }).start((finished) => {
-        if (finished) {
-          refreshActionRef.current();
-          setTimeout(() => {
-            if (!isRefreshQuoteRef.current) {
-              refreshLockedRef.current = false;
-            }
-          }, 100);
-        } else {
-          refreshLockedRef.current = false;
+    debounce(
+      () => {
+        if (
+          !isFocusedRef.current ||
+          disabledRef.current ||
+          isRefreshQuoteRef.current ||
+          refreshLockedRef.current
+        ) {
+          return;
         }
-      });
-    }, 10),
+        refreshLockedRef.current = true;
+        loadingAnimRef.current.setValue(0);
+        Animated.timing(loadingAnimRef.current, {
+          toValue: -1,
+          duration: 500,
+          useNativeDriver: true,
+        }).start((finished) => {
+          if (finished) {
+            refreshActionRef.current();
+            setTimeout(() => {
+              if (!isRefreshQuoteRef.current) {
+                refreshLockedRef.current = false;
+              }
+            }, 100);
+          } else {
+            refreshLockedRef.current = false;
+          }
+        });
+      },
+      10,
+      {
+        leading: true,
+        trailing: false,
+      },
+    ),
     [],
   );
 

--- a/packages/kit/src/views/Swap/pages/components/SwapSlippageTriggerContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapSlippageTriggerContainer.tsx
@@ -57,7 +57,10 @@ const SwapSlippageTriggerContainer = ({
     [displaySlippage, intl, slippageItem.key],
   );
 
-  const debounceOnPress = useDebouncedCallback(onPress, 350);
+  const debounceOnPress = useDebouncedCallback(onPress, 350, {
+    leading: true,
+    trailing: false,
+  });
 
   const valueComponent = useMemo(
     () => (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61507](https://onekeyhq.atlassian.net/browse/OK-61507)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- open imperative action-list and trigger interactions on the leading edge
- suppress duplicate interactions during the 350 ms window without replaying a trailing action
- align the same immediate-interaction debounce pattern in Bootstrap and Swap controls while preserving trailing debounce for state-coalescing paths

## Testing

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- iOS simulator: Wallet Home More opens on the first tap
- iOS simulator: repeated taps within 350 ms produce only one More sheet

## Issue

- https://onekeyhq.atlassian.net/browse/OK-61507

[OK-61507]: https://onekeyhq.atlassian.net/browse/OK-61507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ