### PR TITLE
fix: prevent iOS Perps layout shift on cold start

### DIFF
--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -79,6 +79,7 @@ import type { LayoutChangeEvent } from 'react-native';
 const MobilePerpMarketInline = LazyLoadPage(loadPerpsMobileMarketPage);
 const PERP_NATIVE_HEADER_ROW_HEIGHT = 44;
 const PERP_NATIVE_HEADER_TOP_OFFSET = 20;
+const PERP_NATIVE_IOS_HEADER_TOP_PADDING = 26;
 
 function PerpLayout() {
   const { gtMd } = useMedia();
@@ -212,7 +213,11 @@ function PerpContent() {
   }, []);
 
   const fallbackTabPageHeight = platformEnv.isNative
-    ? resolvedSafeAreaTop + PERP_NATIVE_HEADER_ROW_HEIGHT
+    ? resolvedSafeAreaTop +
+      PERP_NATIVE_HEADER_ROW_HEIGHT +
+      (platformEnv.isNativeIOS
+        ? PERP_NATIVE_IOS_HEADER_TOP_PADDING - PERP_NATIVE_HEADER_TOP_OFFSET
+        : 0)
     : 92;
   const [measuredTabPageHeight, setMeasuredTabPageHeight] = useState<
     number | undefined
@@ -297,7 +302,11 @@ function PerpContent() {
             // safe-area top+28, matching the Wallet header. The MDHeader non-home
             // row is h=44 → center top+22 with the -20/pt($5) cancel; pt=26
             // (=20 offset + 6) lands it at top+28. Other platforms keep $5.
-            pt={platformEnv.isNativeIOS ? 26 : '$5'}
+            pt={
+              platformEnv.isNativeIOS
+                ? PERP_NATIVE_IOS_HEADER_TOP_PADDING
+                : '$5'
+            }
             width="100%"
             onLayout={handleTabPageLayout}
             zIndex={FLOAT_NAV_BAR_Z_INDEX}


### PR DESCRIPTION
## Summary

- keep the iOS native Perps fallback spacer aligned with the measured floating header height
- reuse the iOS header top-padding constant for both the initial fallback and rendered header
- leave Android and web layout behavior unchanged

## Root cause

On iOS cold start, the initial spacer used `safeAreaTop + 44`, while the floating header measured as `safeAreaTop + 50` because of the iOS-specific 26pt top padding and the -20pt offset. Updating the measured height moved the Perps body down by 6pt.

## Cross-platform impact

- iOS: fixes the 6pt cold-start layout shift
- Android: initial and measured heights already match at `safeAreaTop + 44`
- Web: does not render the native spacer or measured absolute header; `md` (<=767px) continues to use the mobile layout and `gtMd` (>=768px) the desktop layout

## Verification

- iOS simulator cold launch: tracked the Perps body across 109 consecutive frames after first render; Y position stayed constant with 0pt displacement
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn jest packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.test.tsx --runInBand` (9/9 passed)
