### PR TITLE
fix: stabilize wallet home asset refresh(OK-61576)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -5,6 +5,15 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import {
+  canApplyAssetSnapshotMeta as canApplySnapshotMeta,
+  getNewestAssetSnapshotMeta,
+  isAssetSnapshotNewer,
+  isAssetSnapshotSameOrNewer,
+  normalizeAssetSnapshotMeta as normalizeSnapshotMeta,
+  sameAssetSnapshotMeta as sameSnapshotMeta,
+} from '@onekeyhq/shared/src/utils/assetSnapshotFreshness';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
 
@@ -14,6 +23,8 @@ import type ServiceAccount from '../../../services/ServiceAccount/ServiceAccount
 export interface IAccountValueEntry {
   value: string;
   currency: 'usd';
+  /** Freshness of the response that produced this single-network value. */
+  assetSnapshotMeta?: IAssetSnapshotMeta;
 }
 
 // Stored value entry for All Networks aggregate, keyed only by addressOrXpub.
@@ -22,6 +33,10 @@ export interface IAccountValueEntry {
 export interface IAllNetworkAccountValueEntry {
   value: Record<string, string>; // <networkId, value>
   currency: 'usd';
+  /** Freshness of the complete all-network snapshot, when known. */
+  assetSnapshotMeta?: IAssetSnapshotMeta;
+  /** Freshness for each network in the value map (partial writes need this). */
+  assetSnapshotMetaByNetwork?: Record<string, IAssetSnapshotMeta>;
 }
 
 export interface IAccountValueDb {
@@ -34,10 +49,22 @@ export interface IAccountValueDb {
 
   // Legacy fields preserved during the one-shot address-key migration so a rollback
   // PR can keep reading old data. Cleaned up in a later release.
-  _legacy_data?: Record<string, { value: string; currency: string }>;
+  _legacy_data?: Record<
+    string,
+    {
+      value: string;
+      currency: string;
+      assetSnapshotMeta?: IAssetSnapshotMeta;
+    }
+  >;
   _legacy_all?: Record<
     string,
-    { value: Record<string, string>; currency: string }
+    {
+      value: Record<string, string>;
+      currency: string;
+      assetSnapshotMeta?: IAssetSnapshotMeta;
+      assetSnapshotMetaByNetwork?: Record<string, IAssetSnapshotMeta>;
+    }
   >;
   _migratedAt?: number;
   // Migration version. Bumped when the migration logic itself is corrected so we
@@ -64,10 +91,77 @@ export interface IAccountValueAllWriteItem {
   xpub?: string;
   networkId: string;
   value: string;
+  assetSnapshotMeta?: IAssetSnapshotMeta;
+}
+
+// Freshness admission helpers live in
+// `@onekeyhq/shared/src/utils/assetSnapshotFreshness` so every persistence
+// layer applies the identical comparison. This adapter only bridges the
+// array-shaped call sites in this entity.
+function maxSnapshotMeta(
+  values: Array<IAssetSnapshotMeta | undefined>,
+): IAssetSnapshotMeta | undefined {
+  return getNewestAssetSnapshotMeta(...values);
+}
+
+function isSameStringMap(
+  left: Record<string, string>,
+  right: Record<string, string>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  return (
+    leftKeys.length === Object.keys(right).length &&
+    leftKeys.every((key) => right[key] === left[key])
+  );
+}
+
+function isSameMetaMap(
+  left: Record<string, IAssetSnapshotMeta> | undefined,
+  right: Record<string, IAssetSnapshotMeta> | undefined,
+): boolean {
+  const leftKeys = Object.keys(left ?? {});
+  return (
+    leftKeys.length === Object.keys(right ?? {}).length &&
+    leftKeys.every(
+      (key) =>
+        Boolean(right?.[key]) && sameSnapshotMeta(left?.[key], right?.[key]),
+    )
+  );
+}
+
+// Value-level equality of a persisted all-network entry, used to skip
+// re-serializing the entity when a refresh repeats what is already stored.
+function isSameAllNetworkEntry(
+  left: IAllNetworkAccountValueEntry,
+  right: IAllNetworkAccountValueEntry,
+): boolean {
+  return (
+    left.currency === right.currency &&
+    isSameStringMap(left.value, right.value) &&
+    sameSnapshotMeta(left.assetSnapshotMeta, right.assetSnapshotMeta) &&
+    isSameMetaMap(
+      left.assetSnapshotMetaByNetwork,
+      right.assetSnapshotMetaByNetwork,
+    )
+  );
 }
 
 function emptyData(): IAccountValueDb {
   return { byAddress: {}, allByAddress: {} };
+}
+
+// A record persisted before the address-key migration (which runs deferred at
+// bootstrap) still has the legacy `data` / `all` shape and lacks the
+// address-keyed buckets. Writers must index normalized buckets rather than
+// `undefined`, otherwise every refresh throws until the migration lands.
+function withAddressBuckets(
+  raw: IAccountValueDb | null | undefined,
+): IAccountValueDb {
+  return {
+    ...raw,
+    byAddress: raw?.byAddress ?? {},
+    allByAddress: raw?.allByAddress ?? {},
+  };
 }
 
 export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValueDb> {
@@ -111,6 +205,9 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       return {
         value: entry?.value,
         currency: entry?.currency,
+        ...(entry?.assetSnapshotMeta
+          ? { assetSnapshotMeta: entry.assetSnapshotMeta }
+          : {}),
       };
     });
   }
@@ -121,28 +218,53 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     xpub,
     value,
     currency,
+    assetSnapshotMeta,
   }: {
     networkId: string;
     accountAddress?: string;
     xpub?: string;
     value: string;
     currency: 'usd';
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }) {
     const key = this.buildSingleKey({ networkId, accountAddress, xpub });
     if (!key) {
       return;
     }
-    const existing = (await this.getRawData())?.byAddress?.[key];
-    if (existing?.value === value && existing?.currency === currency) {
+    const normalizedMeta = normalizeSnapshotMeta(assetSnapshotMeta);
+    // Rejected (stale) or identical writes are no-ops. An unchanged value with
+    // a NEWER marker is not: the marker must be persisted, otherwise a later
+    // stale response would be admitted against the old one.
+    const isNoopAgainst = (existing: IAccountValueEntry | undefined) =>
+      !canApplySnapshotMeta(assetSnapshotMeta, existing?.assetSnapshotMeta) ||
+      (existing?.value === value &&
+        existing?.currency === currency &&
+        sameSnapshotMeta(assetSnapshotMeta, existing?.assetSnapshotMeta));
+    // Pre-check outside the mutex so a repeated refresh does not re-serialize
+    // the whole entity (see updateAllNetworkAccountValue).
+    if (
+      isNoopAgainst(withAddressBuckets(await this.getRawData()).byAddress[key])
+    ) {
       return;
     }
     await this.setRawData((rawData) => {
-      const base = rawData ?? emptyData();
+      const base = withAddressBuckets(rawData);
+      const existing = base.byAddress[key];
+      // The authoritative comparison happens inside the builder: setRawData
+      // serializes this entity's writes, whereas the pre-read above can be
+      // stale by the time the write acquires the mutex.
+      if (isNoopAgainst(existing)) {
+        return base;
+      }
       return {
         ...base,
         byAddress: {
           ...base.byAddress,
-          [key]: { value, currency },
+          [key]: {
+            value,
+            currency,
+            ...(normalizedMeta ? { assetSnapshotMeta: normalizedMeta } : {}),
+          },
         },
       };
     });
@@ -160,6 +282,12 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       return {
         value: entry?.value,
         currency: entry?.currency,
+        ...(entry?.assetSnapshotMeta
+          ? { assetSnapshotMeta: entry.assetSnapshotMeta }
+          : {}),
+        ...(entry?.assetSnapshotMetaByNetwork
+          ? { assetSnapshotMetaByNetwork: entry.assetSnapshotMetaByNetwork }
+          : {}),
       };
     });
   }
@@ -168,6 +296,7 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     items,
     currency,
     updateAll,
+    snapshotMeta,
   }: {
     items: IAccountValueAllWriteItem[];
     currency: 'usd';
@@ -181,59 +310,204 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     // preserved. When `updateAll === false` writes are partial and merge
     // by networkId.
     updateAll?: boolean;
+    /** Freshness of the complete snapshot (used for updateAll replacement). */
+    snapshotMeta?: IAssetSnapshotMeta;
   }) {
+    const normalizedSnapshotMeta = normalizeSnapshotMeta(snapshotMeta);
+
     // Group write items by addressKey so a single setRawData call handles
     // multi-network entries that share the same address.
-    const grouped: Record<string, Record<string, string>> = {};
+    const grouped: Record<
+      string,
+      {
+        value: Record<string, string>;
+        assetSnapshotMetaByNetwork: Record<string, IAssetSnapshotMeta>;
+      }
+    > = {};
     for (const it of items) {
       const key = this.buildAllKey(it);
       if (key) {
-        grouped[key] = { ...grouped[key], [it.networkId]: it.value };
+        const entry =
+          grouped[key] ??
+          (grouped[key] = {
+            value: {},
+            assetSnapshotMetaByNetwork: {},
+          });
+        const incomingMeta = normalizeSnapshotMeta(
+          it.assetSnapshotMeta ?? normalizedSnapshotMeta,
+        );
+        const existingMeta = entry.assetSnapshotMetaByNetwork[it.networkId];
+        // Multiple derive rows can collapse to one address/network. Keep the
+        // newest item from this call before entering the serialized builder.
+        if (!existingMeta || canApplySnapshotMeta(incomingMeta, existingMeta)) {
+          entry.value[it.networkId] = it.value;
+          if (incomingMeta) {
+            entry.assetSnapshotMetaByNetwork[it.networkId] = incomingMeta;
+          }
+        }
       }
     }
     if (Object.keys(grouped).length === 0) {
       return;
     }
 
-    const existingMap = (await this.getRawData())?.allByAddress ?? {};
-    const isNoop = Object.entries(grouped).every(([key, valueMap]) => {
-      const prev = existingMap[key];
-      if (!prev || prev.currency !== currency) return false;
-      if (updateAll) {
-        // Replace mode: the existing map must match the incoming snapshot
-        // exactly, otherwise we still need to write to drop stale networkIds.
-        const prevKeys = Object.keys(prev.value);
-        const nextKeys = Object.keys(valueMap);
-        if (prevKeys.length !== nextKeys.length) return false;
-        return nextKeys.every((nId) => prev.value[nId] === valueMap[nId]);
-      }
-      return Object.entries(valueMap).every(
-        ([nId, v]) => prev.value[nId] === v,
-      );
-    });
-    if (isNoop) {
-      return;
-    }
-
-    await this.setRawData((rawData) => {
-      const base = rawData ?? emptyData();
+    // Applies the grouped writes to one snapshot of the entity and reports
+    // whether anything changed. Used twice: for a cheap pre-check outside the
+    // mutex and, authoritatively, inside the setRawData builder.
+    const applyWrites = (
+      base: IAccountValueDb,
+    ): { next: IAccountValueDb; changed: boolean } => {
       const existing = base.allByAddress;
       const next: Record<string, IAllNetworkAccountValueEntry> = {
         ...existing,
       };
-      for (const [key, valueMap] of Object.entries(grouped)) {
-        next[key] = {
-          value: updateAll
-            ? valueMap
-            : { ...existing[key]?.value, ...valueMap },
-          currency,
-        };
+      let changed = false;
+      for (const [
+        key,
+        { value: valueMap, assetSnapshotMetaByNetwork },
+      ] of Object.entries(grouped)) {
+        const previous = existing[key];
+        const previousMetaByNetwork =
+          previous?.assetSnapshotMetaByNetwork ?? {};
+
+        // A complete snapshot can replace the map only when every network it
+        // supplies is at least as fresh as the stored one, its own version is
+        // not older than the stored complete snapshot, and every network it
+        // omits (evicted by the replacement) is strictly older than the
+        // snapshot's oldest marker. Equal markers for supplied networks are
+        // admitted because the partial path may already have written this
+        // round's responses; rejecting them would make a full refresh unable
+        // to evict a disabled/removed network. This decision is made under the
+        // entity mutex so overlapping writes in this writer see the latest
+        // persisted marker.
+        const previousNetworkMetaOf = (networkId: string) =>
+          maxSnapshotMeta([
+            previousMetaByNetwork[networkId],
+            previous?.assetSnapshotMeta,
+          ]);
+        const incomingNetworksAreFresh = Object.keys(valueMap).every(
+          (networkId) => {
+            const incomingMeta = assetSnapshotMetaByNetwork[networkId];
+            const previousNetworkMeta = previousNetworkMetaOf(networkId);
+            return (
+              !previousNetworkMeta ||
+              isAssetSnapshotSameOrNewer(incomingMeta, previousNetworkMeta)
+            );
+          },
+        );
+        const omittedNetworksAreOlder = Object.keys(previous?.value ?? {})
+          .filter(
+            (networkId) =>
+              !Object.prototype.hasOwnProperty.call(valueMap, networkId),
+          )
+          .every((networkId) => {
+            const previousNetworkMeta = previousNetworkMetaOf(networkId);
+            return (
+              !previousNetworkMeta ||
+              isAssetSnapshotNewer(normalizedSnapshotMeta, previousNetworkMeta)
+            );
+          });
+        const hasCompleteIncomingSnapshotMeta =
+          Boolean(normalizedSnapshotMeta) &&
+          Object.keys(valueMap).every(
+            (networkId) =>
+              normalizeSnapshotMeta(assetSnapshotMetaByNetwork[networkId]) !==
+              undefined,
+          );
+        const canReplaceWhole =
+          updateAll &&
+          hasCompleteIncomingSnapshotMeta &&
+          incomingNetworksAreFresh &&
+          isAssetSnapshotSameOrNewer(
+            normalizedSnapshotMeta,
+            previous?.assetSnapshotMeta,
+          ) &&
+          omittedNetworksAreOlder;
+
+        // Without a complete snapshot version, an address that already has
+        // per-network versions is treated as a partial merge. Dropping absent
+        // networks in that case could resurrect stale data from a legacy
+        // caller, so preserve them until a versioned full snapshot arrives.
+        if (canReplaceWhole) {
+          const replaced: IAllNetworkAccountValueEntry = {
+            value: { ...valueMap },
+            currency,
+            ...(normalizedSnapshotMeta
+              ? { assetSnapshotMeta: normalizedSnapshotMeta }
+              : {}),
+            ...(Object.keys(assetSnapshotMetaByNetwork).length > 0
+              ? {
+                  assetSnapshotMetaByNetwork: { ...assetSnapshotMetaByNetwork },
+                }
+              : {}),
+          };
+          if (!previous || !isSameAllNetworkEntry(previous, replaced)) {
+            next[key] = replaced;
+            changed = true;
+          }
+        } else {
+          // A full snapshot that is not admitted (for example, because one
+          // sibling network has a newer version) degrades to a per-network merge;
+          // this keeps the newer sibling and avoids deleting it.
+          const mergedValue: Record<string, string> = {
+            ...previous?.value,
+          };
+          const mergedMetaByNetwork: Record<string, IAssetSnapshotMeta> = {
+            ...previousMetaByNetwork,
+          };
+          let entryChanged = !previous || previous.currency !== currency;
+          for (const [networkId, incomingValue] of Object.entries(valueMap)) {
+            const incomingMeta = assetSnapshotMetaByNetwork[networkId];
+            const previousNetworkMeta = previousNetworkMetaOf(networkId);
+            if (canApplySnapshotMeta(incomingMeta, previousNetworkMeta)) {
+              if (
+                mergedValue[networkId] !== incomingValue ||
+                !sameSnapshotMeta(mergedMetaByNetwork[networkId], incomingMeta)
+              ) {
+                entryChanged = true;
+              }
+              mergedValue[networkId] = incomingValue;
+              if (incomingMeta) {
+                mergedMetaByNetwork[networkId] = incomingMeta;
+              } else {
+                delete mergedMetaByNetwork[networkId];
+              }
+            }
+          }
+
+          if (entryChanged) {
+            next[key] = {
+              value: updateAll && !previous ? { ...valueMap } : mergedValue,
+              currency,
+              ...(previous?.assetSnapshotMeta
+                ? { assetSnapshotMeta: previous.assetSnapshotMeta }
+                : {}),
+              ...(Object.keys(mergedMetaByNetwork).length > 0
+                ? { assetSnapshotMetaByNetwork: mergedMetaByNetwork }
+                : {}),
+            };
+            changed = true;
+          }
+        }
       }
-      return {
-        ...base,
-        allByAddress: next,
-      };
-    });
+      return changed
+        ? { next: { ...base, allByAddress: next }, changed }
+        : { next: base, changed };
+    };
+
+    // Most refresh calls repeat values the store already holds: every settled
+    // network re-publishes the whole atom snapshot, and a builder-based
+    // setRawData always re-serializes the entire entity. Pre-check on a read
+    // outside the mutex and skip when nothing would change. The builder
+    // re-evaluates under the mutex, so a stale pre-read can at most cost one
+    // redundant write, never a lost one.
+    const preRead = await this.getRawData();
+    if (!applyWrites(withAddressBuckets(preRead)).changed) {
+      return;
+    }
+    await this.setRawData(
+      (rawData) => applyWrites(withAddressBuckets(rawData)).next,
+    );
   }
 
   // One-shot migration from the legacy accountId-keyed `data` / `all` shape
@@ -247,10 +521,22 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
   }) {
     const raw = (await this.getRawData()) as
       | (IAccountValueDb & {
-          data?: Record<string, { value: string; currency: string }>;
+          data?: Record<
+            string,
+            {
+              value: string;
+              currency: string;
+              assetSnapshotMeta?: IAssetSnapshotMeta;
+            }
+          >;
           all?: Record<
             string,
-            { value: Record<string, string>; currency: string }
+            {
+              value: Record<string, string>;
+              currency: string;
+              assetSnapshotMeta?: IAssetSnapshotMeta;
+              assetSnapshotMetaByNetwork?: Record<string, IAssetSnapshotMeta>;
+            }
           >;
         })
       | null
@@ -341,7 +627,13 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
               accountAddress: account.address,
               xpub: accountUtils.pickXpubFromDBAccount(account),
             });
-            byAddress[addressKey] = { value: entry.value, currency: 'usd' };
+            byAddress[addressKey] = {
+              value: entry.value,
+              currency: 'usd',
+              ...(entry.assetSnapshotMeta
+                ? { assetSnapshotMeta: entry.assetSnapshotMeta }
+                : {}),
+            };
           }
         } catch {
           hadResolveError = true;
@@ -372,13 +664,44 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
                 xpub: resolved.xpub,
               });
               const existing = allByAddress[addressKey];
-              allByAddress[addressKey] = {
-                value: {
-                  ...existing?.value,
-                  [parsed.networkId]: worth,
-                },
-                currency: 'usd',
-              };
+              const networkMeta = maxSnapshotMeta([
+                entry.assetSnapshotMetaByNetwork?.[parsed.networkId],
+                entry.assetSnapshotMeta,
+              ]);
+              const existingValueForNetwork =
+                existing?.value?.[parsed.networkId];
+              const existingNetworkMeta = maxSnapshotMeta([
+                existing?.assetSnapshotMetaByNetwork?.[parsed.networkId],
+                existing?.assetSnapshotMeta,
+              ]);
+              // A global legacy marker applies to the whole map, but it must
+              // not prevent copying a different network that has not been
+              // emitted yet. Compare markers only when this network already
+              // has a value; otherwise the legacy row fills the missing key.
+              const canApplyLegacy =
+                existingValueForNetwork === undefined ||
+                canApplySnapshotMeta(networkMeta, existingNetworkMeta);
+              if (canApplyLegacy) {
+                const legacyEntry: IAllNetworkAccountValueEntry = {
+                  value: {
+                    ...existing?.value,
+                    [parsed.networkId]: worth,
+                  },
+                  currency: 'usd',
+                };
+                if (entry.assetSnapshotMeta) {
+                  legacyEntry.assetSnapshotMeta = entry.assetSnapshotMeta;
+                } else if (existing?.assetSnapshotMeta) {
+                  legacyEntry.assetSnapshotMeta = existing.assetSnapshotMeta;
+                }
+                if (networkMeta || existing?.assetSnapshotMetaByNetwork) {
+                  legacyEntry.assetSnapshotMetaByNetwork = {
+                    ...existing?.assetSnapshotMetaByNetwork,
+                    ...(networkMeta ? { [parsed.networkId]: networkMeta } : {}),
+                  };
+                }
+                allByAddress[addressKey] = legacyEntry;
+              }
             }
           }
         }
@@ -399,12 +722,29 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       };
       for (const [key, legacyEntry] of Object.entries(allByAddress)) {
         const cur = mergedAllByAddress[key];
-        mergedAllByAddress[key] = cur
-          ? {
-              value: { ...legacyEntry.value, ...cur.value },
-              currency: cur.currency,
-            }
-          : legacyEntry;
+        if (!cur) {
+          mergedAllByAddress[key] = legacyEntry;
+        } else {
+          const mergedEntry: IAllNetworkAccountValueEntry = {
+            value: { ...legacyEntry.value, ...cur.value },
+            currency: cur.currency,
+          };
+          if (cur.assetSnapshotMeta) {
+            mergedEntry.assetSnapshotMeta = cur.assetSnapshotMeta;
+          } else if (legacyEntry.assetSnapshotMeta) {
+            mergedEntry.assetSnapshotMeta = legacyEntry.assetSnapshotMeta;
+          }
+          if (
+            cur.assetSnapshotMetaByNetwork ||
+            legacyEntry.assetSnapshotMetaByNetwork
+          ) {
+            mergedEntry.assetSnapshotMetaByNetwork = {
+              ...legacyEntry.assetSnapshotMetaByNetwork,
+              ...cur.assetSnapshotMetaByNetwork,
+            };
+          }
+          mergedAllByAddress[key] = mergedEntry;
+        }
       }
 
       return {

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAssetSnapshot.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAssetSnapshot.test.ts
@@ -1,0 +1,662 @@
+import { SimpleDbEntityAccountValue } from './SimpleDbEntityAccountValue';
+import { SimpleDbEntityLocalTokens } from './SimpleDbEntityLocalTokens';
+
+import type { IAccountValueDb } from './SimpleDbEntityAccountValue';
+import type { ISimpleDBLocalTokens } from './SimpleDbEntityLocalTokens';
+
+/*
+yarn jest packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAssetSnapshot.test.ts
+*/
+
+const meta = (localSeq: number, serverDateMs?: number) => ({
+  localSeq,
+  ...(serverDateMs === undefined ? {} : { serverDateMs }),
+});
+
+const token = (key: string) => ({
+  $key: key,
+  name: key,
+  symbol: key,
+  address: key,
+  decimals: 18,
+  isNative: false,
+});
+
+const fiat = (value: string) => ({
+  balance: value,
+  balanceParsed: value,
+  fiatValue: value,
+  price: 1,
+});
+
+function mockEntityStorage<T extends object>(entity: object, initial: T) {
+  type ITestEntity = {
+    getRawData: () => Promise<T | null | undefined>;
+    setRawData: (
+      builder: (rawData: T | null | undefined) => T | Promise<T>,
+    ) => Promise<T>;
+  };
+  const target = entity as ITestEntity;
+  let state: T | null | undefined = initial;
+  jest.spyOn(target, 'getRawData').mockImplementation(async () => state);
+  jest.spyOn(target, 'setRawData').mockImplementation(async (builder) => {
+    state = await builder(state);
+    return state;
+  });
+  return () => state as T;
+}
+
+describe('SimpleDbEntityLocalTokens snapshot admission', () => {
+  it('keeps all token slices from the newest response atomically', async () => {
+    const entity = new SimpleDbEntityLocalTokens();
+    const read = mockEntityStorage<ISimpleDBLocalTokens>(entity, {
+      data: {},
+      tokenList: {},
+      smallBalanceTokenList: {},
+      riskyTokenList: {},
+      tokenListMap: {},
+      tokenListValue: {},
+      tokenListCurrency: {},
+    });
+    const write = async (value: string, localSeq: number) =>
+      entity.updateAccountTokenList({
+        networkId: 'evm--1',
+        accountAddress: '0xalice',
+        tokenList: [token(value)],
+        smallBalanceTokenList: [token(`${value}-small`)],
+        riskyTokenList: [token(`${value}-risk`)],
+        tokenListMap: { [value]: fiat(value) },
+        tokenListValue: value,
+        currency: 'usd',
+        assetSnapshotMeta: meta(localSeq),
+      });
+
+    await write('new', 2);
+    await write('old', 1);
+
+    const result = read();
+    const key = 'evm--1_0xalice';
+    expect(result.tokenList[key]?.[0]?.$key).toBe('new');
+    expect(result.smallBalanceTokenList[key]?.[0]?.$key).toBe('new-small');
+    expect(result.riskyTokenList[key]?.[0]?.$key).toBe('new-risk');
+    expect(result.tokenListValue[key]).toBe('new');
+    expect(result.assetSnapshotMetaByKey?.[key]).toEqual(meta(2));
+  });
+
+  it('preserves an omitted account key when hydrating a partial cache', async () => {
+    const entity = new SimpleDbEntityLocalTokens();
+    const read = mockEntityStorage<ISimpleDBLocalTokens>(entity, {
+      data: {},
+      tokenList: {},
+      smallBalanceTokenList: {},
+      riskyTokenList: {},
+      tokenListMap: {},
+      tokenListValue: {},
+      tokenListCurrency: {},
+    });
+    const write = async (networkId: string, value: string, localSeq: number) =>
+      entity.updateAccountTokenList({
+        networkId,
+        accountAddress: '0xalice',
+        tokenList: [token(value)],
+        smallBalanceTokenList: [],
+        riskyTokenList: [],
+        tokenListMap: { [value]: fiat(value) },
+        tokenListValue: value,
+        currency: 'usd',
+        assetSnapshotMeta: meta(localSeq),
+      });
+
+    await write('evm--1', 'one', 1);
+    await write('evm--56', 'two', 1);
+
+    await entity.updateAccountTokenListByCache({
+      tokenList: { 'evm--1_0xalice': [token('one-new')] },
+      smallBalanceTokenList: {},
+      riskyTokenList: {},
+      tokenListMap: { 'evm--1_0xalice': { 'one-new': fiat('one-new') } },
+      tokenListValue: { 'evm--1_0xalice': 'one-new' },
+      tokenListCurrency: { 'evm--1_0xalice': 'usd' },
+      assetSnapshotMetaByKey: { 'evm--1_0xalice': meta(2) },
+    });
+
+    const result = read();
+    expect(result.tokenList['evm--1_0xalice']?.[0]?.$key).toBe('one-new');
+    expect(result.tokenList['evm--56_0xalice']?.[0]?.$key).toBe('two');
+  });
+});
+
+describe('SimpleDbEntityAccountValue snapshot admission', () => {
+  it('accepts a newer lower balance and rejects an older response', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+
+    await entity.updateAccountValue({
+      networkId: 'evm--1',
+      accountAddress: '0xalice',
+      value: '10',
+      currency: 'usd',
+      assetSnapshotMeta: meta(1),
+    });
+    await entity.updateAccountValue({
+      networkId: 'evm--1',
+      accountAddress: '0xalice',
+      value: '3',
+      currency: 'usd',
+      assetSnapshotMeta: meta(2),
+    });
+    await entity.updateAccountValue({
+      networkId: 'evm--1',
+      accountAddress: '0xalice',
+      value: '99',
+      currency: 'usd',
+      assetSnapshotMeta: meta(1),
+    });
+
+    expect(read().byAddress['evm--1_0xalice']).toEqual({
+      value: '3',
+      currency: 'usd',
+      assetSnapshotMeta: meta(2),
+    });
+  });
+
+  it('does not let an older full snapshot delete a newer network value', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(2),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '20',
+          assetSnapshotMeta: meta(3),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '1',
+          assetSnapshotMeta: meta(1),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(1),
+    });
+
+    expect(read().allByAddress[address]).toMatchObject({
+      value: { 'evm--1': '10', 'evm--56': '20' },
+    });
+  });
+
+  it('keeps a newer sibling when a full snapshot contains a mixed old item', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(10),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '20',
+          assetSnapshotMeta: meta(5),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '1',
+          assetSnapshotMeta: meta(11),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '2',
+          assetSnapshotMeta: meta(6),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(11),
+    });
+
+    expect(read().allByAddress[address]?.value).toEqual({
+      'evm--1': '1',
+      'evm--56': '2',
+    });
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '0',
+          assetSnapshotMeta: meta(12),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '99',
+          assetSnapshotMeta: meta(4),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(12),
+    });
+
+    // The aggregate marker is newer, but the second network item is older than
+    // the stored value. Full replacement must degrade to a per-network merge.
+    expect(read().allByAddress[address]?.value).toEqual({
+      'evm--1': '0',
+      'evm--56': '2',
+    });
+  });
+
+  it('treats an unversioned full snapshot as a partial merge', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(2),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '20',
+          assetSnapshotMeta: meta(2),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '1',
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+    });
+
+    expect(read().allByAddress[address]?.value).toEqual({
+      'evm--1': '10',
+      'evm--56': '20',
+    });
+  });
+
+  it('uses the newest aggregate or network marker for partial admission', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          // Deliberately keep a stale per-network marker alongside a newer
+          // complete marker to exercise the fallback admission path.
+          assetSnapshotMeta: meta(5),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(10),
+    });
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '3',
+          assetSnapshotMeta: meta(6),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+
+    expect(read().allByAddress[address]?.value).toEqual({ 'evm--1': '10' });
+  });
+
+  it('lets a full snapshot drop an omitted network after partial writes admitted the same responses', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+
+    // Older complete snapshot that still covers evm--10.
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '1',
+          assetSnapshotMeta: meta(1),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '2',
+          assetSnapshotMeta: meta(1),
+        },
+        {
+          networkId: 'evm--10',
+          accountAddress: address,
+          value: '3',
+          assetSnapshotMeta: meta(1),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(1),
+    });
+
+    // Progressive per-network writes of the next round (evm--10 disabled).
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(2),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '20',
+          assetSnapshotMeta: meta(3),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+
+    // Full snapshot of that round with EQUAL per-network markers.
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(2),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '20',
+          assetSnapshotMeta: meta(3),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(2),
+    });
+
+    expect(read().allByAddress[address]).toEqual({
+      value: { 'evm--1': '10', 'evm--56': '20' },
+      currency: 'usd',
+      assetSnapshotMeta: meta(2),
+      assetSnapshotMetaByNetwork: { 'evm--1': meta(2), 'evm--56': meta(3) },
+    });
+  });
+
+  it('still keeps an omitted network whose marker is newer than the full snapshot', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(2),
+        },
+        {
+          networkId: 'evm--56',
+          accountAddress: address,
+          value: '20',
+          assetSnapshotMeta: meta(9),
+        },
+      ],
+      currency: 'usd',
+      updateAll: false,
+    });
+
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          networkId: 'evm--1',
+          accountAddress: address,
+          value: '10',
+          assetSnapshotMeta: meta(2),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(2),
+    });
+
+    expect(read().allByAddress[address]).toMatchObject({
+      value: { 'evm--1': '10', 'evm--56': '20' },
+    });
+    expect(read().allByAddress[address]?.assetSnapshotMeta).toBeUndefined();
+  });
+
+  it('skips the storage write when a refresh repeats persisted values and markers', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const address = '0xalice';
+    const setRawDataSpy = jest.spyOn(entity, 'setRawData');
+    const items = [
+      {
+        networkId: 'evm--1',
+        accountAddress: address,
+        value: '10',
+        assetSnapshotMeta: meta(2),
+      },
+      {
+        networkId: 'evm--56',
+        accountAddress: address,
+        value: '20',
+        assetSnapshotMeta: meta(3),
+      },
+    ];
+
+    await entity.updateAllNetworkAccountValue({
+      items,
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(2),
+    });
+    expect(setRawDataSpy).toHaveBeenCalledTimes(1);
+
+    // Same full snapshot again, and the same values as a partial merge:
+    // nothing changes, so the entity must not be re-serialized.
+    await entity.updateAllNetworkAccountValue({
+      items,
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(2),
+    });
+    await entity.updateAllNetworkAccountValue({
+      items: [items[0]],
+      currency: 'usd',
+      updateAll: false,
+    });
+    // A rejected stale response is a no-op as well.
+    await entity.updateAllNetworkAccountValue({
+      items: [{ ...items[0], value: '1', assetSnapshotMeta: meta(1) }],
+      currency: 'usd',
+      updateAll: false,
+    });
+    expect(setRawDataSpy).toHaveBeenCalledTimes(1);
+
+    // A newer marker with an unchanged value must still persist the marker,
+    // otherwise a later stale response would be admitted against the old one.
+    await entity.updateAllNetworkAccountValue({
+      items: [{ ...items[0], assetSnapshotMeta: meta(4) }],
+      currency: 'usd',
+      updateAll: false,
+    });
+    expect(setRawDataSpy).toHaveBeenCalledTimes(2);
+    expect(read().allByAddress[address]?.assetSnapshotMetaByNetwork).toEqual({
+      'evm--1': meta(4),
+      'evm--56': meta(3),
+    });
+  });
+
+  it('skips the single-network storage write when value and marker are unchanged', async () => {
+    const entity = new SimpleDbEntityAccountValue();
+    mockEntityStorage<IAccountValueDb>(entity, {
+      byAddress: {},
+      allByAddress: {},
+    });
+    const setRawDataSpy = jest.spyOn(entity, 'setRawData');
+    const write = (value: string, localSeq: number) =>
+      entity.updateAccountValue({
+        networkId: 'evm--1',
+        accountAddress: '0xalice',
+        value,
+        currency: 'usd',
+        assetSnapshotMeta: meta(localSeq),
+      });
+
+    await write('10', 2);
+    await write('10', 2);
+    await write('99', 1);
+    expect(setRawDataSpy).toHaveBeenCalledTimes(1);
+
+    await write('10', 3);
+    expect(setRawDataSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes into a pre-migration legacy record that lacks the address buckets', async () => {
+    // The address-key migration runs deferred at bootstrap, so an early
+    // refresh can hit a record that still only has the legacy `data` / `all`
+    // shape. Both writers must tolerate the missing buckets instead of
+    // indexing `undefined` and failing the refresh.
+    const entity = new SimpleDbEntityAccountValue();
+    const legacyData = { 'hd-1--evm--1': { value: '1', currency: 'usd' } };
+    const legacyAll = { 'hd-1': { value: { 'evm--1': '1' }, currency: 'usd' } };
+    const read = mockEntityStorage<IAccountValueDb>(entity, {
+      data: legacyData,
+      all: legacyAll,
+    } as unknown as IAccountValueDb);
+
+    await entity.updateAccountValue({
+      networkId: 'evm--1',
+      accountAddress: '0xalice',
+      value: '10',
+      currency: 'usd',
+      assetSnapshotMeta: meta(1),
+    });
+    await entity.updateAllNetworkAccountValue({
+      items: [
+        {
+          accountAddress: '0xalice',
+          networkId: 'evm--1',
+          value: '10',
+          assetSnapshotMeta: meta(1),
+        },
+      ],
+      currency: 'usd',
+      updateAll: true,
+      snapshotMeta: meta(1),
+    });
+
+    const result = read() as IAccountValueDb & {
+      data?: unknown;
+      all?: unknown;
+    };
+    expect(result.byAddress['evm--1_0xalice']).toEqual({
+      value: '10',
+      currency: 'usd',
+      assetSnapshotMeta: meta(1),
+    });
+    expect(result.allByAddress['0xalice']).toEqual({
+      value: { 'evm--1': '10' },
+      currency: 'usd',
+      assetSnapshotMeta: meta(1),
+      assetSnapshotMetaByNetwork: { 'evm--1': meta(1) },
+    });
+    // The legacy snapshot stays intact for the deferred migration to consume.
+    expect(result.data).toEqual(legacyData);
+    expect(result.all).toEqual(legacyAll);
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalTokens.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalTokens.ts
@@ -4,9 +4,14 @@ import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDeco
 import { OneKeyInternalError } from '@onekeyhq/shared/src/errors';
 import { buildFuse } from '@onekeyhq/shared/src/modules3rdParty/fuse';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import {
+  canApplyAssetSnapshotMeta as canApplySnapshotMeta,
+  normalizeAssetSnapshotMeta as normalizeSnapshotMeta,
+} from '@onekeyhq/shared/src/utils/assetSnapshotFreshness';
 import perfUtils, {
   EPerformanceTimerLogNames,
 } from '@onekeyhq/shared/src/utils/debug/perfUtils';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import type {
   IAccountToken,
   IToken,
@@ -32,6 +37,10 @@ export interface ISimpleDBLocalTokens {
   // pre-migration entries in the user's then-active display currency;
   // ServiceToken supplies the lazy fallback.
   tokenListCurrency?: Record<string, string>;
+  // Source freshness for the six per-account token-list slices above. One
+  // metadata entry covers the whole snapshot for a key so the slices are
+  // accepted or rejected atomically.
+  assetSnapshotMetaByKey?: Record<string, IAssetSnapshotMeta>;
 }
 
 export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocalTokens> {
@@ -82,6 +91,7 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
       tokenListMap: rawData?.tokenListMap ?? {},
       tokenListValue: rawData?.tokenListValue ?? {},
       tokenListCurrency: rawData?.tokenListCurrency ?? {},
+      assetSnapshotMetaByKey: rawData?.assetSnapshotMetaByKey ?? {},
     }));
   }
 
@@ -158,6 +168,7 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
     tokenListMap,
     tokenListValue,
     currency,
+    assetSnapshotMeta,
   }: {
     networkId: string;
     accountAddress?: string;
@@ -168,6 +179,7 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
     tokenListMap: Record<string, ITokenFiat>;
     tokenListValue: string;
     currency: string;
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }) {
     if (!accountAddress && !xpub) {
       throw new OneKeyInternalError('accountAddress or xpub is required');
@@ -191,33 +203,59 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
     perf.markEnd('buildAccountLocalAssetsKey');
 
     perf.markStart('setRawData');
-    await this.setRawData((rawData) => ({
-      data: rawData?.data ?? {},
-      tokenList: {
-        ...rawData?.tokenList,
-        [key]: tokenList,
-      },
-      smallBalanceTokenList: {
-        ...rawData?.smallBalanceTokenList,
-        [key]: smallBalanceTokenList,
-      },
-      riskyTokenList: {
-        ...rawData?.riskyTokenList,
-        [key]: riskyTokenList,
-      },
-      tokenListMap: {
-        ...rawData?.tokenListMap,
-        [key]: tokenListMap,
-      },
-      tokenListValue: {
-        ...rawData?.tokenListValue,
-        [key]: tokenListValue,
-      },
-      tokenListCurrency: {
-        ...rawData?.tokenListCurrency,
-        [key]: currency,
-      },
-    }));
+    await this.setRawData((rawData) => {
+      const base = rawData ?? {
+        data: {},
+        tokenList: {},
+        smallBalanceTokenList: {},
+        riskyTokenList: {},
+        tokenListMap: {},
+        tokenListValue: {},
+        tokenListCurrency: {},
+      };
+      const existingMeta = base.assetSnapshotMetaByKey?.[key];
+      const normalizedMeta = normalizeSnapshotMeta(assetSnapshotMeta);
+      // Compare against the value read inside setRawData's per-instance mutex.
+      // The background service funnels normal writes through this entity, so a
+      // stale response cannot replace a newer snapshot in this writer.
+      if (!canApplySnapshotMeta(normalizedMeta, existingMeta)) {
+        return base;
+      }
+
+      const nextMetaByKey = { ...base.assetSnapshotMetaByKey };
+      if (normalizedMeta !== undefined) {
+        nextMetaByKey[key] = normalizedMeta;
+      }
+      return {
+        ...base,
+        data: base.data ?? {},
+        tokenList: {
+          ...base.tokenList,
+          [key]: tokenList,
+        },
+        smallBalanceTokenList: {
+          ...base.smallBalanceTokenList,
+          [key]: smallBalanceTokenList,
+        },
+        riskyTokenList: {
+          ...base.riskyTokenList,
+          [key]: riskyTokenList,
+        },
+        tokenListMap: {
+          ...base.tokenListMap,
+          [key]: tokenListMap,
+        },
+        tokenListValue: {
+          ...base.tokenListValue,
+          [key]: tokenListValue,
+        },
+        tokenListCurrency: {
+          ...base.tokenListCurrency,
+          [key]: currency,
+        },
+        assetSnapshotMetaByKey: nextMetaByKey,
+      };
+    });
     perf.markEnd('setRawData');
     perf.done();
   }
@@ -230,34 +268,98 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
     tokenListValue: Record<string, string>;
     tokenListMap: Record<string, Record<string, ITokenFiat>>;
     tokenListCurrency: Record<string, string>;
+    assetSnapshotMetaByKey?: Record<string, IAssetSnapshotMeta>;
   }) {
-    await this.setRawData((rawData) => ({
-      data: rawData?.data ?? {},
-      tokenList: {
-        ...rawData?.tokenList,
-        ...tokenListCache.tokenList,
-      },
-      smallBalanceTokenList: {
-        ...rawData?.smallBalanceTokenList,
-        ...tokenListCache.smallBalanceTokenList,
-      },
-      riskyTokenList: {
-        ...rawData?.riskyTokenList,
-        ...tokenListCache.riskyTokenList,
-      },
-      tokenListMap: {
-        ...rawData?.tokenListMap,
-        ...tokenListCache.tokenListMap,
-      },
-      tokenListValue: {
-        ...rawData?.tokenListValue,
-        ...tokenListCache.tokenListValue,
-      },
-      tokenListCurrency: {
-        ...rawData?.tokenListCurrency,
-        ...tokenListCache.tokenListCurrency,
-      },
-    }));
+    const cacheKeys = new Set([
+      ...Object.keys(tokenListCache.tokenList ?? {}),
+      ...Object.keys(tokenListCache.smallBalanceTokenList ?? {}),
+      ...Object.keys(tokenListCache.riskyTokenList ?? {}),
+      ...Object.keys(tokenListCache.tokenListMap ?? {}),
+      ...Object.keys(tokenListCache.tokenListValue ?? {}),
+      ...Object.keys(tokenListCache.tokenListCurrency ?? {}),
+      ...Object.keys(tokenListCache.assetSnapshotMetaByKey ?? {}),
+    ]);
+    if (cacheKeys.size === 0) {
+      return;
+    }
+
+    await this.setRawData((rawData) => {
+      const base = rawData ?? {
+        data: {},
+        tokenList: {},
+        smallBalanceTokenList: {},
+        riskyTokenList: {},
+        tokenListMap: {},
+        tokenListValue: {},
+        tokenListCurrency: {},
+      };
+      const existingMetaByKey = base.assetSnapshotMetaByKey ?? {};
+      const nextMetaByKey = { ...existingMetaByKey };
+      const acceptedKeys = [...cacheKeys].filter((key) => {
+        const incomingMeta = normalizeSnapshotMeta(
+          tokenListCache.assetSnapshotMetaByKey?.[key],
+        );
+        const existingMeta = existingMetaByKey[key];
+        // A legacy/unversioned write is allowed only while this key has never
+        // received versioned data. Once versioned data exists, dropping the
+        // legacy write is safer than allowing it to overwrite a fresh snapshot.
+        return canApplySnapshotMeta(incomingMeta, existingMeta);
+      });
+      if (acceptedKeys.length === 0) {
+        return base;
+      }
+
+      const hasOwn = (map: object, key: string) =>
+        Object.prototype.hasOwnProperty.call(map, key);
+      const nextTokenList = { ...base.tokenList };
+      const nextSmallBalanceTokenList = {
+        ...base.smallBalanceTokenList,
+      };
+      const nextRiskyTokenList = { ...base.riskyTokenList };
+      const nextTokenListMap = { ...base.tokenListMap };
+      const nextTokenListValue = { ...base.tokenListValue };
+      const nextTokenListCurrency = { ...base.tokenListCurrency };
+
+      for (const key of acceptedKeys) {
+        if (hasOwn(tokenListCache.tokenList ?? {}, key)) {
+          nextTokenList[key] = tokenListCache.tokenList[key];
+        }
+        if (hasOwn(tokenListCache.smallBalanceTokenList ?? {}, key)) {
+          nextSmallBalanceTokenList[key] =
+            tokenListCache.smallBalanceTokenList[key];
+        }
+        if (hasOwn(tokenListCache.riskyTokenList ?? {}, key)) {
+          nextRiskyTokenList[key] = tokenListCache.riskyTokenList[key];
+        }
+        if (hasOwn(tokenListCache.tokenListMap ?? {}, key)) {
+          nextTokenListMap[key] = tokenListCache.tokenListMap[key];
+        }
+        if (hasOwn(tokenListCache.tokenListValue ?? {}, key)) {
+          nextTokenListValue[key] = tokenListCache.tokenListValue[key];
+        }
+        if (hasOwn(tokenListCache.tokenListCurrency ?? {}, key)) {
+          nextTokenListCurrency[key] = tokenListCache.tokenListCurrency[key];
+        }
+        const incomingMeta = normalizeSnapshotMeta(
+          tokenListCache.assetSnapshotMetaByKey?.[key],
+        );
+        if (incomingMeta !== undefined) {
+          nextMetaByKey[key] = incomingMeta;
+        }
+      }
+
+      return {
+        ...base,
+        data: base.data ?? {},
+        tokenList: nextTokenList,
+        smallBalanceTokenList: nextSmallBalanceTokenList,
+        riskyTokenList: nextRiskyTokenList,
+        tokenListMap: nextTokenListMap,
+        tokenListValue: nextTokenListValue,
+        tokenListCurrency: nextTokenListCurrency,
+        assetSnapshotMetaByKey: nextMetaByKey,
+      };
+    });
   }
 
   @backgroundMethod()
@@ -311,6 +413,9 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
         key,
       ),
       currency: rawData?.tokenListCurrency?.[key],
+      ...(rawData?.assetSnapshotMetaByKey?.[key]
+        ? { assetSnapshotMeta: rawData.assetSnapshotMetaByKey[key] }
+        : {}),
     };
 
     perf.done();
@@ -328,6 +433,7 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
       tokenListMap: {},
       tokenListValue: {},
       tokenListCurrency: {},
+      assetSnapshotMetaByKey: {},
     });
   }
 
@@ -373,6 +479,7 @@ export class SimpleDbEntityLocalTokens extends SimpleDbEntityBase<ISimpleDBLocal
         tokenListMap: filterByOwner(base?.tokenListMap),
         tokenListValue: filterByOwner(base?.tokenListValue),
         tokenListCurrency: filterByOwner(base?.tokenListCurrency),
+        assetSnapshotMetaByKey: filterByOwner(base?.assetSnapshotMetaByKey),
       };
     });
   }

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -1,3 +1,4 @@
+import { Semaphore } from 'async-mutex';
 import BigNumber from 'bignumber.js';
 
 import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
@@ -11,6 +12,11 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { parseRPCResponse } from '@onekeyhq/shared/src/request/utils';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import {
+  getNewestAssetSnapshotMeta,
+  isAssetSnapshotNewer,
+  isAssetSnapshotSameOrNewer,
+} from '@onekeyhq/shared/src/utils/assetSnapshotFreshness';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { promiseAllSettledEnhanced } from '@onekeyhq/shared/src/utils/promiseUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
@@ -26,6 +32,7 @@ import {
   EAddressInteractionStatus,
   EServerInteractedStatus,
 } from '@onekeyhq/shared/types/address';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import type { IResolveNameResp } from '@onekeyhq/shared/types/name';
 import type {
@@ -136,6 +143,12 @@ class ServiceAccountProfile extends ServiceBase {
     string,
     Promise<IAccountBadgeResult>
   >();
+
+  // Active account value updates can arrive from the all-network and
+  // single-network paths at the same time. Keep the atom read/admission/set
+  // sequence atomic within the background runtime so an older continuation
+  // cannot overwrite a newer owner snapshot.
+  private activeAccountValueUpdateMutex = new Semaphore(1);
 
   _fetchAccountDetailsControllers: AbortController[] = [];
 
@@ -1022,10 +1035,32 @@ class ServiceAccountProfile extends ServiceBase {
     value: Record<string, string>;
     currency: string;
     updateAll?: boolean;
+    assetSnapshotMetaByKey?: Record<string, IAssetSnapshotMeta>;
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }) {
-    const { currency, value, updateAll, accountId } = params;
+    const {
+      currency,
+      value,
+      updateAll,
+      accountId,
+      assetSnapshotMetaByKey,
+      assetSnapshotMeta,
+    } = params;
 
     const usdValueMap = await this.convertMapToUsd(value, currency);
+    const inputValueKeys = Object.keys(usdValueMap);
+    // The persistence API is keyed by resolved address/network items and an
+    // empty item list cannot identify which account entry should be cleared.
+    // Treat an empty full result as a no-op so the active atom and SimpleDB do
+    // not diverge (normal zero-balance networks still carry an explicit key).
+    if (inputValueKeys.length === 0) {
+      return;
+    }
+    // A full snapshot needs one response marker for the complete set. Per-key
+    // markers alone cannot prove that an omitted key was observed by the same
+    // refresh, so such input is handled as a partial merge below.
+    const hasCompleteSnapshotMeta =
+      updateAll === true && Boolean(assetSnapshotMeta);
 
     // Atom snapshot stays in the compound-key shape because consumers look
     // entries up via `buildAccountValueKey(accountId, networkId)`.
@@ -1034,7 +1069,9 @@ class ServiceAccountProfile extends ServiceBase {
       xpub?: string;
       networkId: string;
       value: string;
+      assetSnapshotMeta?: IAssetSnapshotMeta;
     };
+    const resolvedValueKeys = new Set<string>();
     const resolveCache = new Map<
       string,
       Promise<{ accountAddress?: string; xpub?: string } | null>
@@ -1057,60 +1094,203 @@ class ServiceAccountProfile extends ServiceBase {
           }
           const r = await pending;
           if (!r) return null;
+          resolvedValueKeys.add(accountValueKey);
+          const incomingMeta =
+            assetSnapshotMetaByKey?.[accountValueKey] ??
+            (hasCompleteSnapshotMeta ? assetSnapshotMeta : undefined);
           return {
             accountAddress: r.accountAddress,
             xpub: r.xpub,
             networkId: parsed.networkId,
             value: usdValue,
+            ...(incomingMeta ? { assetSnapshotMeta: incomingMeta } : {}),
           };
         },
       ),
     );
     const writeItems = resolved.filter((x): x is IWriteItem => x !== null);
 
-    if (updateAll) {
-      await activeAccountValueAtom.set({
-        accountId,
-        value: usdValueMap,
-        currency: 'usd',
+    // A full replacement is safe only when every input value resolved to a
+    // writable address. If one network lookup failed, treating the partial
+    // result as complete would delete that network's last known value.
+    const inputValueCount = inputValueKeys.length;
+    const effectiveUpdateAll =
+      updateAll === true
+        ? writeItems.length === inputValueCount && hasCompleteSnapshotMeta
+        : updateAll;
+    // Others accounts expose a scalar active value (their create network),
+    // while this method materializes a compound-key map for persistence. Do
+    // not let the map writer change the active atom's value shape or race the
+    // scalar writer from HomeOverviewContainer.
+    const shouldUpdateActiveAccountValue = !accountUtils.isOthersAccount({
+      accountId,
+    });
+
+    const buildAcceptedValues = (
+      existingMetaByKey: Record<string, IAssetSnapshotMeta>,
+      aggregateMeta?: IAssetSnapshotMeta,
+      // An admitted full snapshot is authoritative for every key it supplies,
+      // including keys whose marker equals the stored one.
+      admitsEqualMarker = false,
+    ) => {
+      const acceptedValueMap: Record<string, string> = {};
+      const acceptedMetaByKey: Record<string, IAssetSnapshotMeta> = {};
+      Object.entries(usdValueMap).forEach(([key, usdValue]) => {
+        // Address resolution can fail for one network while the others in the
+        // same refresh still succeed. Do not expose an unresolved value in the
+        // active atom when it cannot be persisted alongside the resolved rows.
+        if (!resolvedValueKeys.has(key)) {
+          return;
+        }
+        const incomingMeta =
+          assetSnapshotMetaByKey?.[key] ??
+          (hasCompleteSnapshotMeta ? assetSnapshotMeta : undefined);
+        const existingMeta = getNewestAssetSnapshotMeta(
+          existingMetaByKey[key],
+          aggregateMeta,
+        );
+        const incomingIsFresh = admitsEqualMarker
+          ? isAssetSnapshotSameOrNewer(incomingMeta, existingMeta)
+          : isAssetSnapshotNewer(incomingMeta, existingMeta);
+        if (!existingMeta || incomingIsFresh) {
+          acceptedValueMap[key] = usdValue;
+          if (incomingMeta) {
+            acceptedMetaByKey[key] = incomingMeta;
+          }
+        }
       });
-    } else {
-      const current = await activeAccountValueAtom.get();
-      let baseValue: Record<string, string> = {};
-      if (
-        current?.accountId === accountId &&
-        typeof current.value === 'object' &&
-        current.value !== null
-      ) {
-        baseValue = current.value;
-      } else {
-        // Partial (single-network) write for an account the atom doesn't
-        // currently hold — e.g. an account switch while home is on a
-        // single-chain view, or a cold start outside All Networks. Replacing
-        // the atom with the one-network map would make cross-network
-        // consumers (menu-bar tray, account selector active row) sum a single
-        // network — and read $0 when that network is disabled in the
-        // All-Networks enabled set. Seed the base from the persisted
-        // per-network values instead; the fresh entries overlay their keys.
-        const persisted = await this.getAllNetworkAccountsValueByAccountId({
-          accountId,
+      return { acceptedValueMap, acceptedMetaByKey };
+    };
+    if (shouldUpdateActiveAccountValue) {
+      await this.activeAccountValueUpdateMutex.runExclusive(async () => {
+        const current = await activeAccountValueAtom.get();
+        const sameActiveAccount = current?.accountId === accountId;
+        const currentMetaByKey = sameActiveAccount
+          ? (current?.assetSnapshotMetaByKey ?? {})
+          : {};
+
+        // A switched owner must be admitted against that owner's persisted
+        // snapshot, not the previous owner's atom contents. This also makes the
+        // full and partial paths share one base and one freshness decision.
+        let baseValue: Record<string, string> =
+          sameActiveAccount &&
+          typeof current?.value === 'object' &&
+          current.value !== null
+            ? current.value
+            : {};
+        let baseMetaByKey: Record<string, IAssetSnapshotMeta> =
+          sameActiveAccount ? currentMetaByKey : {};
+        let baseAggregateMeta = sameActiveAccount
+          ? current?.assetSnapshotMeta
+          : undefined;
+
+        if (!sameActiveAccount) {
+          const persisted = await this.getAllNetworkAccountsValueByAccountId({
+            accountId,
+          });
+          baseValue = persisted.value ?? {};
+          baseMetaByKey = persisted.assetSnapshotMetaByKey ?? {};
+          baseAggregateMeta = persisted.assetSnapshotMeta;
+        }
+
+        // The progressive (partial) path may already have written this
+        // round's responses, so a full snapshot's per-key markers can EQUAL
+        // the stored ones. Equal markers must not block the replacement,
+        // otherwise a full refresh could never evict an omitted network.
+        const incomingKeysAreFresh = [...resolvedValueKeys].every((key) => {
+          const incomingMeta =
+            assetSnapshotMetaByKey?.[key] ??
+            (hasCompleteSnapshotMeta ? assetSnapshotMeta : undefined);
+          const existingMeta = getNewestAssetSnapshotMeta(
+            baseMetaByKey[key],
+            baseAggregateMeta,
+          );
+          return (
+            !existingMeta ||
+            isAssetSnapshotSameOrNewer(incomingMeta, existingMeta)
+          );
         });
-        baseValue = persisted.value ?? {};
-      }
-      await activeAccountValueAtom.set({
-        accountId,
-        value: {
-          ...baseValue,
-          ...usdValueMap,
-        },
-        currency: 'usd',
+        // Do not use owner mismatch as an unconditional replacement signal:
+        // the switched-to account may already have a newer persisted value.
+        // Keys omitted by the full snapshot are evicted, so their markers
+        // must be strictly older than the oldest marker the snapshot covers;
+        // supplied keys were admitted per key above.
+        const canReplaceFullSnapshot =
+          effectiveUpdateAll &&
+          (assetSnapshotMeta
+            ? incomingKeysAreFresh &&
+              isAssetSnapshotSameOrNewer(
+                assetSnapshotMeta,
+                baseAggregateMeta,
+              ) &&
+              Object.entries(baseMetaByKey)
+                .filter(([key]) => !resolvedValueKeys.has(key))
+                .every(([, baseMeta]) =>
+                  isAssetSnapshotNewer(assetSnapshotMeta, baseMeta),
+                )
+            : !baseAggregateMeta && Object.keys(baseMetaByKey).length === 0);
+        const { acceptedValueMap, acceptedMetaByKey } = buildAcceptedValues(
+          baseMetaByKey,
+          baseAggregateMeta,
+          canReplaceFullSnapshot,
+        );
+
+        if (effectiveUpdateAll) {
+          const nextValue = canReplaceFullSnapshot
+            ? acceptedValueMap
+            : { ...baseValue, ...acceptedValueMap };
+          const nextMetaByKey = canReplaceFullSnapshot
+            ? acceptedMetaByKey
+            : { ...baseMetaByKey, ...acceptedMetaByKey };
+          const nextActiveSnapshotMeta = canReplaceFullSnapshot
+            ? assetSnapshotMeta
+            : baseAggregateMeta;
+
+          await activeAccountValueAtom.set({
+            accountId,
+            value: nextValue,
+            currency: 'usd',
+            ...(Object.keys(nextMetaByKey).length > 0
+              ? { assetSnapshotMetaByKey: nextMetaByKey }
+              : {}),
+            ...(nextActiveSnapshotMeta
+              ? { assetSnapshotMeta: nextActiveSnapshotMeta }
+              : {}),
+          });
+        } else {
+          // Partial writes never evict an omitted network. Overlay only values
+          // admitted against the selected owner base.
+          // A partial write must not promote a per-network marker to the
+          // aggregate marker. Preserve only a marker already known to cover the
+          // complete persisted snapshot.
+          const nextActiveSnapshotMeta = baseAggregateMeta;
+          const nextMetaByKey = { ...baseMetaByKey, ...acceptedMetaByKey };
+
+          await activeAccountValueAtom.set({
+            accountId,
+            value: {
+              ...baseValue,
+              ...acceptedValueMap,
+            },
+            currency: 'usd',
+            ...(Object.keys(nextMetaByKey).length > 0
+              ? { assetSnapshotMetaByKey: nextMetaByKey }
+              : {}),
+            ...(nextActiveSnapshotMeta
+              ? { assetSnapshotMeta: nextActiveSnapshotMeta }
+              : {}),
+          });
+        }
       });
     }
 
     await simpleDb.accountValue.updateAllNetworkAccountValue({
       items: writeItems,
       currency: 'usd',
-      updateAll,
+      updateAll: effectiveUpdateAll,
+      ...(effectiveUpdateAll && assetSnapshotMeta
+        ? { snapshotMeta: assetSnapshotMeta }
+        : {}),
     });
 
     // Check DEPOSIT task for rookie guide (fire-and-forget)
@@ -1438,6 +1618,10 @@ class ServiceAccountProfile extends ServiceBase {
       accountId,
       value: undefined as Record<string, string> | undefined,
       currency: undefined as 'usd' | undefined,
+      assetSnapshotMetaByKey: undefined as
+        | Record<string, IAssetSnapshotMeta>
+        | undefined,
+      assetSnapshotMeta: undefined as IAssetSnapshotMeta | undefined,
     };
     if (!accountId) {
       return empty;
@@ -1467,7 +1651,29 @@ class ServiceAccountProfile extends ServiceBase {
           });
           value[compoundKey] = v;
         }
-        return { accountId, value, currency: entry.currency };
+        const assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta> = {};
+        for (const networkId of Object.keys(entry.value)) {
+          const snapshotMeta = getNewestAssetSnapshotMeta(
+            entry.assetSnapshotMetaByNetwork?.[networkId],
+            entry.assetSnapshotMeta,
+          );
+          if (snapshotMeta) {
+            assetSnapshotMetaByKey[
+              accountUtils.buildAccountValueKey({ accountId, networkId })
+            ] = snapshotMeta;
+          }
+        }
+        return {
+          accountId,
+          value,
+          currency: entry.currency,
+          ...(entry.assetSnapshotMeta
+            ? { assetSnapshotMeta: entry.assetSnapshotMeta }
+            : {}),
+          ...(Object.keys(assetSnapshotMetaByKey).length > 0
+            ? { assetSnapshotMetaByKey }
+            : {}),
+        };
       }
 
       // HD/HW indexed account path.
@@ -1503,7 +1709,26 @@ class ServiceAccountProfile extends ServiceBase {
       });
 
       const value: Record<string, string> = {};
+      const assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta> = {};
       let currency: 'usd' | undefined;
+      let aggregateSnapshotMeta: IAssetSnapshotMeta | undefined;
+      const hasCompleteAggregateMeta =
+        entries.length === items.length &&
+        entries.every(
+          (entry) => Boolean(entry?.value) && Boolean(entry?.assetSnapshotMeta),
+        );
+      if (hasCompleteAggregateMeta) {
+        aggregateSnapshotMeta = entries.reduce<IAssetSnapshotMeta | undefined>(
+          (oldest, entry) => {
+            const meta = entry?.assetSnapshotMeta;
+            if (!meta) return oldest;
+            return !oldest || isAssetSnapshotNewer(oldest, meta)
+              ? meta
+              : oldest;
+          },
+          undefined,
+        );
+      }
       entries.forEach((entry, idx) => {
         if (!entry?.value) return;
         const dbAccountId = items[idx].dbAccountId;
@@ -1513,6 +1738,13 @@ class ServiceAccountProfile extends ServiceBase {
             networkId,
           });
           value[compoundKey] = v;
+          const snapshotMeta = getNewestAssetSnapshotMeta(
+            entry.assetSnapshotMetaByNetwork?.[networkId],
+            entry.assetSnapshotMeta,
+          );
+          if (snapshotMeta) {
+            assetSnapshotMetaByKey[compoundKey] = snapshotMeta;
+          }
         }
         currency = entry.currency;
       });
@@ -1520,7 +1752,17 @@ class ServiceAccountProfile extends ServiceBase {
       if (Object.keys(value).length === 0) {
         return empty;
       }
-      return { accountId, value, currency };
+      return {
+        accountId,
+        value,
+        currency,
+        ...(aggregateSnapshotMeta
+          ? { assetSnapshotMeta: aggregateSnapshotMeta }
+          : {}),
+        ...(Object.keys(assetSnapshotMetaByKey).length > 0
+          ? { assetSnapshotMetaByKey }
+          : {}),
+      };
     } catch {
       return empty;
     }
@@ -1580,12 +1822,95 @@ class ServiceAccountProfile extends ServiceBase {
     value: string;
     currency: string;
     shouldUpdateActiveAccountValue?: boolean;
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }) {
     if (params.shouldUpdateActiveAccountValue) {
-      await activeAccountValueAtom.set({
-        accountId: params.accountId,
-        value: params.value,
-        currency: params.currency,
+      await this.activeAccountValueUpdateMutex.runExclusive(async () => {
+        const valueKey = accountUtils.buildAccountValueKey({
+          accountId: params.networkAccountId,
+          networkId: params.networkId,
+        });
+        const current = await activeAccountValueAtom.get();
+        const isOthersAccount = accountUtils.isOthersAccount({
+          accountId: params.accountId,
+        });
+        const sameActiveAccount = current?.accountId === params.accountId;
+        let baseValue: Record<string, string> | undefined;
+        let baseScalarValue: string | undefined;
+        let baseCurrency: string | undefined;
+        let baseMetaByKey: Record<string, IAssetSnapshotMeta> = {};
+        let baseAggregateMeta: IAssetSnapshotMeta | undefined;
+        if (sameActiveAccount) {
+          baseCurrency = current?.currency;
+          baseAggregateMeta = current.assetSnapshotMeta;
+          baseMetaByKey = current.assetSnapshotMetaByKey ?? {};
+          if (typeof current.value === 'object' && current.value !== null) {
+            baseValue = current.value;
+          } else if (typeof current.value === 'string') {
+            baseScalarValue = current.value;
+          }
+        } else {
+          const persisted = await this.getAllNetworkAccountsValueByAccountId({
+            accountId: params.accountId,
+          });
+          baseCurrency = persisted.currency;
+          baseMetaByKey = persisted.assetSnapshotMetaByKey ?? {};
+          baseAggregateMeta = persisted.assetSnapshotMeta;
+          if (isOthersAccount) {
+            // Others accounts use a scalar active value. The persisted helper
+            // exposes a compound-key map, so select this network explicitly.
+            baseScalarValue = persisted.value?.[valueKey];
+          } else {
+            baseValue = persisted.value;
+          }
+        }
+        const currentMeta = getNewestAssetSnapshotMeta(
+          baseMetaByKey[valueKey],
+          baseAggregateMeta,
+        );
+        const incomingIsFresh =
+          !currentMeta ||
+          isAssetSnapshotNewer(params.assetSnapshotMeta, currentMeta);
+
+        // A stale response must still switch the atom to the target owner's
+        // persisted base. Otherwise the atom keeps the previous owner's
+        // scalar/map until another response happens to arrive.
+        if (!sameActiveAccount || incomingIsFresh) {
+          const nextMetaByKey = {
+            ...baseMetaByKey,
+            ...(incomingIsFresh && params.assetSnapshotMeta
+              ? { [valueKey]: params.assetSnapshotMeta }
+              : {}),
+          };
+          let nextValue: Record<string, string> | string;
+          let nextCurrency = params.currency;
+          if (isOthersAccount) {
+            nextValue = incomingIsFresh
+              ? params.value
+              : (baseScalarValue ?? '0');
+            if (!incomingIsFresh && baseScalarValue !== undefined) {
+              nextCurrency = baseCurrency ?? 'usd';
+            }
+          } else {
+            nextValue = incomingIsFresh
+              ? { ...baseValue, [valueKey]: params.value }
+              : (baseValue ?? {});
+            if (!incomingIsFresh) {
+              nextCurrency = baseCurrency ?? 'usd';
+            }
+          }
+          await activeAccountValueAtom.set({
+            accountId: params.accountId,
+            value: nextValue,
+            currency: nextCurrency,
+            ...(Object.keys(nextMetaByKey).length > 0
+              ? { assetSnapshotMetaByKey: nextMetaByKey }
+              : {}),
+            ...(baseAggregateMeta
+              ? { assetSnapshotMeta: baseAggregateMeta }
+              : {}),
+          });
+        }
       });
     }
 
@@ -1602,6 +1927,9 @@ class ServiceAccountProfile extends ServiceBase {
       xpub: resolved.xpub,
       value: usdValue,
       currency: 'usd',
+      ...(params.assetSnapshotMeta
+        ? { assetSnapshotMeta: params.assetSnapshotMeta }
+        : {}),
     });
   }
 
@@ -1612,31 +1940,8 @@ class ServiceAccountProfile extends ServiceBase {
     networkId: string;
     value: string;
     currency: string;
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }) {
-    const resolved = await this.resolveAddressKey({
-      accountId: params.networkAccountId,
-      networkId: params.networkId,
-    });
-    if (!resolved) return;
-
-    const [existing] = await simpleDb.accountValue.getAccountsValue({
-      items: [
-        {
-          networkId: params.networkId,
-          accountAddress: resolved.accountAddress,
-          xpub: resolved.xpub,
-        },
-      ],
-    });
-
-    const usdValue = await this.convertOneToUsd(params.value, params.currency);
-    if (
-      existing?.value &&
-      usdValue &&
-      new BigNumber(usdValue).lte(existing.value)
-    ) {
-      return;
-    }
     await this.updateAccountValue(params);
   }
 

--- a/packages/kit-bg/src/services/ServiceAccountProfile.updateAllNetworkAccountValue.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.updateAllNetworkAccountValue.test.ts
@@ -106,6 +106,8 @@ const mockAtomState: {
         accountId: string;
         value: Record<string, string> | string;
         currency: string;
+        assetSnapshotMetaByKey?: Record<string, { localSeq: number }>;
+        assetSnapshotMeta?: { localSeq: number };
       }
     | undefined;
 } = { current: undefined };
@@ -125,7 +127,12 @@ jest.mock('../states/jotai/atoms', () => ({
 }));
 
 type ISimpleDbAccountValueEntry =
-  | { value?: Record<string, string>; currency?: 'usd' }
+  | {
+      value?: Record<string, string>;
+      currency?: 'usd';
+      assetSnapshotMetaByNetwork?: Record<string, { localSeq: number }>;
+      assetSnapshotMeta?: { localSeq: number };
+    }
   | undefined;
 const mockGetAllNetworkAccountsValue = jest.fn<
   Promise<ISimpleDbAccountValueEntry[]>,
@@ -135,6 +142,9 @@ const mockSimpleDbUpdateAllNetworkAccountValue = jest.fn<
   Promise<void>,
   unknown[]
 >(async () => undefined);
+const mockSimpleDbUpdateAccountValue = jest.fn<Promise<void>, unknown[]>(
+  async () => undefined,
+);
 
 jest.mock('../dbs/simple/simpleDb', () => ({
   __esModule: true,
@@ -144,6 +154,8 @@ jest.mock('../dbs/simple/simpleDb', () => ({
         mockGetAllNetworkAccountsValue(...args),
       updateAllNetworkAccountValue: (...args: unknown[]) =>
         mockSimpleDbUpdateAllNetworkAccountValue(...args),
+      updateAccountValue: (...args: unknown[]) =>
+        mockSimpleDbUpdateAccountValue(...args),
     },
   },
 }));
@@ -162,16 +174,21 @@ const TRON_ACCOUNT_B = "hd-1--m/44'/195'/0'/0/0";
 
 function makeService({
   accountsInSameIndexedAccountId = {},
+  unresolvedNetworkId,
 }: {
   accountsInSameIndexedAccountId?: Record<
     string,
     Array<{ id: string; address?: string; xpub?: string }>
   >;
+  unresolvedNetworkId?: string;
 } = {}) {
   const backgroundApi = {
     serviceAccount: {
       getAccountXpub: jest.fn(async () => undefined),
-      getAccountAddressForApi: jest.fn(async () => 'mock-address'),
+      getAccountAddressForApi: jest.fn(
+        async ({ networkId }: { networkId: string }) =>
+          networkId === unresolvedNetworkId ? undefined : 'mock-address',
+      ),
       getAccountsInSameIndexedAccountId: jest.fn(
         async ({ indexedAccountId }: { indexedAccountId: string }) => ({
           accounts: accountsInSameIndexedAccountId[indexedAccountId] ?? [],
@@ -192,6 +209,7 @@ describe('ServiceAccountProfile.updateAllNetworkAccountValue', () => {
     mockAtomState.current = undefined;
     mockGetAllNetworkAccountsValue.mockReset();
     mockSimpleDbUpdateAllNetworkAccountValue.mockReset();
+    mockSimpleDbUpdateAccountValue.mockReset();
   });
 
   it('seeds the atom from persisted per-network values when the atom belongs to another account (single-chain account switch)', async () => {
@@ -264,7 +282,33 @@ describe('ServiceAccountProfile.updateAllNetworkAccountValue', () => {
     expect(mockGetAllNetworkAccountsValue).not.toHaveBeenCalled();
   });
 
-  it('replaces the atom without seeding when updateAll is set (authoritative all-networks refresh)', async () => {
+  it('uses the aggregate marker when a partial key marker is missing', async () => {
+    const valueKey = `${TRON_ACCOUNT_A}_${TRON_ID}`;
+    mockAtomState.current = {
+      accountId: INDEXED_A,
+      value: { [valueKey]: '10' },
+      currency: 'usd',
+      assetSnapshotMeta: { localSeq: 10 },
+    };
+
+    const service = makeService();
+
+    await service.updateAllNetworkAccountValue({
+      accountId: INDEXED_A,
+      value: { [valueKey]: '1' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: { [valueKey]: { localSeq: 5 } },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId: INDEXED_A,
+      value: { [valueKey]: '10' },
+      currency: 'usd',
+      assetSnapshotMeta: { localSeq: 10 },
+    });
+  });
+
+  it('replaces the atom without seeding for a versioned full snapshot', async () => {
     mockAtomState.current = {
       accountId: INDEXED_A,
       value: { [`${EVM_ACCOUNT_A}_${EVM_ID}`]: '55' },
@@ -278,14 +322,57 @@ describe('ServiceAccountProfile.updateAllNetworkAccountValue', () => {
       value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '4.17' },
       currency: 'usd',
       updateAll: true,
+      assetSnapshotMeta: { localSeq: 1 },
     });
 
     expect(mockAtomState.current).toEqual({
       accountId: INDEXED_A,
       value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '4.17' },
       currency: 'usd',
+      assetSnapshotMeta: { localSeq: 1 },
+      assetSnapshotMetaByKey: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: { localSeq: 1 },
+      },
     });
     expect(mockGetAllNetworkAccountsValue).not.toHaveBeenCalled();
+  });
+
+  it('does not replace a switched owner with a stale full snapshot', async () => {
+    mockAtomState.current = {
+      accountId: INDEXED_B,
+      value: { [`${TRON_ACCOUNT_B}_${TRON_ID}`]: '0' },
+      currency: 'usd',
+    };
+    mockGetAllNetworkAccountsValue.mockResolvedValue([
+      {
+        value: { [TRON_ID]: '10' },
+        currency: 'usd',
+        assetSnapshotMetaByNetwork: { [TRON_ID]: { localSeq: 10 } },
+      },
+    ]);
+
+    const service = makeService({
+      accountsInSameIndexedAccountId: {
+        [INDEXED_A]: [{ id: TRON_ACCOUNT_A, address: 'mock-address' }],
+      },
+    });
+
+    await service.updateAllNetworkAccountValue({
+      accountId: INDEXED_A,
+      value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '1' },
+      currency: 'usd',
+      updateAll: true,
+      assetSnapshotMeta: { localSeq: 5 },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId: INDEXED_A,
+      value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '10' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: { localSeq: 10 },
+      },
+    });
   });
 
   it('keeps the atom write alive when persisted seeding finds nothing', async () => {
@@ -310,6 +397,45 @@ describe('ServiceAccountProfile.updateAllNetworkAccountValue', () => {
       accountId: INDEXED_A,
       value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '4.17' },
       currency: 'usd',
+    });
+  });
+
+  it('does not overlay a stale partial response on newer persisted values after an account switch', async () => {
+    mockAtomState.current = {
+      accountId: INDEXED_B,
+      value: { [`${TRON_ACCOUNT_B}_${TRON_ID}`]: '0' },
+      currency: 'usd',
+    };
+    mockGetAllNetworkAccountsValue.mockResolvedValue([
+      {
+        value: { [TRON_ID]: '4.17' },
+        currency: 'usd',
+        assetSnapshotMetaByNetwork: { [TRON_ID]: { localSeq: 10 } },
+      },
+    ]);
+
+    const service = makeService({
+      accountsInSameIndexedAccountId: {
+        [INDEXED_A]: [{ id: TRON_ACCOUNT_A, address: 'mock-address' }],
+      },
+    });
+
+    await service.updateAllNetworkAccountValue({
+      accountId: INDEXED_A,
+      value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '1' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: { localSeq: 5 },
+      },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId: INDEXED_A,
+      value: { [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '4.17' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: { localSeq: 10 },
+      },
     });
   });
 
@@ -338,6 +464,194 @@ describe('ServiceAccountProfile.updateAllNetworkAccountValue', () => {
       ],
       currency: 'usd',
       updateAll: undefined,
+    });
+  });
+
+  it('downgrades a full replacement when one value cannot resolve its address', async () => {
+    mockAtomState.current = {
+      accountId: INDEXED_A,
+      value: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '1',
+        [`${EVM_ACCOUNT_A}_${EVM_ID}`]: '2',
+      },
+      currency: 'usd',
+    };
+    const service = makeService({ unresolvedNetworkId: EVM_ID });
+
+    await service.updateAllNetworkAccountValue({
+      accountId: INDEXED_A,
+      value: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '4.17',
+        [`${EVM_ACCOUNT_A}_${EVM_ID}`]: '55',
+      },
+      currency: 'usd',
+      updateAll: true,
+      assetSnapshotMeta: { localSeq: 10 },
+    });
+
+    const persistedParams = mockSimpleDbUpdateAllNetworkAccountValue.mock
+      .calls[0]?.[0] as {
+      items: unknown[];
+      updateAll?: boolean;
+      snapshotMeta?: unknown;
+    };
+    expect(persistedParams.items).toHaveLength(1);
+    expect(persistedParams.updateAll).toBe(false);
+    expect(persistedParams.snapshotMeta).toBeUndefined();
+    expect(mockAtomState.current).toEqual({
+      accountId: INDEXED_A,
+      value: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: '4.17',
+        [`${EVM_ACCOUNT_A}_${EVM_ID}`]: '2',
+      },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [`${TRON_ACCOUNT_A}_${TRON_ID}`]: { localSeq: 10 },
+      },
+    });
+  });
+
+  it('rejects a stale scalar update when an Others account has a per-key marker', async () => {
+    const accountId = 'imported--account-1';
+    const valueKey = `${accountId}_${TRON_ID}`;
+    mockAtomState.current = {
+      accountId,
+      value: '10',
+      currency: 'usd',
+      assetSnapshotMetaByKey: { [valueKey]: { localSeq: 10 } },
+    };
+
+    const service = makeService();
+
+    await service.updateAccountValue({
+      accountId,
+      networkAccountId: accountId,
+      networkId: TRON_ID,
+      value: '1',
+      currency: 'usd',
+      shouldUpdateActiveAccountValue: true,
+      assetSnapshotMeta: { localSeq: 5 },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId,
+      value: '10',
+      currency: 'usd',
+      assetSnapshotMetaByKey: { [valueKey]: { localSeq: 10 } },
+    });
+  });
+
+  it('does not change an Others active atom to the all-network map shape', async () => {
+    const accountId = 'imported--account-1';
+    const valueKey = `${accountId}_${TRON_ID}`;
+    mockAtomState.current = {
+      accountId,
+      value: '10',
+      currency: 'usd',
+    };
+
+    const service = makeService();
+
+    await service.updateAllNetworkAccountValue({
+      accountId,
+      value: { [valueKey]: '5' },
+      currency: 'usd',
+      updateAll: true,
+      assetSnapshotMeta: { localSeq: 2 },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId,
+      value: '10',
+      currency: 'usd',
+    });
+    expect(mockSimpleDbUpdateAllNetworkAccountValue).toHaveBeenCalled();
+  });
+
+  it('lets a full snapshot evict an omitted network after progressive writes admitted the same responses', async () => {
+    const SOL_ID = 'sol--101';
+    const SOL_ACCOUNT_A = "hd-1--m/44'/501'/0'/0/1";
+    const tronKey = `${TRON_ACCOUNT_A}_${TRON_ID}`;
+    const evmKey = `${EVM_ACCOUNT_A}_${EVM_ID}`;
+    const solKey = `${SOL_ACCOUNT_A}_${SOL_ID}`;
+    // Progressive per-network writes from the current round already landed
+    // (tron seq 2, evm seq 3); sol is a retained key from an older round.
+    mockAtomState.current = {
+      accountId: INDEXED_A,
+      value: { [tronKey]: '4', [evmKey]: '55', [solKey]: '9' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [tronKey]: { localSeq: 2 },
+        [evmKey]: { localSeq: 3 },
+        [solKey]: { localSeq: 1 },
+      },
+      assetSnapshotMeta: { localSeq: 1 },
+    };
+
+    const service = makeService();
+
+    await service.updateAllNetworkAccountValue({
+      accountId: INDEXED_A,
+      value: { [tronKey]: '4', [evmKey]: '55' },
+      currency: 'usd',
+      updateAll: true,
+      assetSnapshotMetaByKey: {
+        [tronKey]: { localSeq: 2 },
+        [evmKey]: { localSeq: 3 },
+      },
+      assetSnapshotMeta: { localSeq: 2 },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId: INDEXED_A,
+      value: { [tronKey]: '4', [evmKey]: '55' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [tronKey]: { localSeq: 2 },
+        [evmKey]: { localSeq: 3 },
+      },
+      assetSnapshotMeta: { localSeq: 2 },
+    });
+    expect(mockSimpleDbUpdateAllNetworkAccountValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updateAll: true,
+        snapshotMeta: { localSeq: 2 },
+      }),
+    );
+  });
+
+  it('still refuses a full snapshot when an omitted key carries a newer marker', async () => {
+    const tronKey = `${TRON_ACCOUNT_A}_${TRON_ID}`;
+    const evmKey = `${EVM_ACCOUNT_A}_${EVM_ID}`;
+    mockAtomState.current = {
+      accountId: INDEXED_A,
+      value: { [tronKey]: '4', [evmKey]: '55' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [tronKey]: { localSeq: 2 },
+        [evmKey]: { localSeq: 9 },
+      },
+    };
+
+    const service = makeService();
+
+    await service.updateAllNetworkAccountValue({
+      accountId: INDEXED_A,
+      value: { [tronKey]: '4' },
+      currency: 'usd',
+      updateAll: true,
+      assetSnapshotMetaByKey: { [tronKey]: { localSeq: 2 } },
+      assetSnapshotMeta: { localSeq: 2 },
+    });
+
+    expect(mockAtomState.current).toEqual({
+      accountId: INDEXED_A,
+      value: { [tronKey]: '4', [evmKey]: '55' },
+      currency: 'usd',
+      assetSnapshotMetaByKey: {
+        [tronKey]: { localSeq: 2 },
+        [evmKey]: { localSeq: 9 },
+      },
     });
   });
 });

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -14,6 +14,11 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import {
+  createAssetSnapshotMeta,
+  getServerDateMsFromHeaders,
+  isAssetSnapshotNewer,
+} from '@onekeyhq/shared/src/utils/assetSnapshotFreshness';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import perfUtils, {
   EPerformanceTimerLogNames,
@@ -26,6 +31,7 @@ import {
   getEmptyTokenData,
   getMergedTokenData,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import type {
   IBinancePreOrderParams,
@@ -63,6 +69,28 @@ type IFetchAccountTokensController = {
   controller: AbortController;
   flag?: string;
 };
+
+type ILocalAccountTokensCache = {
+  tokenList: Record<string, IAccountToken[]>;
+  smallBalanceTokenList: Record<string, IAccountToken[]>;
+  riskyTokenList: Record<string, IAccountToken[]>;
+  tokenListValue: Record<string, string>;
+  tokenListMap: Record<string, Record<string, ITokenFiat>>;
+  tokenListCurrency: Record<string, string>;
+  assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta>;
+};
+
+function createEmptyLocalAccountTokensCache(): ILocalAccountTokensCache {
+  return {
+    tokenList: {},
+    smallBalanceTokenList: {},
+    riskyTokenList: {},
+    tokenListValue: {},
+    tokenListMap: {},
+    tokenListCurrency: {},
+    assetSnapshotMetaByKey: {},
+  };
+}
 
 @backgroundClass()
 class ServiceToken extends ServiceBase {
@@ -112,21 +140,47 @@ class ServiceToken extends ServiceBase {
       );
   }
 
-  localAccountTokensCache: {
-    tokenList: Record<string, IAccountToken[]>;
-    smallBalanceTokenList: Record<string, IAccountToken[]>;
-    riskyTokenList: Record<string, IAccountToken[]>;
-    tokenListValue: Record<string, string>;
-    tokenListMap: Record<string, Record<string, ITokenFiat>>;
-    tokenListCurrency: Record<string, string>;
-  } = {
-    tokenList: {},
-    smallBalanceTokenList: {},
-    riskyTokenList: {},
-    tokenListValue: {},
-    tokenListMap: {},
-    tokenListCurrency: {},
-  };
+  localAccountTokensCache: ILocalAccountTokensCache =
+    createEmptyLocalAccountTokensCache();
+
+  private mergeLocalAccountTokensCache(source: ILocalAccountTokensCache): void {
+    const target = this.localAccountTokensCache;
+    const keys = new Set([
+      ...Object.keys(source.tokenList),
+      ...Object.keys(source.smallBalanceTokenList),
+      ...Object.keys(source.riskyTokenList),
+      ...Object.keys(source.tokenListValue),
+      ...Object.keys(source.tokenListMap),
+      ...Object.keys(source.tokenListCurrency),
+      ...Object.keys(source.assetSnapshotMetaByKey ?? {}),
+    ]);
+    keys.forEach((key) => {
+      const incomingMeta = source.assetSnapshotMetaByKey?.[key];
+      const existingMeta = target.assetSnapshotMetaByKey[key];
+      if (existingMeta && !isAssetSnapshotNewer(incomingMeta, existingMeta)) {
+        return;
+      }
+      if (!incomingMeta && existingMeta) {
+        return;
+      }
+      if (source.tokenList[key]) target.tokenList[key] = source.tokenList[key];
+      if (source.smallBalanceTokenList[key]) {
+        target.smallBalanceTokenList[key] = source.smallBalanceTokenList[key];
+      }
+      if (source.riskyTokenList[key]) {
+        target.riskyTokenList[key] = source.riskyTokenList[key];
+      }
+      if (source.tokenListValue[key] !== undefined) {
+        target.tokenListValue[key] = source.tokenListValue[key];
+      }
+      if (source.tokenListMap[key])
+        target.tokenListMap[key] = source.tokenListMap[key];
+      if (source.tokenListCurrency[key] !== undefined) {
+        target.tokenListCurrency[key] = source.tokenListCurrency[key];
+      }
+      if (incomingMeta) target.assetSnapshotMetaByKey[key] = incomingMeta;
+    });
+  }
 
   // Returns `null` when the rate is missing or unusable so callers can skip
   // conversion and tag entries with the source currency instead — the cache
@@ -218,6 +272,10 @@ class ServiceToken extends ServiceBase {
       dbAccount?: IDBAccount;
     },
   ): Promise<IFetchAccountTokensResp> {
+    // Allocate the ordering token before any await. The background service is
+    // the writer for this runtime, so this sequence orders requests even when
+    // their network responses settle out of order.
+    const requestMeta = createAssetSnapshotMeta();
     const {
       mergeTokens,
       flag,
@@ -420,6 +478,13 @@ class ServiceToken extends ServiceBase {
       }
     })();
 
+    const assetSnapshotMeta = createAssetSnapshotMeta({
+      localSeq: requestMeta.localSeq,
+      serverDateMs: getServerDateMsFromHeaders(
+        (resp as unknown as { headers?: unknown }).headers,
+      ),
+    });
+
     const resolvedCurrency = await this.normalizeTokensRespToUsd(
       resp.data.data,
       requestCurrency,
@@ -520,15 +585,25 @@ class ServiceToken extends ServiceBase {
           xpub,
         });
 
-        this.localAccountTokensCache.tokenList[key] = filteredTokenList;
-        this.localAccountTokensCache.smallBalanceTokenList[key] =
-          filteredSmallBalanceTokenList;
-        this.localAccountTokensCache.riskyTokenList[key] =
-          filteredRiskyTokenList;
-        this.localAccountTokensCache.tokenListValue[key] =
-          tokenListValue.toFixed();
-        this.localAccountTokensCache.tokenListMap[key] = filteredTokenListMap;
-        this.localAccountTokensCache.tokenListCurrency[key] = resolvedCurrency;
+        const existingMeta =
+          this.localAccountTokensCache.assetSnapshotMetaByKey[key];
+        if (
+          !existingMeta ||
+          isAssetSnapshotNewer(assetSnapshotMeta, existingMeta)
+        ) {
+          this.localAccountTokensCache.tokenList[key] = filteredTokenList;
+          this.localAccountTokensCache.smallBalanceTokenList[key] =
+            filteredSmallBalanceTokenList;
+          this.localAccountTokensCache.riskyTokenList[key] =
+            filteredRiskyTokenList;
+          this.localAccountTokensCache.tokenListValue[key] =
+            tokenListValue.toFixed();
+          this.localAccountTokensCache.tokenListMap[key] = filteredTokenListMap;
+          this.localAccountTokensCache.tokenListCurrency[key] =
+            resolvedCurrency;
+          this.localAccountTokensCache.assetSnapshotMetaByKey[key] =
+            assetSnapshotMeta;
+        }
 
         await this._updateAccountLocalTokensDebounced();
       } else {
@@ -542,6 +617,7 @@ class ServiceToken extends ServiceBase {
           tokenListValue: tokenListValue.toFixed(),
           tokenListMap: filteredTokenListMap,
           currency: resolvedCurrency,
+          assetSnapshotMeta,
         });
       }
     }
@@ -554,6 +630,7 @@ class ServiceToken extends ServiceBase {
 
     resp.data.data.accountId = accountId;
     resp.data.data.networkId = networkId;
+    resp.data.data.assetSnapshotMeta = assetSnapshotMeta;
 
     return resp.data.data;
   }
@@ -622,17 +699,26 @@ class ServiceToken extends ServiceBase {
 
   _updateAccountLocalTokensDebounced = debounce(
     async () => {
-      await this.backgroundApi.simpleDb.localTokens.updateAccountTokenListByCache(
-        this.localAccountTokensCache,
-      );
-      this.localAccountTokensCache = {
-        tokenList: {},
-        smallBalanceTokenList: {},
-        riskyTokenList: {},
-        tokenListValue: {},
-        tokenListMap: {},
-        tokenListCurrency: {},
-      };
+      // Swap the pending batch before awaiting storage. Fetches that settle
+      // while the write is in flight must remain in the next batch instead of
+      // being cleared by the completion handler.
+      const pending = this.localAccountTokensCache;
+      this.localAccountTokensCache = createEmptyLocalAccountTokensCache();
+      try {
+        await this.backgroundApi.simpleDb.localTokens.updateAccountTokenListByCache(
+          pending,
+        );
+      } catch (error) {
+        // Preserve failed writes, but let a newer in-memory snapshot win for
+        // each key when the pending batch is merged back.
+        this.mergeLocalAccountTokensCache(pending);
+        // Reschedule persistence for the recovered batch; without this the
+        // data survives only in memory until another fetch happens to flush.
+        // The debounced wrapper only arms its trailing timer here, so this
+        // neither recurses nor changes how the original error propagates.
+        void this._updateAccountLocalTokensDebounced();
+        throw error;
+      }
     },
     3000,
     {
@@ -976,6 +1062,7 @@ class ServiceToken extends ServiceBase {
     tokenListMap: Record<string, ITokenFiat>;
     tokenListValue: string;
     currency: string;
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }) {
     const {
       dbAccount,
@@ -987,6 +1074,7 @@ class ServiceToken extends ServiceBase {
       tokenListMap,
       tokenListValue,
       currency,
+      assetSnapshotMeta,
     } = params;
     const [xpub, accountAddress] = await Promise.all([
       this.backgroundApi.serviceAccount.getAccountXpub({
@@ -1011,6 +1099,7 @@ class ServiceToken extends ServiceBase {
       tokenListMap,
       tokenListValue,
       currency,
+      ...(assetSnapshotMeta ? { assetSnapshotMeta } : {}),
     });
   }
 

--- a/packages/kit-bg/src/states/jotai/atoms/activeAccountValue.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/activeAccountValue.ts
@@ -1,11 +1,14 @@
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
+
 import { EAtomNames } from '../atomNames';
 import { globalAtom } from '../utils';
-
 export type IAccountValueAtom =
   | {
       accountId: string;
       value: Record<string, string> | string;
       currency: string;
+      assetSnapshotMetaByKey?: Record<string, IAssetSnapshotMeta>;
+      assetSnapshotMeta?: IAssetSnapshotMeta;
     }
   | undefined;
 

--- a/packages/kit/src/hooks/allNetworkRunResultUtils.test.ts
+++ b/packages/kit/src/hooks/allNetworkRunResultUtils.test.ts
@@ -1,4 +1,7 @@
-import { resolveAllNetworkPublishedResult } from './allNetworkRunResultUtils';
+import {
+  resolveAllNetworkFailedRunRestore,
+  resolveAllNetworkPublishedResult,
+} from './allNetworkRunResultUtils';
 
 describe('resolveAllNetworkPublishedResult', () => {
   const signature = 'account-1|all--networks|wallet-1|0|0';
@@ -83,6 +86,119 @@ describe('resolveAllNetworkPublishedResult', () => {
     ).toEqual({
       publishedResult: null,
       nextLastPublished: { result: null, runSignature: signature },
+    });
+  });
+
+  test('retains a superseded result as the last-good snapshot when the accepted run cleared it', () => {
+    const completed = [{ networkId: 'evm--1' }];
+
+    // The accepted run invalidated the retained result before its fan-out;
+    // a must-run queued meanwhile supersedes this completed result.
+    const resolved = resolveAllNetworkPublishedResult({
+      completedResult: completed,
+      hasQueuedRerun: true,
+      lastPublished: undefined,
+      runSignature: signature,
+      retainSupersededResult: true,
+    });
+
+    expect(resolved).toEqual({
+      publishedResult: undefined,
+      nextLastPublished: { result: completed, runSignature: signature },
+    });
+
+    // The queued run fails: the superseded snapshot must be restorable.
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: resolved.nextLastPublished,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: { result: completed, runSignature: signature },
+      shouldRestoreResult: true,
+    });
+  });
+
+  test('prefers the newer superseded result over a retained one when retaining', () => {
+    const previous = [{ networkId: 'btc--0' }];
+    const completed = [{ networkId: 'evm--1' }];
+
+    expect(
+      resolveAllNetworkPublishedResult({
+        completedResult: completed,
+        hasQueuedRerun: true,
+        lastPublished: { result: previous, runSignature: signature },
+        runSignature: signature,
+        retainSupersededResult: true,
+      }),
+    ).toEqual({
+      publishedResult: previous,
+      nextLastPublished: { result: completed, runSignature: signature },
+    });
+  });
+});
+
+describe('resolveAllNetworkFailedRunRestore', () => {
+  const signature = 'account-1|all--networks|wallet-1|0|0';
+  const previous = {
+    result: [{ networkId: 'evm--1' }],
+    runSignature: signature,
+  };
+
+  test('restores the last-good result when the owner is unchanged', () => {
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: previous,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: previous,
+      shouldRestoreResult: true,
+    });
+  });
+
+  test('keeps the ref but does not touch the visible result after an owner switch', () => {
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: previous,
+        ownerUnchanged: false,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: previous,
+      shouldRestoreResult: false,
+    });
+  });
+
+  test('has nothing to restore when no result was ever published', () => {
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: undefined,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: undefined,
+      shouldRestoreResult: false,
+    });
+  });
+
+  test('keeps the ref but does not publish a snapshot minted for another run signature', () => {
+    // The retained ref outlives an account switch: owner X's superseded
+    // result is still in the ref when owner Y's first run is accepted. If
+    // that run fails, `ownerUnchanged` is true for Y's own runner, yet the
+    // snapshot belongs to X and must not be published under Y.
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: previous,
+        ownerUnchanged: true,
+        currentRunSignature: 'account-2|all--networks|wallet-1|0|0',
+      }),
+    ).toEqual({
+      nextLastPublished: previous,
+      shouldRestoreResult: false,
     });
   });
 });

--- a/packages/kit/src/hooks/allNetworkRunResultUtils.ts
+++ b/packages/kit/src/hooks/allNetworkRunResultUtils.ts
@@ -8,11 +8,19 @@ export function resolveAllNetworkPublishedResult<T>({
   hasQueuedRerun,
   lastPublished,
   runSignature,
+  retainSupersededResult = false,
 }: {
   completedResult: Array<T> | null;
   hasQueuedRerun: boolean;
   lastPublished: IAllNetworkLastPublishedResult<T> | undefined;
   runSignature: string;
+  /**
+   * Consumers that clear the retained result when a run is accepted have no
+   * last-good snapshot left by the time a superseded run completes. Record
+   * the superseded (unpublished) result as that snapshot so the queued run
+   * can restore it if its own fan-out fails.
+   */
+  retainSupersededResult?: boolean;
 }): {
   publishedResult: Array<T> | null | undefined;
   nextLastPublished: IAllNetworkLastPublishedResult<T> | undefined;
@@ -23,7 +31,9 @@ export function resolveAllNetworkPublishedResult<T>({
         lastPublished?.runSignature === runSignature
           ? lastPublished.result
           : undefined,
-      nextLastPublished: lastPublished,
+      nextLastPublished: retainSupersededResult
+        ? { result: completedResult, runSignature }
+        : lastPublished,
     };
   }
 
@@ -34,5 +44,39 @@ export function resolveAllNetworkPublishedResult<T>({
   return {
     publishedResult: completedResult,
     nextLastPublished,
+  };
+}
+
+/**
+ * An accepted run invalidates the retained result BEFORE its fan-out starts.
+ * When that fan-out then fails, the previously published result must be
+ * restored — otherwise the consumer stays pinned on `undefined` until the
+ * next successful must-run. The visible result is only restored while the
+ * owner is unchanged AND the retained snapshot carries the current run
+ * signature. `ownerUnchanged` only proves the failed runner still owns the
+ * hook; the retained ref outlives account/network switches, so without the
+ * signature check the first failed refresh after a switch would publish the
+ * previous owner's snapshot under the new owner. The ref restore itself is
+ * unconditional: the skip path and the publish path both re-check the run
+ * signature before serving it.
+ */
+export function resolveAllNetworkFailedRunRestore<T>({
+  previousPublished,
+  ownerUnchanged,
+  currentRunSignature,
+}: {
+  previousPublished: IAllNetworkLastPublishedResult<T> | undefined;
+  ownerUnchanged: boolean;
+  currentRunSignature: string;
+}): {
+  nextLastPublished: IAllNetworkLastPublishedResult<T> | undefined;
+  shouldRestoreResult: boolean;
+} {
+  return {
+    nextLastPublished: previousPublished,
+    shouldRestoreResult:
+      ownerUnchanged &&
+      previousPublished !== undefined &&
+      previousPublished.runSignature === currentRunSignature,
   };
 }

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -45,6 +45,7 @@ import { makeColdRequestFactory } from './makeColdRequestFactory';
 import { reorderNetworksByCachePriority } from './reorderNetworksByCachePriority';
 import { shouldSkipRedundantAllNetworkRun } from './shouldSkipRedundantAllNetworkRun';
 import { usePromiseResult } from './usePromiseResult';
+import { useRouteIsFocused } from './useRouteIsFocused';
 
 // Native keeps a strict cap to avoid Hermes memory spikes.
 // Web keeps full fan-out to preserve Home startup latency.
@@ -410,6 +411,43 @@ function useAllNetworkRequests<T>(params: {
   const runGenerationRef = useRef(0);
   const [isEmptyAccount, setIsEmptyAccount] = useState(false);
   const [isLocked] = useAppIsLockedAtom();
+  const isRouteFocused = useRouteIsFocused();
+  let traceRequestKind = 'token';
+  if (isNFTRequests) {
+    traceRequestKind = 'nft';
+  } else if (isDeFiRequests) {
+    traceRequestKind = 'defi';
+  }
+  // Diagnostic: usePromiseResult drops deps-triggered runs while the route
+  // is unfocused or the app is locked, and that skip is invisible from this
+  // hook. Record the gate inputs whenever they change so a run that never
+  // starts can be explained from device logs.
+  useEffect(() => {
+    if (!isAllNetworks) {
+      return;
+    }
+    defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+      runtime: 'main',
+      phase: 'all-network-hook-gate',
+      networkId: currentNetworkId,
+      isAllNetworks: true,
+      reason: traceRequestKind,
+      disabled,
+      isRouteFocused,
+      isLocked,
+      shouldAlwaysFetch: !!shouldAlwaysFetch,
+      ownerPresent: !!currentAccountId,
+    });
+  }, [
+    currentAccountId,
+    currentNetworkId,
+    disabled,
+    isAllNetworks,
+    isLocked,
+    isRouteFocused,
+    shouldAlwaysFetch,
+    traceRequestKind,
+  ]);
   const [enabledNetworksChangedNonce, setEnabledNetworksChangedNonce] =
     useState(0);
   const rerunAfterCurrentRef = useRef(false);
@@ -594,20 +632,44 @@ function useAllNetworkRequests<T>(params: {
       // out before the redundant-run gate so the stale closure cannot clear
       // the new owner's published result via `applyResultRef` or corrupt
       // `lastRunSignatureRef` / `isFetching` with a full ghost fan-out.
+      let requestKind = 'token';
+      if (isNFTRequests) {
+        requestKind = 'nft';
+      } else if (isDeFiRequests) {
+        requestKind = 'defi';
+      }
+      const traceRunSkipped = (skipReason: string) => {
+        if (!isAllNetworks) {
+          return;
+        }
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'all-network-hook-run-skipped',
+          networkId: currentNetworkId,
+          isAllNetworks: true,
+          reason: requestKind,
+          skipReason,
+          ownerPresent: !!currentAccountId,
+        });
+      };
       if (liveRunOwnerKeyRef.current !== runnerOwnerKey) {
+        traceRunSkipped('stale-owner');
         if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
         return;
       }
 
       if (effectiveDisabled) {
+        traceRunSkipped('disabled');
         if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
         return;
       }
       if (isFetching.current) {
+        traceRunSkipped('queued-behind-active-run');
         rerunAfterCurrentRef.current = true;
         return;
       }
       if (!currentAccountId || !currentNetworkId || !currentWalletId) {
+        traceRunSkipped('missing-owner');
         if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
         return;
       }
@@ -630,12 +692,6 @@ function useAllNetworkRequests<T>(params: {
         alwaysSetStateForThisRun ||
         skipAccountsCacheRef.current ||
         ignoreDisabledForThisRun;
-      let requestKind = 'token';
-      if (isNFTRequests) {
-        requestKind = 'nft';
-      } else if (isDeFiRequests) {
-        requestKind = 'defi';
-      }
       if (
         shouldSkipRedundantAllNetworkRun({
           isMustRun,
@@ -644,6 +700,7 @@ function useAllNetworkRequests<T>(params: {
           lastSignature: lastRunSignatureRef.current,
         })
       ) {
+        traceRunSkipped('redundant-same-owner');
         if (clearRetainedResultOnAcceptedRun) {
           scheduleQueuedRerun();
           return lastPublishedResultRef.current?.runSignature ===

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -38,6 +38,7 @@ import { perfTokenListView } from '../components/TokenListView/perfTokenListView
 
 import {
   type IAllNetworkLastPublishedResult,
+  resolveAllNetworkFailedRunRestore,
   resolveAllNetworkPublishedResult,
 } from './allNetworkRunResultUtils';
 import { makeColdRequestFactory } from './makeColdRequestFactory';
@@ -214,6 +215,26 @@ function filterAllNetworkAccountsInfoResult({
   };
 }
 
+// Identity of the owner a runner closure was created for. A runner parked in
+// the debounce window can outlive an account/network/wallet switch; comparing
+// this key against a render-updated ref lets the stale runner bail out before
+// it mutates any shared ref or clears the new owner's published result.
+function buildAllNetworkRunOwnerKey({
+  accountId,
+  networkId,
+  walletId,
+  isAllNetworks,
+}: {
+  accountId?: string;
+  networkId?: string;
+  walletId?: string;
+  isAllNetworks?: boolean;
+}): string {
+  return `${accountId ?? ''}|${networkId ?? ''}|${walletId ?? ''}|${
+    isAllNetworks ? 1 : 0
+  }`;
+}
+
 type IEnabledNetworksCompatResult = {
   networkInfoMap: Record<string, INetworkDeriveInfo>;
   compatibleNetworks: IServerNetwork[];
@@ -341,6 +362,11 @@ function useAllNetworkRequests<T>(params: {
   // consumer's LWW materialized view reject a stale earlier run's settle.
   onRequestSettled?: (result: T, generation: number) => void;
   revalidateOnFocus?: boolean;
+  // Clear a retained result after the all-network redundant-run gate accepts a
+  // new fan-out. Deliberately NOT forwarded to usePromiseResult's
+  // `undefinedResultIfReRun` (which clears on EVERY runner start): a skipped
+  // duplicate must keep its stable result here.
+  clearRetainedResultOnAcceptedRun?: boolean;
 }) {
   type IAllNetworkRequestsRunConfig = {
     alwaysSetState?: boolean;
@@ -367,9 +393,15 @@ function useAllNetworkRequests<T>(params: {
     onCacheChecked,
     onRequestSettled,
     revalidateOnFocus = false,
+    clearRetainedResultOnAcceptedRun = false,
   } = params;
   const allNetworkDataInit = useRef(false);
   const isFetching = useRef(false);
+  // Reserve active debounce windows so a second manual refresh is queued by
+  // runWithQueue instead of starting another usePromiseResult runner and
+  // invalidating the first runner's nonce. A count handles overlapping
+  // dependency-triggered runners without releasing the reservation early.
+  const debouncePendingCountRef = useRef(0);
   const runCountRef = useRef(0);
   // Monotonic run generation for the consumer's LWW materialized view. Unlike
   // `runCountRef` (reset to 0 on owner/enabled-network change), this is NEVER
@@ -387,6 +419,14 @@ function useAllNetworkRequests<T>(params: {
   const runWithQueueRef = useRef<
     ((config?: IAllNetworkRequestsRunConfig) => Promise<void>) | undefined
   >(undefined);
+  // Applies a value to the hook result from inside the runner closure.
+  // `setResult` is declared after the runner (usePromiseResult return), so it
+  // must be reached through a render-updated ref.
+  const applyResultRef = useRef<
+    ((result: Array<T> | null | undefined) => void) | undefined
+  >(undefined);
+  // Render-updated owner identity used to detect a stale runner closure.
+  const liveRunOwnerKeyRef = useRef('');
   const lastPublishedResultRef = useRef<
     IAllNetworkLastPublishedResult<T> | undefined
   >(undefined);
@@ -479,8 +519,14 @@ function useAllNetworkRequests<T>(params: {
     enabledNetworksChangedNonce,
   ]);
 
-  const { run, result } = usePromiseResult(
+  const { run, result, setResult } = usePromiseResult(
     async () => {
+      const runnerOwnerKey = buildAllNetworkRunOwnerKey({
+        accountId: currentAccountId,
+        networkId: currentNetworkId,
+        walletId: currentWalletId,
+        isAllNetworks,
+      });
       const ignoreDisabledForThisRun = ignoreDisabledRef.current;
       ignoreDisabledRef.current = false;
       const effectiveDisabled = disabled && !ignoreDisabledForThisRun;
@@ -493,7 +539,16 @@ function useAllNetworkRequests<T>(params: {
         !!isAllNetworks &&
         runCountRef.current > 0;
       if (shouldDebounceWait) {
-        await timerUtils.wait(POLLING_DEBOUNCE_INTERVAL);
+        if (clearRetainedResultOnAcceptedRun) {
+          debouncePendingCountRef.current += 1;
+        }
+        try {
+          await timerUtils.wait(POLLING_DEBOUNCE_INTERVAL);
+        } finally {
+          if (clearRetainedResultOnAcceptedRun) {
+            debouncePendingCountRef.current -= 1;
+          }
+        }
       }
       perfTokenListView.markEnd(
         'useAllNetworkRequestsRun_debounceDelay',
@@ -506,13 +561,60 @@ function useAllNetworkRequests<T>(params: {
 
       perfTokenListView.markStart('useAllNetworkRequestsRun');
 
-      if (effectiveDisabled) return;
+      const scheduleQueuedRerun = () => {
+        const hasQueuedRerun = rerunAfterCurrentRef.current;
+        if (!hasQueuedRerun) {
+          return false;
+        }
+        rerunAfterCurrentRef.current = false;
+        // Preserve the explicit refresh flags from runWithQueue. A queue set
+        // by an internal dependency runner has no config and must still pass
+        // through the redundant-run gate; otherwise every render churn could
+        // be promoted to another forced fan-out.
+        const rerunConfig = rerunConfigRef.current;
+        const hasQueuedMustRun =
+          !!rerunConfig?.alwaysSetState ||
+          !!rerunConfig?.skipAccountsCache ||
+          !!rerunConfig?.ignoreDisabled;
+        rerunConfigRef.current = undefined;
+        setTimeout(() => {
+          void runWithQueueRef.current?.(rerunConfig);
+        }, 0);
+        // Only an explicit must-run refresh supersedes the result that just
+        // completed. A dependency-triggered duplicate is still drained, but
+        // its preceding result remains publishable while the gate skips it.
+        return clearRetainedResultOnAcceptedRun
+          ? hasQueuedMustRun
+          : hasQueuedRerun;
+      };
+
+      // A runner resumed from the debounce window may belong to a previous
+      // owner: the dep change that swapped the owner already spawned a fresh
+      // runner, and this one's return value is nonce-invalidated anyway. Bail
+      // out before the redundant-run gate so the stale closure cannot clear
+      // the new owner's published result via `applyResultRef` or corrupt
+      // `lastRunSignatureRef` / `isFetching` with a full ghost fan-out.
+      if (liveRunOwnerKeyRef.current !== runnerOwnerKey) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
+
+      if (effectiveDisabled) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
       if (isFetching.current) {
         rerunAfterCurrentRef.current = true;
         return;
       }
-      if (!currentAccountId || !currentNetworkId || !currentWalletId) return;
-      if (!isAllNetworks) return;
+      if (!currentAccountId || !currentNetworkId || !currentWalletId) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
+      if (!isAllNetworks) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
 
       // L5: drop redundant same-owner re-fires (usePromiseResult dep-identity
       // churn during/after a switch). Read+reset the relayed alwaysSetState
@@ -542,9 +644,26 @@ function useAllNetworkRequests<T>(params: {
           lastSignature: lastRunSignatureRef.current,
         })
       ) {
+        if (clearRetainedResultOnAcceptedRun) {
+          scheduleQueuedRerun();
+          return lastPublishedResultRef.current?.runSignature ===
+            currentRunSignature
+            ? lastPublishedResultRef.current.result
+            : undefined;
+        }
         return;
       }
       lastRunSignatureRef.current = currentRunSignature;
+
+      // Captured for the failure path: an accepted run invalidates the
+      // retained result below, and a failed fan-out must restore it.
+      const previousPublishedResult = lastPublishedResultRef.current;
+      if (clearRetainedResultOnAcceptedRun) {
+        // Keep a queued refresh from restoring the prior published result
+        // after the new run has already invalidated it.
+        applyResultRef.current?.(undefined);
+        lastPublishedResultRef.current = undefined;
+      }
 
       runCountRef.current += 1;
       runGenerationRef.current += 1;
@@ -912,6 +1031,29 @@ function useAllNetworkRequests<T>(params: {
           ownerPresent: !!currentAccountId,
           reason: requestKind,
         });
+      } catch (error) {
+        if (clearRetainedResultOnAcceptedRun) {
+          // The accepted run cleared the retained result before fetching.
+          // Restore the last-good snapshot so a failed fan-out does not pin
+          // the consumer on `undefined` until the next successful must-run.
+          // The visible result is only restored while the owner is unchanged
+          // AND the retained snapshot carries this run's signature: the ref
+          // outlives owner switches, so `ownerUnchanged` alone cannot prove
+          // the snapshot belongs to the current owner. The ref restore alone
+          // is safe because the skip path re-checks the run signature before
+          // serving it.
+          const { nextLastPublished, shouldRestoreResult } =
+            resolveAllNetworkFailedRunRestore({
+              previousPublished: previousPublishedResult,
+              ownerUnchanged: liveRunOwnerKeyRef.current === runnerOwnerKey,
+              currentRunSignature,
+            });
+          lastPublishedResultRef.current = nextLastPublished;
+          if (shouldRestoreResult && previousPublishedResult) {
+            applyResultRef.current?.(previousPublishedResult.result);
+          }
+        }
+        throw error;
       } finally {
         // Wait for onStarted to settle before firing onFinished, so
         // the started/finished events for this run land in monotonic
@@ -940,15 +1082,7 @@ function useAllNetworkRequests<T>(params: {
         // during async cleanup must queue behind this run so its completed
         // result can be classified as superseded before publication.
         isFetching.current = false;
-        hasQueuedRerun = rerunAfterCurrentRef.current;
-        if (hasQueuedRerun) {
-          rerunAfterCurrentRef.current = false;
-          const rerunConfig = rerunConfigRef.current;
-          rerunConfigRef.current = undefined;
-          setTimeout(() => {
-            void runWithQueueRef.current?.(rerunConfig);
-          }, 0);
-        }
+        hasQueuedRerun = scheduleQueuedRerun();
       }
 
       const resolved = resolveAllNetworkPublishedResult({
@@ -956,6 +1090,10 @@ function useAllNetworkRequests<T>(params: {
         hasQueuedRerun,
         lastPublished: lastPublishedResultRef.current,
         runSignature: currentRunSignature,
+        // The accepted run cleared the retained result above; a superseded
+        // completed result is then the only last-good snapshot the queued
+        // must-run can restore from if its fan-out fails.
+        retainSupersededResult: clearRetainedResultOnAcceptedRun,
       });
       lastPublishedResultRef.current = resolved.nextLastPublished;
       return resolved.publishedResult;
@@ -978,6 +1116,7 @@ function useAllNetworkRequests<T>(params: {
       allNetworkCacheData,
       allNetworkRequests,
       onRequestSettled,
+      clearRetainedResultOnAcceptedRun,
     ],
     {
       revalidateOnFocus,
@@ -989,7 +1128,11 @@ function useAllNetworkRequests<T>(params: {
 
   const runWithQueue = useCallback(
     async (config?: IAllNetworkRequestsRunConfig) => {
-      if (isFetching.current) {
+      if (
+        isFetching.current ||
+        (clearRetainedResultOnAcceptedRun &&
+          debouncePendingCountRef.current > 0)
+      ) {
         rerunAfterCurrentRef.current = true;
         rerunConfigRef.current = {
           ...rerunConfigRef.current,
@@ -1017,9 +1160,16 @@ function useAllNetworkRequests<T>(params: {
       }
       await run(config);
     },
-    [run],
+    [run, clearRetainedResultOnAcceptedRun],
   );
 
+  applyResultRef.current = (nextResult) => setResult(nextResult);
+  liveRunOwnerKeyRef.current = buildAllNetworkRunOwnerKey({
+    accountId: currentAccountId,
+    networkId: currentNetworkId,
+    walletId: currentWalletId,
+    isAllNetworks,
+  });
   runWithQueueRef.current = runWithQueue;
 
   return {

--- a/packages/kit/src/states/jotai/contexts/accountOverview/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountOverview/actions.test.tsx
@@ -1,0 +1,785 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+
+import { useAccountOverviewActions } from './actions';
+import {
+  ProviderJotaiContextAccountOverview,
+  useAccountWorthAtom,
+} from './atoms';
+
+function createWrapper() {
+  const store = createStore();
+  return function Wrapper({ children }: { children?: ReactNode }) {
+    return (
+      <ProviderJotaiContextAccountOverview store={store}>
+        {children}
+      </ProviderJotaiContextAccountOverview>
+    );
+  };
+}
+
+describe('account overview worth freshness', () => {
+  it('recomputes the create-network scalar when a fresh network value changes', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+    const accountId = 'watching--evm--0xalice';
+    const networkId = 'evm--1';
+    const valueKey = `${accountId}_${networkId}`;
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId,
+        createAtNetwork: networkId,
+        initialized: true,
+        worth: { [valueKey]: '10' },
+        createAtNetworkWorth: '10',
+        merge: true,
+        assetSnapshotMetaByKey: { [valueKey]: { localSeq: 1 } },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId,
+        createAtNetwork: networkId,
+        initialized: true,
+        worth: { [valueKey]: '5' },
+        createAtNetworkWorth: '5',
+        merge: true,
+        assetSnapshotMetaByKey: { [valueKey]: { localSeq: 2 } },
+      });
+    });
+
+    expect(result.current.worth.worth[valueKey]).toBe('5');
+    expect(result.current.worth.createAtNetworkWorth).toBe('5');
+  });
+
+  it('keeps the create-network scalar tied to its network during merges', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+    const accountId = 'watching--evm--0xalice';
+    const createNetworkId = 'evm--1';
+    const otherNetworkId = 'evm--137';
+    const createKey = `${accountId}_${createNetworkId}`;
+    const otherKey = `${accountId}_${otherNetworkId}`;
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId,
+        createAtNetwork: createNetworkId,
+        initialized: true,
+        worth: { [createKey]: '10' },
+        createAtNetworkWorth: '10',
+        merge: true,
+        assetSnapshotMetaByKey: { [createKey]: { localSeq: 1 } },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId,
+        createAtNetwork: createNetworkId,
+        initialized: true,
+        worth: { [otherKey]: '20' },
+        createAtNetworkWorth: '20',
+        merge: true,
+        assetSnapshotMetaByKey: { [otherKey]: { localSeq: 2 } },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      [createKey]: '10',
+      [otherKey]: '20',
+    });
+    expect(result.current.worth.createAtNetworkWorth).toBe('10');
+  });
+
+  it('adds a fresh create-at-network value even when its response sequence is older', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-b': '5' },
+        createAtNetworkWorth: '0',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-b': { localSeq: 2 },
+        },
+        assetSnapshotMeta: { localSeq: 2 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 1 },
+        },
+        assetSnapshotMeta: { localSeq: 1 },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-b': '5',
+      'account-1_network-a': '7',
+    });
+    expect(result.current.worth.createAtNetworkWorth).toBe('7');
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '99' },
+        createAtNetworkWorth: '99',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 1 },
+        },
+        assetSnapshotMeta: { localSeq: 1 },
+      });
+    });
+
+    expect(result.current.worth.worth['account-1_network-a']).toBe('7');
+    expect(result.current.worth.createAtNetworkWorth).toBe('7');
+  });
+
+  it('does not let an unversioned full snapshot delete versioned keys', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: {
+          'account-1_network-a': '7',
+          'account-1_network-b': '5',
+        },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 2 },
+          'account-1_network-b': { localSeq: 2 },
+        },
+        assetSnapshotMeta: { localSeq: 2 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '1' },
+        createAtNetworkWorth: '1',
+        updateAll: true,
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '7',
+      'account-1_network-b': '5',
+    });
+    expect(result.current.worth.createAtNetworkWorth).toBe('7');
+  });
+
+  it('keeps the scalar while hydrating a freshly reset owner from a partial cache', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: false,
+        worth: {},
+        createAtNetworkWorth: '0',
+        reset: true,
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 1 },
+        },
+      });
+    });
+
+    expect(result.current.worth.createAtNetworkWorth).toBe('7');
+  });
+
+  it('retains omitted networks when an unversioned all-network cache is partial', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'watching--account-1',
+        initialized: true,
+        worth: {
+          'watching--account-1_network-a': '7',
+          'watching--account-1_network-b': '5',
+        },
+        createAtNetwork: 'network-a',
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'watching--account-1_network-a': { localSeq: 2 },
+          'watching--account-1_network-b': { localSeq: 2 },
+        },
+        assetSnapshotMeta: { localSeq: 2 },
+      });
+    });
+
+    // Cache hydration only includes networks with a non-empty cached row and
+    // therefore cannot authorize eviction of the omitted network.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'watching--account-1',
+        initialized: true,
+        worth: { 'watching--account-1_network-a': '8' },
+        createAtNetwork: 'network-a',
+        createAtNetworkWorth: '8',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'watching--account-1_network-a': { localSeq: 3 },
+        },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'watching--account-1_network-a': '8',
+      'watching--account-1_network-b': '5',
+    });
+    expect(result.current.worth.createAtNetworkWorth).toBe('8');
+  });
+
+  it('keeps merge:false replacement semantics for an unversioned legacy write', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: {
+          'account-1_network-a': '7',
+          'account-1_network-b': '5',
+        },
+        createAtNetworkWorth: '7',
+        merge: false,
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '1' },
+        createAtNetworkWorth: '1',
+        merge: false,
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '1',
+    });
+    expect(result.current.worth.createAtNetworkWorth).toBe('1');
+  });
+
+  it('does not promote a partial network marker to the aggregate marker', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 1 },
+        },
+        assetSnapshotMeta: { localSeq: 1 },
+      });
+    });
+
+    // The aggregate marker above belongs to an independent network response,
+    // so it must not be promoted to a complete-snapshot marker.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-b': '5' },
+        createAtNetworkWorth: '5',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-b': { localSeq: 2 },
+        },
+      });
+    });
+
+    expect(result.current.worth.assetSnapshotMeta).toBeUndefined();
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '7',
+      'account-1_network-b': '5',
+    });
+  });
+
+  it('does not carry the previous owner aggregate marker into a merged update', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 1 },
+        },
+        assetSnapshotMeta: { localSeq: 1 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-2',
+        initialized: true,
+        worth: { 'account-2_network-b': '5' },
+        createAtNetworkWorth: '5',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-2_network-b': { localSeq: 2 },
+        },
+      });
+    });
+
+    expect(result.current.worth.accountId).toBe('account-2');
+    expect(result.current.worth.assetSnapshotMeta).toBeUndefined();
+  });
+
+  it('uses a complete marker as the fallback for keys without a per-key marker', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMeta: { localSeq: 2 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '1' },
+        createAtNetworkWorth: '1',
+        merge: true,
+      });
+    });
+
+    expect(result.current.worth.worth['account-1_network-a']).toBe('7');
+  });
+
+  it('does not let an older per-key marker bypass a newer aggregate marker', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMeta: { localSeq: 10 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '1' },
+        createAtNetworkWorth: '1',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 5 },
+        },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '2' },
+        createAtNetworkWorth: '2',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 6 },
+        },
+      });
+    });
+
+    expect(result.current.worth.worth['account-1_network-a']).toBe('7');
+    expect(
+      result.current.worth.assetSnapshotMetaByKey?.['account-1_network-a'],
+    ).toEqual({ localSeq: 10 });
+  });
+
+  it('does not let the previous owner marker gate a complete owner switch', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMeta: { localSeq: 100 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-2',
+        initialized: true,
+        worth: {},
+        createAtNetworkWorth: '0',
+        updateAll: true,
+        assetSnapshotMeta: { localSeq: 10 },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-2',
+        initialized: true,
+        worth: { 'account-2_network-a': '99' },
+        createAtNetworkWorth: '99',
+        merge: true,
+        assetSnapshotMetaByKey: {
+          'account-2_network-a': { localSeq: 5 },
+        },
+      });
+    });
+
+    expect(result.current.worth.accountId).toBe('account-2');
+    expect(result.current.worth.worth).toEqual({});
+    expect(result.current.worth.assetSnapshotMeta).toEqual({ localSeq: 10 });
+  });
+
+  it('lets a full snapshot evict omitted networks after progressive merges admitted the same responses', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    // Round 1: a complete snapshot that still includes network-c.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: {
+          'account-1_network-a': '7',
+          'account-1_network-b': '5',
+          'account-1_network-c': '3',
+        },
+        createAtNetworkWorth: '15',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 1 },
+          'account-1_network-b': { localSeq: 1 },
+          'account-1_network-c': { localSeq: 1 },
+        },
+        assetSnapshotMeta: { localSeq: 1 },
+      });
+    });
+
+    // Round 2 (network-c disabled): progressive per-network merges arrive
+    // first and admit each response.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '8' },
+        createAtNetworkWorth: '8',
+        merge: true,
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 2 } },
+      });
+    });
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-b': '6' },
+        createAtNetworkWorth: '6',
+        merge: true,
+        assetSnapshotMetaByKey: { 'account-1_network-b': { localSeq: 3 } },
+      });
+    });
+
+    // The full snapshot for the same round re-materializes those responses
+    // with EQUAL markers. It must still replace the map and drop network-c.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: {
+          'account-1_network-a': '8',
+          'account-1_network-b': '6',
+        },
+        createAtNetworkWorth: '14',
+        updateAll: true,
+        assetSnapshotMetaByKey: {
+          'account-1_network-a': { localSeq: 2 },
+          'account-1_network-b': { localSeq: 3 },
+        },
+        assetSnapshotMeta: { localSeq: 2 },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '8',
+      'account-1_network-b': '6',
+    });
+    expect(result.current.worth.assetSnapshotMeta).toEqual({ localSeq: 2 });
+    expect(result.current.worth.assetSnapshotMetaByKey).toEqual({
+      'account-1_network-a': { localSeq: 2 },
+      'account-1_network-b': { localSeq: 3 },
+    });
+    expect(result.current.worth.createAtNetworkWorth).toBe('14');
+  });
+
+  it('still refuses a full snapshot whose omitted network carries a newer marker', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        merge: true,
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 2 } },
+      });
+    });
+    // network-b was refreshed after the full snapshot's oldest response.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-b': '5' },
+        createAtNetworkWorth: '5',
+        merge: true,
+        assetSnapshotMetaByKey: { 'account-1_network-b': { localSeq: 9 } },
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '7' },
+        createAtNetworkWorth: '7',
+        updateAll: true,
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 2 } },
+        assetSnapshotMeta: { localSeq: 2 },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '7',
+      'account-1_network-b': '5',
+    });
+    expect(result.current.worth.assetSnapshotMeta).toBeUndefined();
+  });
+
+  it('keeps the currency tag of retained values when a replacement rejects every incoming value', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useAccountOverviewActions().current;
+        const [worth] = useAccountWorthAtom();
+        return { actions, worth };
+      },
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '70' },
+        createAtNetworkWorth: '70',
+        merge: false,
+        currency: 'cny',
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 5 } },
+      });
+    });
+
+    // A stale replacement tagged in another currency is rejected; the
+    // retained value must keep describing itself as CNY.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '10' },
+        createAtNetworkWorth: '10',
+        merge: false,
+        currency: 'usd',
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 1 } },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '70',
+    });
+    expect(result.current.worth.currency).toBe('cny');
+
+    // Same for a stale progressive merge.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '11' },
+        createAtNetworkWorth: '11',
+        merge: true,
+        currency: 'usd',
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 2 } },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '70',
+    });
+    expect(result.current.worth.currency).toBe('cny');
+
+    // A fresh value adopts the incoming tag again.
+    act(() => {
+      result.current.actions.updateAccountWorth({
+        accountId: 'account-1',
+        initialized: true,
+        worth: { 'account-1_network-a': '10' },
+        createAtNetworkWorth: '10',
+        merge: false,
+        currency: 'usd',
+        assetSnapshotMetaByKey: { 'account-1_network-a': { localSeq: 6 } },
+      });
+    });
+
+    expect(result.current.worth.worth).toEqual({
+      'account-1_network-a': '10',
+    });
+    expect(result.current.worth.currency).toBe('usd');
+  });
+});

--- a/packages/kit/src/states/jotai/contexts/accountOverview/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/accountOverview/actions.ts
@@ -3,7 +3,14 @@ import { useRef } from 'react';
 import BigNumber from 'bignumber.js';
 
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import {
+  getNewestAssetSnapshotMeta,
+  isAssetSnapshotNewer,
+  isAssetSnapshotSameOrNewer,
+} from '@onekeyhq/shared/src/utils/assetSnapshotFreshness';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import type { IWalletBanner } from '@onekeyhq/shared/types/walletBanner';
 
 import { ContextJotaiActionsBase } from '../../utils/ContextJotaiActionsBase';
@@ -19,6 +26,32 @@ import {
   overviewDeFiDataStateAtom,
   walletTopBannersAtom,
 } from './atoms';
+
+function recomputeCreateAtNetworkWorth({
+  worth,
+  accountId,
+  createAtNetwork,
+}: {
+  worth: Record<string, string>;
+  accountId: string;
+  createAtNetwork?: string;
+}): string | undefined {
+  if (!createAtNetwork) {
+    return undefined;
+  }
+
+  if (accountUtils.isOthersAccount({ accountId })) {
+    const key = accountUtils.buildAccountValueKey({
+      accountId,
+      networkId: createAtNetwork,
+    });
+    return new BigNumber(worth[key] ?? '0').toFixed();
+  }
+
+  return Object.values(worth)
+    .reduce<BigNumber>((sum, value) => sum.plus(value), new BigNumber(0))
+    .toFixed();
+}
 
 class ContextJotaiActionsAccountOverview extends ContextJotaiActionsBase {
   updateAllNetworksState = contextAtomMethod(
@@ -46,24 +79,22 @@ class ContextJotaiActionsAccountOverview extends ContextJotaiActionsBase {
       payload: {
         worth: Record<string, string>;
         createAtNetworkWorth?: string;
+        createAtNetwork?: string;
         initialized: boolean;
         accountId: string;
         updateAll?: boolean;
         merge?: boolean;
+        reset?: boolean;
         currency?: string;
+        assetSnapshotMetaByKey?: Record<string, IAssetSnapshotMeta>;
+        assetSnapshotMeta?: IAssetSnapshotMeta;
       },
     ) => {
       const currency = payload.currency ?? USD_CURRENCY_ID;
-      if (payload.merge) {
-        const { worth, createAtNetworkWorth } = get(accountWorthAtom());
+      if (payload.reset) {
         set(accountWorthAtom(), {
-          worth: {
-            ...worth,
-            ...payload.worth,
-          },
-          createAtNetworkWorth: new BigNumber(createAtNetworkWorth ?? '0')
-            .plus(payload.createAtNetworkWorth ?? '0')
-            .toFixed(),
+          worth: {},
+          createAtNetworkWorth: '0',
           initialized: payload.initialized,
           accountId: payload.accountId,
           updateAll: payload.updateAll,
@@ -72,13 +103,273 @@ class ContextJotaiActionsAccountOverview extends ContextJotaiActionsBase {
         return;
       }
 
+      const current = get(accountWorthAtom());
+      const sameAccount = current.accountId === payload.accountId;
+      // `merge: false` is the long-standing replacement mode used by the
+      // single-network path. An all-network `updateAll` payload is a complete
+      // replacement only when it carries the aggregate marker proving that
+      // every enabled network was observed. Cache hydration and incomplete
+      // fan-outs also use `updateAll`, but they are partial and must retain
+      // omitted networks.
+      const isCompleteSnapshot =
+        payload.merge !== true &&
+        (payload.updateAll !== true || Boolean(payload.assetSnapshotMeta));
+      const currentMetaByKey = sameAccount
+        ? (current.assetSnapshotMetaByKey ?? {})
+        : {};
+      const currentAggregateMeta = sameAccount
+        ? current.assetSnapshotMeta
+        : undefined;
+      const incomingMetaForKey = (key: string) =>
+        payload.assetSnapshotMetaByKey?.[key] ??
+        (isCompleteSnapshot ? payload.assetSnapshotMeta : undefined);
+
+      if (payload.merge) {
+        const baseWorth = sameAccount ? current.worth : {};
+        const baseCreateAtNetworkWorth = sameAccount
+          ? current.createAtNetworkWorth
+          : '0';
+        const acceptedWorth: Record<string, string> = {};
+        Object.entries(payload.worth).forEach(([key, value]) => {
+          const incomingMeta = incomingMetaForKey(key);
+          const existingMeta = getNewestAssetSnapshotMeta(
+            currentMetaByKey[key],
+            currentAggregateMeta,
+          );
+          if (
+            !existingMeta ||
+            isAssetSnapshotNewer(incomingMeta, existingMeta)
+          ) {
+            acceptedWorth[key] = value;
+          }
+        });
+        const nextMetaByKey = { ...currentMetaByKey };
+        Object.entries(payload.worth).forEach(([key]) => {
+          const incomingMeta = incomingMetaForKey(key);
+          const existingMeta = getNewestAssetSnapshotMeta(
+            currentMetaByKey[key],
+            currentAggregateMeta,
+          );
+          if (
+            incomingMeta &&
+            (!existingMeta || isAssetSnapshotNewer(incomingMeta, existingMeta))
+          ) {
+            nextMetaByKey[key] = incomingMeta;
+          }
+        });
+        const nextWorth = {
+          ...baseWorth,
+          ...acceptedWorth,
+        };
+        const hasAcceptedWorth = Object.keys(acceptedWorth).length > 0;
+        const recomputedCreateAtNetworkWorth =
+          payload.createAtNetworkWorth !== undefined
+            ? recomputeCreateAtNetworkWorth({
+                worth: nextWorth,
+                accountId: payload.accountId,
+                createAtNetwork: payload.createAtNetwork,
+              })
+            : undefined;
+        // `merge` receives independent network responses. When the producer
+        // supplies the owner's create network, derive the scalar from the
+        // materialized absolute values so a refreshed key replaces its prior
+        // contribution instead of being added a second time. Legacy callers
+        // without that context retain the historical additive behavior.
+        let nextCreateAtNetworkWorth = baseCreateAtNetworkWorth;
+        if (recomputedCreateAtNetworkWorth !== undefined) {
+          nextCreateAtNetworkWorth = recomputedCreateAtNetworkWorth;
+        } else if (
+          payload.createAtNetworkWorth !== undefined &&
+          (Object.keys(payload.worth).length === 0 || hasAcceptedWorth)
+        ) {
+          nextCreateAtNetworkWorth = new BigNumber(
+            baseCreateAtNetworkWorth ?? '0',
+          )
+            .plus(payload.createAtNetworkWorth)
+            .toFixed();
+        }
+        // `merge: true` is an independent per-network update. Its marker
+        // cannot describe the complete account snapshot, so never promote it
+        // to the aggregate marker used by full replacements.
+        const nextAggregateMeta = currentAggregateMeta;
+        // The currency tag describes the values in `nextWorth`. When every
+        // incoming value was rejected as stale, only retained values remain
+        // and they still carry the previous tag; adopting the rejected
+        // payload's tag would convert them from the wrong currency downstream.
+        const nextCurrency =
+          !hasAcceptedWorth && sameAccount && Object.keys(nextWorth).length > 0
+            ? current.currency
+            : currency;
+        set(accountWorthAtom(), {
+          worth: nextWorth,
+          createAtNetworkWorth: nextCreateAtNetworkWorth,
+          initialized: payload.initialized,
+          accountId: payload.accountId,
+          updateAll: payload.updateAll,
+          currency: nextCurrency,
+          ...(Object.keys(nextMetaByKey).length > 0
+            ? { assetSnapshotMetaByKey: nextMetaByKey }
+            : {}),
+          ...(nextAggregateMeta
+            ? { assetSnapshotMeta: nextAggregateMeta }
+            : {}),
+        });
+        return;
+      }
+
+      const currentValue =
+        sameAccount &&
+        typeof current.worth === 'object' &&
+        current.worth !== null
+          ? current.worth
+          : {};
+      // Progressive per-network merges admit each response as it settles, and
+      // the full snapshot built from the same round re-materializes those
+      // responses with EQUAL markers. Equal markers must not block the
+      // replacement, otherwise a full refresh could never evict an omitted
+      // (disabled/removed) network; only strictly older input is stale.
+      const incomingKeysAreFresh = Object.keys(payload.worth).every((key) => {
+        const incomingMeta = incomingMetaForKey(key);
+        const existingMeta = getNewestAssetSnapshotMeta(
+          currentMetaByKey[key],
+          currentAggregateMeta,
+        );
+        return (
+          !existingMeta ||
+          isAssetSnapshotSameOrNewer(incomingMeta, existingMeta)
+        );
+      });
+      // Keys omitted by the full snapshot are evicted, so their markers must
+      // be strictly older than the oldest marker the snapshot covers. Keys the
+      // snapshot supplies were admitted per key above.
+      const completeMetaIsFresh = payload.assetSnapshotMeta
+        ? isAssetSnapshotSameOrNewer(
+            payload.assetSnapshotMeta,
+            currentAggregateMeta,
+          ) &&
+          Object.entries(currentMetaByKey)
+            .filter(
+              ([key]) =>
+                !Object.prototype.hasOwnProperty.call(payload.worth, key),
+            )
+            .every(([, currentMeta]) =>
+              isAssetSnapshotNewer(payload.assetSnapshotMeta, currentMeta),
+            )
+        : !currentAggregateMeta && Object.keys(currentMetaByKey).length === 0;
+      const hasVersionedCurrentSnapshot =
+        Boolean(currentAggregateMeta) ||
+        Object.keys(currentMetaByKey).length > 0;
+      const hasIncomingSnapshotMeta =
+        Boolean(payload.assetSnapshotMeta) ||
+        Object.keys(payload.assetSnapshotMetaByKey ?? {}).length > 0;
+      const hasCompleteIncomingSnapshotMeta =
+        !isCompleteSnapshot ||
+        (!hasIncomingSnapshotMeta && !hasVersionedCurrentSnapshot) ||
+        (Boolean(payload.assetSnapshotMeta) &&
+          Object.keys(payload.worth).every((key) =>
+            Boolean(incomingMetaForKey(key)),
+          ));
+      const canReplaceFullSnapshot =
+        !isCompleteSnapshot ||
+        (hasCompleteIncomingSnapshotMeta &&
+          incomingKeysAreFresh &&
+          completeMetaIsFresh);
+      const preserveCurrentValues =
+        sameAccount && (!isCompleteSnapshot || !canReplaceFullSnapshot);
+      const nextWorth: Record<string, string> = preserveCurrentValues
+        ? { ...currentValue }
+        : {};
+      const nextMetaByKey: Record<string, IAssetSnapshotMeta> =
+        preserveCurrentValues ? { ...currentMetaByKey } : {};
+      // An admitted full snapshot is authoritative for every key it supplies,
+      // including keys whose marker equals the stored one (see above).
+      const admitsEqualMarker = isCompleteSnapshot && canReplaceFullSnapshot;
+      let acceptedValueCount = 0;
+      Object.entries(payload.worth).forEach(([key, value]) => {
+        const incomingMeta = incomingMetaForKey(key);
+        const existingMeta = getNewestAssetSnapshotMeta(
+          currentMetaByKey[key],
+          currentAggregateMeta,
+        );
+        const incomingIsFresh = admitsEqualMarker
+          ? isAssetSnapshotSameOrNewer(incomingMeta, existingMeta)
+          : isAssetSnapshotNewer(incomingMeta, existingMeta);
+        if (!sameAccount || !existingMeta || incomingIsFresh) {
+          nextWorth[key] = value;
+          acceptedValueCount += 1;
+          if (incomingMeta) {
+            nextMetaByKey[key] = incomingMeta;
+          }
+        } else if (current.worth[key] !== undefined) {
+          // Replacement still preserves the current value for an explicitly
+          // supplied key when that incoming snapshot is stale.
+          nextWorth[key] = current.worth[key];
+          if (existingMeta) {
+            nextMetaByKey[key] = existingMeta;
+          }
+        }
+      });
+      const shouldUpdateAggregate =
+        payload.updateAll === true &&
+        isCompleteSnapshot &&
+        canReplaceFullSnapshot;
+      let nextAggregateMeta: IAssetSnapshotMeta | undefined;
+      if (shouldUpdateAggregate) {
+        nextAggregateMeta = payload.assetSnapshotMeta;
+      } else if (sameAccount) {
+        nextAggregateMeta = currentAggregateMeta;
+      }
+      const shouldUpdateCreateAtNetworkWorth =
+        !sameAccount ||
+        (isCompleteSnapshot && canReplaceFullSnapshot) ||
+        (payload.updateAll !== true && acceptedValueCount > 0) ||
+        // Cache hydration is a partial all-network seed (no aggregate marker),
+        // but it is also the first value for a freshly reset owner. Preserve
+        // its create-at-network scalar so Others-account persistence does not
+        // briefly write zero while the per-network map is already populated.
+        (payload.updateAll === true &&
+          payload.createAtNetworkWorth !== undefined &&
+          sameAccount &&
+          current.createAtNetworkWorth === '0' &&
+          Object.keys(currentValue).length === 0 &&
+          !currentAggregateMeta &&
+          Object.keys(currentMetaByKey).length === 0 &&
+          acceptedValueCount > 0);
+      let nextCreateAtNetworkWorth = current.createAtNetworkWorth;
+      const recomputedCreateAtNetworkWorth =
+        payload.createAtNetworkWorth !== undefined
+          ? recomputeCreateAtNetworkWorth({
+              worth: nextWorth,
+              accountId: payload.accountId,
+              createAtNetwork: payload.createAtNetwork,
+            })
+          : undefined;
+      if (recomputedCreateAtNetworkWorth !== undefined) {
+        nextCreateAtNetworkWorth = recomputedCreateAtNetworkWorth;
+      } else if (shouldUpdateAggregate || shouldUpdateCreateAtNetworkWorth) {
+        nextCreateAtNetworkWorth = payload.createAtNetworkWorth ?? '0';
+      }
+
+      // See the merge path: a replacement that rejected every incoming value
+      // keeps only retained values and must keep their currency tag.
+      const nextCurrency =
+        acceptedValueCount === 0 &&
+        sameAccount &&
+        Object.keys(nextWorth).length > 0
+          ? current.currency
+          : currency;
+
       set(accountWorthAtom(), {
-        worth: payload.worth,
-        createAtNetworkWorth: payload.createAtNetworkWorth ?? '0',
+        worth: nextWorth,
+        createAtNetworkWorth: nextCreateAtNetworkWorth,
         initialized: payload.initialized,
         accountId: payload.accountId,
         updateAll: payload.updateAll,
-        currency,
+        currency: nextCurrency,
+        ...(Object.keys(nextMetaByKey).length > 0
+          ? { assetSnapshotMetaByKey: nextMetaByKey }
+          : {}),
+        ...(nextAggregateMeta ? { assetSnapshotMeta: nextAggregateMeta } : {}),
       });
     },
   );

--- a/packages/kit/src/states/jotai/contexts/accountOverview/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/accountOverview/atoms.ts
@@ -1,4 +1,5 @@
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import type { IWalletBanner } from '@onekeyhq/shared/types/walletBanner';
 
 import { createJotaiContext } from '../../utils/createJotaiContext';
@@ -40,6 +41,10 @@ export const { atom: accountWorthAtom, use: useAccountWorthAtom } =
     // Undefined means pre-migration hydrate stored in the user's then-active
     // display currency; consumers fall back to settings.currencyInfo.id.
     currency?: string;
+    /** Freshness marker for each account-value compound key. */
+    assetSnapshotMetaByKey?: Record<string, IAssetSnapshotMeta>;
+    /** Marker for the complete aggregate snapshot/scalar value. */
+    assetSnapshotMeta?: IAssetSnapshotMeta;
   }>(
     {
       worth: {},

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -1433,6 +1433,11 @@ function TokenSelector() {
               // USD value by the active display rate when settings != USD.
               value: { [valueKey]: totalFiatValue },
               currency: r.tokens.currency ?? 'usd',
+              ...(r.assetSnapshotMeta
+                ? {
+                    assetSnapshotMetaByKey: { [valueKey]: r.assetSnapshotMeta },
+                  }
+                : {}),
             },
           );
         }

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -1416,7 +1416,10 @@ function TokenSelector() {
             valueAccountId = activeAccountId;
           }
         }
-        if (valueAccountId && activeNetworkId) {
+        // A filtered selector response is only a token subset (wallet-only or
+        // dApp-only). It must not be persisted as the canonical network total;
+        // otherwise opening the selector can overwrite Home with a partial sum.
+        if (valueAccountId && activeNetworkId && !showTokenSelectorFilter) {
           const valueKey = accountUtils.buildAccountValueKey({
             accountId: activeAccountId,
             networkId: activeNetworkId,
@@ -1461,6 +1464,7 @@ function TokenSelector() {
     networkId,
     showActiveAccountTokenList,
     showLpTokensOnly,
+    showTokenSelectorFilter,
     showFetchTokenListErrorToast,
     tokenSelectorFilterParams,
     useSelectorFilteredTokenList,

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.cacheOnlyGate.test.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.cacheOnlyGate.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/*
+yarn jest packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.cacheOnlyGate.test.ts
+*/
+
+describe('DeFiListBlock cache-only readiness producer', () => {
+  it('lets the cache-only all-network hook run regardless of route focus', () => {
+    // The cache-only instance is the only writer of the header's DeFi
+    // readiness. Device logs showed sessions where its hook never started,
+    // pinning the All Networks header to a stale persisted total.
+    const source = readFileSync(join(__dirname, 'DeFiListBlock.tsx'), 'utf8');
+    const hookStart = source.indexOf('} = useAllNetworkRequests<');
+    const hookEnd = source.indexOf('});', hookStart);
+    const hookConfig = source.slice(hookStart, hookEnd);
+
+    expect(hookStart).toBeGreaterThan(0);
+    expect(hookConfig).toContain('isDeFiRequests: true');
+    expect(hookConfig).toContain('shouldAlwaysFetch: refreshCacheOnly');
+  });
+});

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -958,6 +958,11 @@ function DeFiListBlock({
     clearAllNetworkData: handleClearAllNetworkData,
     isDeFiRequests: true,
     disabled: network?.isAllNetworks ? !isAllNetRequestsEnabled : false,
+    // The cache-only instance is the sole writer of the header's DeFi
+    // readiness and only reads local caches. usePromiseResult skips
+    // deps-triggered runs while the route is unfocused, which left readiness
+    // unset for entire sessions; let this instance run regardless of focus.
+    shouldAlwaysFetch: refreshCacheOnly,
   });
 
   const handleRefreshAllNetworkData = useCallback(() => {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -64,6 +64,7 @@ import {
   shouldShowDeFiEmptyState,
 } from './deFiListLoadingReducer';
 import { DeFiListSkeleton } from './DeFiListSkeleton';
+import { planDeFiOverviewInit } from './deFiOverviewInitPlan';
 import { getOverviewCollapsedProtocolLimit } from './DeFiOverviewPlanner';
 import { formatPortfolioTotal } from './formatPortfolioTotal';
 import { buildDeFiOverviewCells } from './hooks/useDeFiOverviewTopN';
@@ -281,6 +282,8 @@ function DeFiListBlock({
     cacheKey?: string;
     hasCache: boolean;
   }>({ hasCache: false });
+  // Owner the init effect last ran for; see planDeFiOverviewInit.
+  const initDeFiOwnerKeyRef = useRef<string | undefined>(undefined);
 
   const [isSliced, setIsSliced] = useDeFiListSlicedAtom();
   const overviewCols = useMemo(
@@ -1036,17 +1039,26 @@ function DeFiListBlock({
         cacheKey,
         hasCache: false,
       };
-      updateOverviewDeFiDataState({
+      const initPlan = planDeFiOverviewInit({
         accountId,
         networkId,
-        isReady: undefined,
+        accountAddress: account?.address,
+        lastInitOwnerKey: initDeFiOwnerKeyRef.current,
       });
+      initDeFiOwnerKeyRef.current = initPlan.ownerKey;
+      if (initPlan.shouldResetReadiness) {
+        updateOverviewDeFiDataState({
+          accountId,
+          networkId,
+          isReady: undefined,
+        });
+      }
       void backgroundApiProxy.serviceDeFi.updateCurrentAccount({
         networkId,
         accountId,
       });
 
-      if (networkUtils.isAllNetwork({ networkId })) {
+      if (!initPlan.shouldHydrateSingleNetworkCache) {
         return;
       }
 

--- a/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.test.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.test.ts
@@ -1,0 +1,60 @@
+import {
+  buildDeFiOverviewInitOwnerKey,
+  planDeFiOverviewInit,
+} from './deFiOverviewInitPlan';
+
+const owner = {
+  accountId: 'hd-1--m/44h/60h/0h/0/0',
+  networkId: 'onekeyall--0',
+  accountAddress: '0xabc',
+};
+
+describe('planDeFiOverviewInit', () => {
+  it('resets readiness on the first init for an owner', () => {
+    const plan = planDeFiOverviewInit({
+      ...owner,
+      lastInitOwnerKey: undefined,
+    });
+    expect(plan.isOwnerChanged).toBe(true);
+    expect(plan.shouldResetReadiness).toBe(true);
+    expect(plan.shouldHydrateSingleNetworkCache).toBe(false);
+  });
+
+  it('keeps all-network readiness when only the currency map changed', () => {
+    // A currency-map refresh re-fires the init effect for the SAME owner.
+    // The cache-only Portfolio instance only writes readiness during the
+    // cold cache probe, so clearing it here would leave the header pinned
+    // on the last confirmed balance until the DeFi tab is visited.
+    const plan = planDeFiOverviewInit({
+      ...owner,
+      lastInitOwnerKey: buildDeFiOverviewInitOwnerKey(owner),
+    });
+    expect(plan.isOwnerChanged).toBe(false);
+    expect(plan.shouldResetReadiness).toBe(false);
+    expect(plan.shouldHydrateSingleNetworkCache).toBe(false);
+  });
+
+  it('re-hydrates the single-network cache for a same-owner re-run', () => {
+    const singleNetworkOwner = { ...owner, networkId: 'evm--1' };
+    const plan = planDeFiOverviewInit({
+      ...singleNetworkOwner,
+      lastInitOwnerKey: buildDeFiOverviewInitOwnerKey(singleNetworkOwner),
+    });
+    expect(plan.shouldResetReadiness).toBe(false);
+    expect(plan.shouldHydrateSingleNetworkCache).toBe(true);
+  });
+
+  it.each([
+    ['accountId', { accountId: 'hd-2--m/44h/60h/0h/0/0' }],
+    ['networkId', { networkId: 'evm--1' }],
+    ['accountAddress', { accountAddress: '0xdef' }],
+  ])('resets readiness when %s changes', (_field, patch) => {
+    const plan = planDeFiOverviewInit({
+      ...owner,
+      ...patch,
+      lastInitOwnerKey: buildDeFiOverviewInitOwnerKey(owner),
+    });
+    expect(plan.isOwnerChanged).toBe(true);
+    expect(plan.shouldResetReadiness).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.ts
@@ -1,0 +1,57 @@
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+
+export interface IDeFiOverviewInitOwner {
+  accountId: string;
+  networkId: string;
+  accountAddress?: string;
+}
+
+export interface IDeFiOverviewInitPlan {
+  ownerKey: string;
+  isOwnerChanged: boolean;
+  /**
+   * Clear `overviewDeFiDataState.isReady` before (re)initializing.
+   *
+   * Only an owner switch may clear it. The init effect also re-fires when
+   * the currency map or display currency changes, and in All Networks mode
+   * readiness is written solely by the all-network cold cache probe /
+   * fan-out — nothing re-runs those for a same-owner re-fire. Clearing
+   * readiness there would leave the always-visible header holding the last
+   * confirmed balance indefinitely (it gates on token AND DeFi readiness).
+   */
+  shouldResetReadiness: boolean;
+  /** Single-network owners re-hydrate the local overview on every run. */
+  shouldHydrateSingleNetworkCache: boolean;
+}
+
+export function buildDeFiOverviewInitOwnerKey({
+  accountId,
+  networkId,
+  accountAddress,
+}: IDeFiOverviewInitOwner): string {
+  return `${accountId}__${networkId}__${accountAddress ?? ''}`;
+}
+
+export function planDeFiOverviewInit({
+  accountId,
+  networkId,
+  accountAddress,
+  lastInitOwnerKey,
+}: IDeFiOverviewInitOwner & {
+  lastInitOwnerKey: string | undefined;
+}): IDeFiOverviewInitPlan {
+  const ownerKey = buildDeFiOverviewInitOwnerKey({
+    accountId,
+    networkId,
+    accountAddress,
+  });
+  const isOwnerChanged = ownerKey !== lastInitOwnerKey;
+  return {
+    ownerKey,
+    isOwnerChanged,
+    shouldResetReadiness: isOwnerChanged,
+    shouldHydrateSingleNetworkCache: !networkUtils.isAllNetwork({
+      networkId,
+    }),
+  };
+}

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.portfolioSync.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.portfolioSync.test.ts
@@ -30,6 +30,7 @@ describe('TokenListBlock portfolio sync producer', () => {
     );
     expect(source).toContain('assetStatusCurrency &&');
     expect(source).toContain('if (!snapshot || isStaleOwnerRequest())');
+    expect(source).toContain('clearRetainedResultOnAcceptedRun: true');
     expect(source).toContain('totalFiatCurrency: assetStatusCurrency');
     expect(gateIndex).toBeGreaterThan(0);
     expect(gateIndex).toBeLessThan(buildIndex);
@@ -41,5 +42,31 @@ describe('TokenListBlock portfolio sync producer', () => {
     expect(source).not.toContain(
       'appEventBus.emit(EAppEventBusNames.AllNetworksTokenListSettled',
     );
+  });
+
+  it('commits the authoritative snapshot before running asset status analytics', () => {
+    const source = readFileSync(join(__dirname, 'TokenListBlock.tsx'), 'utf8');
+    const producerStart = source.indexOf(
+      'const updateAllNetworksTokenList = useCallback',
+    );
+    const producerSource = source.slice(producerStart);
+    const worthIndex = producerSource.indexOf('updateAccountWorth({');
+    const commitIndex = producerSource.indexOf(
+      'commitAuthoritativeIngest(snapshot);',
+    );
+    const readyStateIndex = producerSource.indexOf(
+      'updateTokenListState({',
+      commitIndex,
+    );
+    const analyticsIndex = producerSource.indexOf(
+      'getWalletAssetStatusAnalytics',
+      commitIndex,
+    );
+
+    expect(producerStart).toBeGreaterThan(0);
+    expect(worthIndex).toBeGreaterThan(0);
+    expect(commitIndex).toBeGreaterThan(worthIndex);
+    expect(readyStateIndex).toBeGreaterThan(commitIndex);
+    expect(analyticsIndex).toBeGreaterThan(readyStateIndex);
   });
 });

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1641,6 +1641,7 @@ function TokenListBlock({
     onCacheChecked: handleAllNetworkCacheChecked,
     onRequestSettled: handleAllNetworkRequestSettled,
     shouldAlwaysFetch,
+    clearRetainedResultOnAcceptedRun: true,
   });
 
   const updateAllNetworksTokenList = useCallback(async () => {
@@ -1693,120 +1694,6 @@ function TokenListBlock({
         result: allNetworksResult,
       });
     const assetStatusCurrency = getWalletAssetStatusCurrency(allNetworksResult);
-    if (
-      assetStatusAggregationComplete &&
-      assetStatusCurrency?.toLowerCase() === USD_CURRENCY_ID
-    ) {
-      const reportNow = Date.now();
-      const assetStatusAnalytics =
-        await backgroundApiProxy.simpleDb.appStatus.getWalletAssetStatusAnalytics();
-      const { wallets: eligibleWallets } =
-        await backgroundApiProxy.serviceAccount.getAllHdHwQrWallets({
-          includingAccounts: true,
-        });
-      if (isStaleOwnerRequest()) {
-        return;
-      }
-      const eligibleAccountIds = Array.from(
-        new Set(
-          eligibleWallets.flatMap((eligibleWallet) =>
-            (eligibleWallet.dbIndexedAccounts ?? []).map(
-              (indexedAccountItem) => indexedAccountItem.id,
-            ),
-          ),
-        ),
-      );
-
-      if (eligibleAccountIds.length) {
-        const accountValues =
-          await backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountIdBatch(
-            {
-              accounts: eligibleAccountIds.map((accountId) => ({
-                accountId,
-              })),
-            },
-          );
-        if (isStaleOwnerRequest()) {
-          return;
-        }
-        const currentAccountValueId =
-          indexedAccount?.id ?? account?.indexedAccountId;
-        const currentAccountValue =
-          currentAccountValueId &&
-          eligibleAccountIds.includes(currentAccountValueId)
-            ? {
-                accountId: currentAccountValueId,
-                value: snapshot.accountsWorth,
-                currency: USD_CURRENCY_ID,
-              }
-            : undefined;
-        const assetStatusEvaluation = evaluateWalletAssetStatus({
-          accountValues,
-          currentAccountValue,
-          eligibleWalletCount: eligibleWallets.length,
-        });
-
-        if (
-          assetStatusEvaluation.assetStatus &&
-          assetStatusEvaluation.balanceBucket &&
-          assetStatusEvaluation.changeReason
-        ) {
-          const baseParams = {
-            source: WALLET_ASSET_STATUS_SOURCE,
-            scope: WALLET_ASSET_STATUS_SCOPE,
-            assetStatus: assetStatusEvaluation.assetStatus,
-            balanceBucket: assetStatusEvaluation.balanceBucket,
-            thresholdUsd: WALLET_ASSET_STATUS_THRESHOLD_USD,
-            thresholdCurrency: WALLET_ASSET_STATUS_THRESHOLD_CURRENCY,
-            assetBasis: WALLET_ASSET_STATUS_BASIS,
-            eligibleWalletTypes: WALLET_ASSET_STATUS_ELIGIBLE_WALLET_TYPES,
-            eligibleWalletCount: assetStatusEvaluation.eligibleWalletCount,
-            eligibleAccountCount: assetStatusEvaluation.eligibleAccountCount,
-            knownAccountCount: assetStatusEvaluation.knownAccountCount,
-            unknownAccountCount: assetStatusEvaluation.unknownAccountCount,
-          } as const;
-          const shouldReportSnapshot = shouldReportWalletAssetStatusSnapshot({
-            lastReportedAt: assetStatusAnalytics?.lastSnapshotReportedAt,
-            now: reportNow,
-          });
-          const shouldReportChange = shouldReportWalletAssetStatusChange({
-            previousStatus: assetStatusAnalytics?.assetStatus,
-            currentStatus: assetStatusEvaluation.assetStatus,
-          });
-
-          if (shouldReportSnapshot) {
-            defaultLogger.wallet.balance.walletAssetStatusEvaluated(baseParams);
-          }
-          if (shouldReportChange) {
-            defaultLogger.wallet.balance.walletAssetStatusChanged({
-              ...baseParams,
-              previousStatus: assetStatusAnalytics?.assetStatus ?? 'unknown',
-              currentStatus: assetStatusEvaluation.assetStatus,
-              changeReason: assetStatusEvaluation.changeReason,
-            });
-          }
-
-          if (
-            shouldReportSnapshot ||
-            shouldReportChange ||
-            assetStatusAnalytics?.assetStatus !==
-              assetStatusEvaluation.assetStatus
-          ) {
-            await backgroundApiProxy.simpleDb.appStatus.setWalletAssetStatusAnalytics(
-              {
-                assetStatus: assetStatusEvaluation.assetStatus,
-                lastSnapshotReportedAt: shouldReportSnapshot
-                  ? reportNow
-                  : assetStatusAnalytics?.lastSnapshotReportedAt,
-                lastStatusChangedAt: shouldReportChange
-                  ? reportNow
-                  : assetStatusAnalytics?.lastStatusChangedAt,
-              },
-            );
-          }
-        }
-      }
-    }
 
     if (isStaleOwnerRequest()) {
       return;
@@ -1924,6 +1811,124 @@ function TokenListBlock({
       initialized: true,
       isRefreshing: false,
     });
+
+    // Asset status analytics is non-critical for the Home refresh. Keep it
+    // after the authoritative snapshot has reached the UI so a slow background
+    // RPC cannot hold the refreshed balance/token list in a loading state.
+    if (
+      assetStatusAggregationComplete &&
+      assetStatusCurrency?.toLowerCase() === USD_CURRENCY_ID
+    ) {
+      const reportNow = Date.now();
+      const assetStatusAnalytics =
+        await backgroundApiProxy.simpleDb.appStatus.getWalletAssetStatusAnalytics();
+      const { wallets: eligibleWallets } =
+        await backgroundApiProxy.serviceAccount.getAllHdHwQrWallets({
+          includingAccounts: true,
+        });
+      if (isStaleOwnerRequest()) {
+        return;
+      }
+      const eligibleAccountIds = Array.from(
+        new Set(
+          eligibleWallets.flatMap((eligibleWallet) =>
+            (eligibleWallet.dbIndexedAccounts ?? []).map(
+              (indexedAccountItem) => indexedAccountItem.id,
+            ),
+          ),
+        ),
+      );
+
+      if (eligibleAccountIds.length) {
+        const accountValues =
+          await backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountIdBatch(
+            {
+              accounts: eligibleAccountIds.map((accountId) => ({
+                accountId,
+              })),
+            },
+          );
+        if (isStaleOwnerRequest()) {
+          return;
+        }
+        const currentAccountValueId =
+          indexedAccount?.id ?? account?.indexedAccountId;
+        const currentAccountValue =
+          currentAccountValueId &&
+          eligibleAccountIds.includes(currentAccountValueId)
+            ? {
+                accountId: currentAccountValueId,
+                value: snapshot.accountsWorth,
+                currency: USD_CURRENCY_ID,
+              }
+            : undefined;
+        const assetStatusEvaluation = evaluateWalletAssetStatus({
+          accountValues,
+          currentAccountValue,
+          eligibleWalletCount: eligibleWallets.length,
+        });
+
+        if (
+          assetStatusEvaluation.assetStatus &&
+          assetStatusEvaluation.balanceBucket &&
+          assetStatusEvaluation.changeReason
+        ) {
+          const baseParams = {
+            source: WALLET_ASSET_STATUS_SOURCE,
+            scope: WALLET_ASSET_STATUS_SCOPE,
+            assetStatus: assetStatusEvaluation.assetStatus,
+            balanceBucket: assetStatusEvaluation.balanceBucket,
+            thresholdUsd: WALLET_ASSET_STATUS_THRESHOLD_USD,
+            thresholdCurrency: WALLET_ASSET_STATUS_THRESHOLD_CURRENCY,
+            assetBasis: WALLET_ASSET_STATUS_BASIS,
+            eligibleWalletTypes: WALLET_ASSET_STATUS_ELIGIBLE_WALLET_TYPES,
+            eligibleWalletCount: assetStatusEvaluation.eligibleWalletCount,
+            eligibleAccountCount: assetStatusEvaluation.eligibleAccountCount,
+            knownAccountCount: assetStatusEvaluation.knownAccountCount,
+            unknownAccountCount: assetStatusEvaluation.unknownAccountCount,
+          } as const;
+          const shouldReportSnapshot = shouldReportWalletAssetStatusSnapshot({
+            lastReportedAt: assetStatusAnalytics?.lastSnapshotReportedAt,
+            now: reportNow,
+          });
+          const shouldReportChange = shouldReportWalletAssetStatusChange({
+            previousStatus: assetStatusAnalytics?.assetStatus,
+            currentStatus: assetStatusEvaluation.assetStatus,
+          });
+
+          if (shouldReportSnapshot) {
+            defaultLogger.wallet.balance.walletAssetStatusEvaluated(baseParams);
+          }
+          if (shouldReportChange) {
+            defaultLogger.wallet.balance.walletAssetStatusChanged({
+              ...baseParams,
+              previousStatus: assetStatusAnalytics?.assetStatus ?? 'unknown',
+              currentStatus: assetStatusEvaluation.assetStatus,
+              changeReason: assetStatusEvaluation.changeReason,
+            });
+          }
+
+          if (
+            shouldReportSnapshot ||
+            shouldReportChange ||
+            assetStatusAnalytics?.assetStatus !==
+              assetStatusEvaluation.assetStatus
+          ) {
+            await backgroundApiProxy.simpleDb.appStatus.setWalletAssetStatusAnalytics(
+              {
+                assetStatus: assetStatusEvaluation.assetStatus,
+                lastSnapshotReportedAt: shouldReportSnapshot
+                  ? reportNow
+                  : assetStatusAnalytics?.lastSnapshotReportedAt,
+                lastStatusChangedAt: shouldReportChange
+                  ? reportNow
+                  : assetStatusAnalytics?.lastStatusChangedAt,
+              },
+            );
+          }
+        }
+      }
+    }
   }, [
     account?.address,
     account?.id,
@@ -2463,7 +2468,11 @@ function TokenListBlock({
   useEffect(() => {
     const fn = () => {
       if (network?.isAllNetworks) {
-        void runAllNetworksRequests({ alwaysSetState: true });
+        // The all-network token refresh for this event is handled inside
+        // useAllNetworkRequests (its wallet-scoped listener also bypasses the
+        // accounts cache). Kicking it again here queued a second forced
+        // fan-out per hardware-account batch; only the LP token list still
+        // needs a dedicated trigger.
         if (showLpTokensOnly) {
           void runLpTokenList({ alwaysSetState: true });
         }
@@ -2473,12 +2482,7 @@ function TokenListBlock({
     return () => {
       appEventBus.off(EAppEventBusNames.AddDBAccountsToWallet, fn);
     };
-  }, [
-    network?.isAllNetworks,
-    runAllNetworksRequests,
-    runLpTokenList,
-    showLpTokensOnly,
-  ]);
+  }, [network?.isAllNetworks, runLpTokenList, showLpTokensOnly]);
 
   const handleRefreshAllNetworkDataByAccounts = useCallback(
     async (accounts: { accountId: string; networkId: string }[]) => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -119,6 +119,7 @@ import {
 } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { sumTokenGroupsFiatValueIgnoringUnavailable } from '@onekeyhq/shared/src/utils/tokenValueUtils';
 import { EHomeTab } from '@onekeyhq/shared/types';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import type {
   IAccountToken,
   ICustomTokenItem,
@@ -602,6 +603,7 @@ function TokenListBlock({
           };
 
           const accountWorth: Record<string, string> = {};
+          const assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta> = {};
 
           resp.forEach((item) => {
             if (item.accountId && item.networkId) {
@@ -614,6 +616,9 @@ function TokenListBlock({
               // the row-level '--' still surfaces the broken entry.
               accountWorth[key] =
                 sumTokenGroupsFiatValueIgnoringUnavailable(item);
+              if (item.assetSnapshotMeta) {
+                assetSnapshotMetaByKey[key] = item.assetSnapshotMeta;
+              }
             }
           });
 
@@ -625,10 +630,12 @@ function TokenListBlock({
 
             updateAccountWorth({
               accountId,
+              createAtNetwork: account?.createAtNetwork,
               initialized: true,
               worth: accountWorth,
               createAtNetworkWorth: '0',
               merge: false,
+              assetSnapshotMetaByKey,
             });
           }
         } else {
@@ -652,6 +659,7 @@ function TokenListBlock({
 
             updateAccountWorth({
               accountId,
+              createAtNetwork: account?.createAtNetwork,
               initialized: true,
               worth: {
                 [accountUtils.buildAccountValueKey({
@@ -661,6 +669,14 @@ function TokenListBlock({
               },
               createAtNetworkWorth: accountWorth,
               merge: false,
+              assetSnapshotMetaByKey: r.assetSnapshotMeta
+                ? {
+                    [accountUtils.buildAccountValueKey({
+                      accountId,
+                      networkId: network.id,
+                    })]: r.assetSnapshotMeta,
+                  }
+                : undefined,
             });
           }
         }
@@ -1166,6 +1182,7 @@ function TokenListBlock({
             accountId: mergeDeriveAddressData
               ? (indexedAccount?.id ?? '')
               : (account?.id ?? ''),
+            createAtNetwork: account?.createAtNetwork,
             initialized: true,
             worth: {
               [accountUtils.buildAccountValueKey({
@@ -1175,6 +1192,14 @@ function TokenListBlock({
             },
             createAtNetworkWorth,
             merge: true,
+            assetSnapshotMetaByKey: r.assetSnapshotMeta
+              ? {
+                  [accountUtils.buildAccountValueKey({
+                    accountId,
+                    networkId,
+                  })]: r.assetSnapshotMeta,
+                }
+              : undefined,
           });
         }
 
@@ -1457,6 +1482,7 @@ function TokenListBlock({
         accountId: string;
         hasCache: boolean;
         currency?: string;
+        assetSnapshotMeta?: IAssetSnapshotMeta;
       }[];
       accountId: string;
       networkId: string;
@@ -1476,15 +1502,26 @@ function TokenListBlock({
 
       // Per-account worth map for the overview update below.
       let tokenListValue: Record<string, string> = {};
+      let assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta> = {};
+      // The cache callback receives only non-empty cache rows. A missing row
+      // can therefore mean either an empty cache or a network that has not
+      // settled yet; it cannot prove that this is a complete all-network
+      // snapshot. Keep per-network markers for partial LWW admission, but do
+      // not attach an aggregate marker that could authorize key deletion.
+      const cacheAssetSnapshotMeta = undefined;
       const hasAnyCache = data.some((item) => item.hasCache);
       data.forEach((item) => {
-        tokenListValue = {
-          ...tokenListValue,
-          [accountUtils.buildAccountValueKey({
-            accountId: item.accountId,
-            networkId: item.networkId,
-          })]: item.tokenListValue,
-        };
+        const key = accountUtils.buildAccountValueKey({
+          accountId: item.accountId,
+          networkId: item.networkId,
+        });
+        tokenListValue = { ...tokenListValue, [key]: item.tokenListValue };
+        if (item.assetSnapshotMeta) {
+          assetSnapshotMetaByKey = {
+            ...assetSnapshotMetaByKey,
+            [key]: item.assetSnapshotMeta,
+          };
+        }
       });
 
       if (syncTokenFilterToOverview) {
@@ -1527,6 +1564,7 @@ function TokenListBlock({
             accountId: mergeDeriveAddressData
               ? (indexedAccount?.id ?? '')
               : (account?.id ?? ''),
+            createAtNetwork: account?.createAtNetwork,
             initialized: true,
             worth: tokenListValue,
             createAtNetworkWorth:
@@ -1538,6 +1576,8 @@ function TokenListBlock({
               ],
             updateAll: true,
             currency: cacheCurrency,
+            assetSnapshotMetaByKey,
+            assetSnapshotMeta: cacheAssetSnapshotMeta,
           });
           updateAccountOverviewState({
             isRefreshing: false,
@@ -1716,10 +1756,18 @@ function TokenListBlock({
         accountId: mergeDeriveAddressData
           ? (indexedAccount?.id ?? '')
           : (account?.id ?? ''),
+        createAtNetwork: account?.createAtNetwork,
         initialized: true,
         updateAll: true,
         worth: snapshot.accountsWorth,
         createAtNetworkWorth: snapshot.createAtNetworkWorth,
+        assetSnapshotMetaByKey: snapshot.assetSnapshotMetaByKey,
+        // `buildAuthoritativeSnapshot` materializes only settled rounds. If
+        // one enabled network failed or is still pending, the resulting map is
+        // partial and must not carry the full-snapshot deletion marker.
+        assetSnapshotMeta: assetStatusAggregationComplete
+          ? snapshot.assetSnapshotMeta
+          : undefined,
       });
 
       if (
@@ -1931,6 +1979,7 @@ function TokenListBlock({
     }
   }, [
     account?.address,
+    account?.createAtNetwork,
     account?.id,
     account?.indexedAccountId,
     accountName,
@@ -2015,6 +2064,7 @@ function TokenListBlock({
       let riskyTokenListMap: Record<string, ITokenFiat> = {};
       let tokenListValue = '0';
       let tokenListWorth: Record<string, string> = {};
+      let assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta> = {};
       let hasLocalTokenCache = false;
       let cachedWorthCurrency: string | undefined;
 
@@ -2049,13 +2099,20 @@ function TokenListBlock({
 
         const params = resp.map((r) => {
           if (r.accountId && r.networkId) {
+            const valueKey = accountUtils.buildAccountValueKey({
+              accountId: r.accountId,
+              networkId: r.networkId,
+            });
             tokenListWorth = {
               ...tokenListWorth,
-              [accountUtils.buildAccountValueKey({
-                accountId: r.accountId,
-                networkId: r.networkId,
-              })]: r.tokenListValue,
+              [valueKey]: r.tokenListValue,
             };
+            if (r.assetSnapshotMeta) {
+              assetSnapshotMetaByKey = {
+                ...assetSnapshotMetaByKey,
+                [valueKey]: r.assetSnapshotMeta,
+              };
+            }
           }
           tokenListValue = new BigNumber(tokenListValue)
             .plus(r.tokenListValue ?? '0')
@@ -2085,6 +2142,7 @@ function TokenListBlock({
                 tokenListMap: r.tokenListMap,
               }),
             },
+            assetSnapshotMeta: r.assetSnapshotMeta,
           };
         });
 
@@ -2127,12 +2185,18 @@ function TokenListBlock({
           tokenListMap: localTokens.tokenListMap,
         });
         tokenListValue = localTokens.tokenListValue;
+        const valueKey = accountUtils.buildAccountValueKey({
+          accountId,
+          networkId,
+        });
         tokenListWorth = {
-          [accountUtils.buildAccountValueKey({
-            accountId,
-            networkId,
-          })]: localTokens.tokenListValue,
+          [valueKey]: localTokens.tokenListValue,
         };
+        if (localTokens.assetSnapshotMeta) {
+          assetSnapshotMetaByKey = {
+            [valueKey]: localTokens.assetSnapshotMeta,
+          };
+        }
       }
 
       // Owner-change or unmount happened while we were awaiting the local
@@ -2206,11 +2270,13 @@ function TokenListBlock({
             accountId: mergeDeriveAddressData
               ? (indexedAccount?.id ?? '')
               : (account?.id ?? ''),
+            createAtNetwork: account?.createAtNetwork,
             initialized: true,
             worth: tokenListWorth,
             createAtNetworkWorth: tokenListValue,
             merge: false,
             currency: cachedWorthCurrency,
+            assetSnapshotMetaByKey,
           });
           handleClearAllNetworkData();
           // Stamp the empty cached owner into the cell VM so an empty cached
@@ -2253,11 +2319,13 @@ function TokenListBlock({
           accountId: mergeDeriveAddressData
             ? (indexedAccount?.id ?? '')
             : (account?.id ?? ''),
+          createAtNetwork: account?.createAtNetwork,
           initialized: true,
           worth: tokenListWorth,
           createAtNetworkWorth: tokenListValue,
           merge: false,
           currency: cachedWorthCurrency,
+          assetSnapshotMetaByKey,
         });
         updateAccountOverviewState({
           isRefreshing: false,
@@ -2287,6 +2355,7 @@ function TokenListBlock({
     };
   }, [
     account?.address,
+    account?.createAtNetwork,
     account?.id,
     // @ts-expect-error
     account?.xpub,
@@ -2613,6 +2682,7 @@ function TokenListBlock({
         updateAccountOverviewState({ isRefreshing: false, initialized: true });
         updateAccountWorth({
           accountId,
+          createAtNetwork: account?.createAtNetwork,
           initialized: true,
           worth: {
             [accountUtils.buildAccountValueKey({ accountId, networkId })]:
@@ -2620,6 +2690,14 @@ function TokenListBlock({
           },
           createAtNetworkWorth: accountWorth,
           merge: false,
+          assetSnapshotMetaByKey: r.assetSnapshotMeta
+            ? {
+                [accountUtils.buildAccountValueKey({
+                  accountId,
+                  networkId,
+                })]: r.assetSnapshotMeta,
+              }
+            : undefined,
         });
 
         if (r.allTokens) {
@@ -2650,6 +2728,7 @@ function TokenListBlock({
       }
     },
     [
+      account?.createAtNetwork,
       walletTokenFilterParams,
       updateAccountOverviewState,
       updateAccountWorth,

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
@@ -406,4 +406,35 @@ describe('buildMergedAllNetworkSnapshot', () => {
     ]);
     expect(snap.smallBalanceFiatValue).toBe('1');
   });
+
+  it('does not mark a materialized subset as a complete snapshot', () => {
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds: [
+        makeRound({
+          networkId: 'evm--1',
+          assetSnapshotMeta: { localSeq: 2 },
+        }),
+      ],
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+      expectedAccountValueKeys: new Set([
+        accountUtils.buildAccountValueKey({
+          accountId: 'acc1',
+          networkId: 'evm--1',
+        }),
+        accountUtils.buildAccountValueKey({
+          accountId: 'acc1',
+          networkId: 'evm--56',
+        }),
+      ]),
+    });
+
+    expect(snap.assetSnapshotMeta).toBeUndefined();
+    expect(snap.assetSnapshotMetaByKey).toEqual({
+      [accountUtils.buildAccountValueKey({
+        accountId: 'acc1',
+        networkId: 'evm--1',
+      })]: { localSeq: 2 },
+    });
+  });
 });

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
@@ -3,6 +3,7 @@ import { uniqBy } from 'lodash';
 
 import { TOKEN_LIST_HIGH_VALUE_MAX } from '@onekeyhq/shared/src/consts/walletConsts';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { compareAssetSnapshotMeta } from '@onekeyhq/shared/src/utils/assetSnapshotFreshness';
 import {
   flattenAggregateTokensMap,
   mergeAggregateTokenListMap,
@@ -19,6 +20,7 @@ import {
   sumFiatValuesFromTokens,
   sumTokenGroupsFiatValueIgnoringUnavailable,
 } from '@onekeyhq/shared/src/utils/tokenValueUtils';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
 /**
@@ -64,6 +66,8 @@ export interface IAllNetworkSnapshotRound {
    * leak risk-only keys into the account worth even after per-$key dedup.
    */
   accountWorth?: string;
+  /** Freshness marker for the values in this network round. */
+  assetSnapshotMeta?: IAssetSnapshotMeta;
 }
 
 /**
@@ -83,6 +87,10 @@ export interface IMergedAllNetworkSnapshot {
   smallBalanceFiatValue: string;
   accountsWorth: Record<string, string>;
   createAtNetworkWorth: string;
+  /** Freshness marker per account-value compound key. */
+  assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta>;
+  /** Oldest marker covered by the full snapshot, used for safe replacement. */
+  assetSnapshotMeta?: IAssetSnapshotMeta;
   tokenKeys: string;
   smallBalanceKeys: string;
   riskyKeys: string;
@@ -108,11 +116,14 @@ export function buildMergedAllNetworkSnapshot({
   mergeDeriveAssetsByNetworkId,
   accountId,
   createAtNetwork,
+  expectedAccountValueKeys,
 }: {
   rounds: IAllNetworkSnapshotRound[];
   mergeDeriveAssetsByNetworkId: Record<string, boolean | undefined>;
   accountId?: string;
   createAtNetwork?: string;
+  /** Keys required before the result may carry a complete-snapshot marker. */
+  expectedAccountValueKeys?: ReadonlySet<string>;
 }): IMergedAllNetworkSnapshot {
   const tokenList: { tokens: IAccountToken[]; keys: string } = {
     tokens: [],
@@ -131,6 +142,9 @@ export function buildMergedAllNetworkSnapshot({
   let smallBalanceTokenListMap: Record<string, ITokenFiat> = {};
   let riskyTokenListMap: Record<string, ITokenFiat> = {};
   const accountsWorth: Record<string, string> = {};
+  const assetSnapshotMetaByKey: Record<string, IAssetSnapshotMeta> = {};
+  let assetSnapshotMeta: IAssetSnapshotMeta | undefined;
+  let hasUnversionedAccountValue = false;
   let createAtNetworkWorth = new BigNumber(0);
   let smallBalanceTokensFiatValue = new BigNumber(0);
 
@@ -215,12 +229,28 @@ export function buildMergedAllNetworkSnapshot({
       ? r.accountWorth
       : sumTokenGroupsFiatValueIgnoringUnavailable(r);
 
-    accountsWorth[
-      accountUtils.buildAccountValueKey({
-        accountId: r.accountId ?? '',
-        networkId: r.networkId ?? '',
-      })
-    ] = accountWorth;
+    const accountValueKey = accountUtils.buildAccountValueKey({
+      accountId: r.accountId ?? '',
+      networkId: r.networkId ?? '',
+    });
+    accountsWorth[accountValueKey] = accountWorth;
+    if (r.assetSnapshotMeta) {
+      assetSnapshotMetaByKey[accountValueKey] = r.assetSnapshotMeta;
+      // `updateAll` may remove keys omitted by a full snapshot. Use the
+      // oldest covered marker so an unrelated newer persisted value is never
+      // deleted by an older/partial response.
+      if (
+        !assetSnapshotMeta ||
+        compareAssetSnapshotMeta(r.assetSnapshotMeta, assetSnapshotMeta) < 0
+      ) {
+        assetSnapshotMeta = r.assetSnapshotMeta;
+      }
+    } else {
+      // A legacy disk cache may not have a freshness marker. Keep its value in
+      // the per-network result, but do not manufacture a complete-snapshot
+      // marker from a different network and use it to replace newer data.
+      hasUnversionedAccountValue = true;
+    }
 
     if (
       accountId &&
@@ -290,6 +320,19 @@ export function buildMergedAllNetworkSnapshot({
     map: riskyTokenListMap,
   });
 
+  // `rounds` is often a materialized subset while a fan-out is still in
+  // flight. A marker on that subset would let downstream persistence treat it
+  // as a full replacement and delete the missing networks. The caller may
+  // provide the authoritative enabled-key set so absence is distinguished from
+  // an empty value returned by a settled round.
+  const hasCompleteExpectedKeys =
+    expectedAccountValueKeys === undefined
+      ? true
+      : expectedAccountValueKeys.size > 0 &&
+        [...expectedAccountValueKeys].every((key) =>
+          Object.prototype.hasOwnProperty.call(accountsWorth, key),
+        );
+
   return {
     orderedTokens: tokenList.tokens,
     smallBalanceTokens: smallBalanceTokenList.smallBalanceTokens,
@@ -301,6 +344,12 @@ export function buildMergedAllNetworkSnapshot({
     smallBalanceFiatValue: smallBalanceTokensFiatValue.toFixed(),
     accountsWorth,
     createAtNetworkWorth: createAtNetworkWorth.toFixed(),
+    assetSnapshotMetaByKey,
+    ...(assetSnapshotMeta &&
+    !hasUnversionedAccountValue &&
+    hasCompleteExpectedKeys
+      ? { assetSnapshotMeta }
+      : {}),
     tokenKeys: tokenList.keys,
     smallBalanceKeys: smallBalanceTokenList.keys,
     riskyKeys: riskyTokenList.keys,

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
@@ -35,6 +35,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { LwwMaterializedView } from '@onekeyhq/shared/src/utils/lwwMaterializedView';
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
 import type {
   IAccountToken,
   ICustomTokenItem,
@@ -93,6 +94,7 @@ export interface ICacheSeedItem {
   aggregateTokenMap?: Record<string, ITokenFiat>;
   accountId: string;
   networkId: string;
+  assetSnapshotMeta?: IAssetSnapshotMeta;
 }
 
 /** A settled LIVE round (structurally a superset of `IAllNetworkSnapshotRound`). */
@@ -318,6 +320,7 @@ export function useTokenListReactivePipeline(
         mergeDeriveAssetsByNetworkId: {},
         accountId: ownerAccountId,
         createAtNetwork: ownerCreateAtNetwork,
+        expectedAccountValueKeys: enabledKeysRef.current,
       });
       ingestMergedSnapshot(snapshot, source, ownerTokenAtFlushStart);
     },
@@ -379,6 +382,7 @@ export function useTokenListReactivePipeline(
               map: item.tokenListMap,
             },
             accountWorth: item.tokenListValue,
+            assetSnapshotMeta: item.assetSnapshotMeta,
             aggregateTokenListMap: item.aggregateTokenListMap,
             aggregateTokenMap: item.aggregateTokenMap,
             ownerAccountId,
@@ -460,6 +464,7 @@ export function useTokenListReactivePipeline(
       mergeDeriveAssetsByNetworkId: {},
       accountId: ownerAccountId,
       createAtNetwork: ownerCreateAtNetwork,
+      expectedAccountValueKeys: enabledKeysRef.current,
     });
   }, [ownerAccountId, ownerCreateAtNetwork, resolveRoundsWithMergeFlag]);
 

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -459,19 +459,31 @@ function HomeOverviewContainer() {
         // accountValue SimpleDB.
         const accountWorthCurrency =
           accountWorth.currency ?? settings.currencyInfo.id;
+        const createAtNetworkValueKey = accountUtils.buildAccountValueKey({
+          accountId: account.id,
+          networkId: account.createAtNetwork ?? '',
+        });
         if (isOthers) {
           if (
             account.createAtNetwork &&
             (network.isAllNetworks || account.createAtNetwork === network.id)
           ) {
-            void backgroundApiProxy.serviceAccountProfile.updateAccountValue({
-              accountId: accountValueId,
-              networkAccountId: account.id,
-              networkId: account.createAtNetwork,
-              value: accountWorth.createAtNetworkWorth,
-              currency: accountWorthCurrency,
-              shouldUpdateActiveAccountValue: true,
-            });
+            const createAtNetworkValue =
+              accountWorth.worth[createAtNetworkValueKey];
+            if (createAtNetworkValue !== undefined) {
+              void backgroundApiProxy.serviceAccountProfile.updateAccountValue({
+                accountId: accountValueId,
+                networkAccountId: account.id,
+                networkId: account.createAtNetwork,
+                // The compound-key map stores the absolute value for this
+                // network. Prefer it over the legacy scalar, which can be
+                // transiently stale while independent network responses
+                // merge.
+                value: createAtNetworkValue,
+                currency: accountWorthCurrency,
+                shouldUpdateActiveAccountValue: true,
+              });
+            }
           }
         } else if (!network.isAllNetworks) {
           const singleNetworkValue =

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -60,9 +60,14 @@ import { showBalanceDetailsDialog } from '../components/BalanceDetailsDialog';
 import { useHomeWalletTabSupport } from '../hooks/useHomeWalletTabSupport';
 import { HomeTestIDs } from '../testIDs';
 
+import { resolveHomeOverviewBalanceHold } from './homeOverviewBalanceHold';
+
 // Grace period (ms) after an account switch during which the previous
 // balance is shown as a placeholder to avoid a skeleton flash.
 const BALANCE_REUSE_GRACE_MS = 180;
+// After the token side commits a complete All Networks snapshot, wait this
+// long for DeFi readiness before showing the live total without it.
+const ALL_NETWORKS_DEFI_GRACE_MS = 5000;
 
 const HOME_OVERVIEW_REFRESH_TABS = [
   EHomeTab.TOKENS,
@@ -723,6 +728,16 @@ function HomeOverviewContainer() {
   const isCurrentAllNetworksBalanceFullyReady =
     !network?.isAllNetworks ||
     (isCurrentAccountWorthReady && isCurrentAccountDeFiReady);
+  const isCurrentAccountWorthOwner =
+    !!accountWorth.accountId &&
+    (accountWorth.accountId === (account?.id ?? '') ||
+      accountWorth.accountId === (account?.indexedAccountId ?? ''));
+  // `updateAll` marks a complete snapshot for this owner (cache hydrate or an
+  // authoritative fan-out commit) as opposed to per-network progressive merges.
+  const isCurrentTokenSnapshotCommitted =
+    isCurrentAccountWorthOwner &&
+    accountWorth.initialized &&
+    accountWorth.updateAll === true;
 
   const [reuseLatestBalanceGraceExpired, setReuseLatestBalanceGraceExpired] =
     useState(false);
@@ -813,11 +828,32 @@ function HomeOverviewContainer() {
   ]);
 
   // During All Networks progressive loading, hold the previous confirmed
-  // balance until both token and DeFi data finish loading.
-  const shouldHoldCurrentConfirmedBalance =
-    !!network?.isAllNetworks &&
-    !!currentConfirmedBalance &&
-    !isCurrentAllNetworksBalanceFullyReady;
+  // balance until token and DeFi data finish loading. The hold is bounded:
+  // DeFi readiness only arrives through the cache-only DeFi hook, and when
+  // that hook does not run the header must not stay pinned to a stale
+  // persisted total for the whole session (see resolveHomeOverviewBalanceHold).
+  const [deFiGraceExpired, setDeFiGraceExpired] = useState(false);
+  const { shouldHold: shouldHoldCurrentConfirmedBalance, shouldArmDeFiGrace } =
+    resolveHomeOverviewBalanceHold({
+      isAllNetworks: !!network?.isAllNetworks,
+      hasConfirmedBalance: !!currentConfirmedBalance,
+      isTokenWorthReady: isCurrentAccountWorthReady,
+      isTokenSnapshotCommitted: isCurrentTokenSnapshotCommitted,
+      isDeFiReady: isCurrentAccountDeFiReady,
+      deFiGraceExpired,
+    });
+  useEffect(() => {
+    setDeFiGraceExpired(false);
+    if (!shouldArmDeFiGrace) {
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setDeFiGraceExpired(true);
+    }, ALL_NETWORKS_DEFI_GRACE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [currentOverviewOwnerKey, shouldArmDeFiGrace]);
 
   const lastConfirmedLatestUsd =
     canReuseLatestDisplayedBalance && lastConfirmedOverviewBalance.latest

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -282,6 +282,7 @@ function HomeOverviewContainer() {
           accountId: account.id,
           worth: {},
           initialized: false,
+          reset: true,
         });
         updateAccountDeFiOverview({
           accountId: account.id,
@@ -487,6 +488,10 @@ function HomeOverviewContainer() {
                 value: createAtNetworkValue,
                 currency: accountWorthCurrency,
                 shouldUpdateActiveAccountValue: true,
+                assetSnapshotMeta:
+                  accountWorth.assetSnapshotMetaByKey?.[
+                    createAtNetworkValueKey
+                  ],
               });
             }
           }
@@ -498,6 +503,10 @@ function HomeOverviewContainer() {
                 networkId: network.id,
               })
             ];
+          const singleNetworkValueKey = accountUtils.buildAccountValueKey({
+            accountId: account.id,
+            networkId: network.id,
+          });
           void backgroundApiProxy.serviceAccountProfile.updateAccountValueForSingleNetwork(
             {
               accountId: accountValueId,
@@ -505,6 +514,8 @@ function HomeOverviewContainer() {
               networkId: network.id,
               value: singleNetworkValue ?? '0',
               currency: accountWorthCurrency,
+              assetSnapshotMeta:
+                accountWorth.assetSnapshotMetaByKey?.[singleNetworkValueKey],
             },
           );
         }
@@ -515,6 +526,8 @@ function HomeOverviewContainer() {
             value: accountWorth.worth,
             currency: accountWorthCurrency,
             updateAll: accountWorth.updateAll,
+            assetSnapshotMetaByKey: accountWorth.assetSnapshotMetaByKey,
+            assetSnapshotMeta: accountWorth.assetSnapshotMeta,
           },
         );
       }

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
@@ -1,0 +1,69 @@
+import { resolveHomeOverviewBalanceHold } from './homeOverviewBalanceHold';
+
+/*
+yarn jest packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
+*/
+
+const base = {
+  isAllNetworks: true,
+  hasConfirmedBalance: true,
+  isTokenWorthReady: true,
+  isTokenSnapshotCommitted: true,
+  isDeFiReady: false,
+  deFiGraceExpired: false,
+};
+
+describe('resolveHomeOverviewBalanceHold', () => {
+  it('never holds outside All Networks', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, isAllNetworks: false }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: false });
+  });
+
+  it('has nothing to hold without a confirmed balance', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, hasConfirmedBalance: false }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: true });
+  });
+
+  it('holds while the token fan-out is still progressive', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({
+        ...base,
+        isTokenSnapshotCommitted: false,
+      }),
+    ).toEqual({ shouldHold: true, shouldArmDeFiGrace: false });
+  });
+
+  it('releases as soon as both token and DeFi are ready', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, isDeFiReady: true }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: false });
+  });
+
+  it('keeps holding during the DeFi grace window after the token commit', () => {
+    expect(resolveHomeOverviewBalanceHold(base)).toEqual({
+      shouldHold: true,
+      shouldArmDeFiGrace: true,
+    });
+  });
+
+  it('releases the live total when DeFi never reports within the grace window', () => {
+    // Regression for the iOS log where the cache-only DeFi hook never ran:
+    // the header stayed on a persisted total for the whole session while the
+    // token list already showed live values.
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, deFiGraceExpired: true }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: true });
+  });
+
+  it('does not let an expired grace release a still-progressive token side', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({
+        ...base,
+        isTokenSnapshotCommitted: false,
+        deFiGraceExpired: true,
+      }),
+    ).toEqual({ shouldHold: true, shouldArmDeFiGrace: false });
+  });
+});

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
@@ -1,0 +1,58 @@
+export interface IHomeOverviewBalanceHoldInput {
+  isAllNetworks: boolean;
+  /** A confirmed balance for this owner exists (persisted or from this session). */
+  hasConfirmedBalance: boolean;
+  /** Token worth for this owner has at least one network value. */
+  isTokenWorthReady: boolean;
+  /**
+   * The token side has committed a COMPLETE snapshot for this owner
+   * (`accountWorth.updateAll`): cache hydrate or an authoritative fan-out
+   * commit, as opposed to per-network progressive merges.
+   */
+  isTokenSnapshotCommitted: boolean;
+  /** `overviewDeFiDataState.isReady !== undefined` for this owner. */
+  isDeFiReady: boolean;
+  /** The DeFi grace timer armed after the token commit has elapsed. */
+  deFiGraceExpired: boolean;
+}
+
+export interface IHomeOverviewBalanceHoldPlan {
+  /** Keep showing the previously confirmed balance. */
+  shouldHold: boolean;
+  /** Arm (or keep) the DeFi grace timer for the current owner. */
+  shouldArmDeFiGrace: boolean;
+}
+
+/**
+ * Decide whether the All Networks header keeps the previously confirmed
+ * balance instead of the live, progressively merged total.
+ *
+ * The hold keeps the header from climbing network by network while a fan-out
+ * is in flight. It used to release only when BOTH token and DeFi readiness
+ * were true, and DeFi readiness is written solely inside the cache-only DeFi
+ * hook's run. When that run does not happen, the header stayed pinned to a
+ * stale persisted total for the whole session while the token list already
+ * showed live values. The hold is therefore bounded: once the token side has
+ * committed a complete snapshot, DeFi gets a short grace window and then the
+ * live total is shown with whatever DeFi value is currently known.
+ */
+export function resolveHomeOverviewBalanceHold({
+  isAllNetworks,
+  hasConfirmedBalance,
+  isTokenWorthReady,
+  isTokenSnapshotCommitted,
+  isDeFiReady,
+  deFiGraceExpired,
+}: IHomeOverviewBalanceHoldInput): IHomeOverviewBalanceHoldPlan {
+  if (!isAllNetworks) {
+    return { shouldHold: false, shouldArmDeFiGrace: false };
+  }
+  const shouldArmDeFiGrace = isTokenSnapshotCommitted && !isDeFiReady;
+  const isReleased =
+    isTokenWorthReady &&
+    (isDeFiReady || (isTokenSnapshotCommitted && deFiGraceExpired));
+  return {
+    shouldHold: hasConfirmedBalance && !isReleased,
+    shouldArmDeFiGrace,
+  };
+}

--- a/packages/shared/src/logger/scopes/account/scenes/allNetworkAccountPerf.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/allNetworkAccountPerf.ts
@@ -25,6 +25,11 @@ type IHomeTokenListRefreshTraceParams = {
   indexedAccountPresent?: boolean;
   source?: string;
   reason?: string;
+  skipReason?: string;
+  disabled?: boolean;
+  isRouteFocused?: boolean;
+  isLocked?: boolean;
+  shouldAlwaysFetch?: boolean;
 };
 
 export class AllNetworkAccountPerf extends BaseScene {

--- a/packages/shared/src/utils/assetSnapshotFreshness.test.ts
+++ b/packages/shared/src/utils/assetSnapshotFreshness.test.ts
@@ -1,0 +1,118 @@
+import {
+  canApplyAssetSnapshotMeta,
+  compareAssetSnapshotMeta,
+  createAssetSnapshotMeta,
+  getNewestAssetSnapshotMeta,
+  getServerDateMsFromHeaders,
+  isAssetSnapshotNewer,
+  isAssetSnapshotSameOrNewer,
+  normalizeAssetSnapshotMeta,
+} from './assetSnapshotFreshness';
+
+describe('assetSnapshotFreshness', () => {
+  it('reads valid Date headers from common header shapes', () => {
+    const expected = Date.parse('Tue, 01 Sep 2026 08:00:00 GMT');
+    expect(
+      getServerDateMsFromHeaders({ date: 'Tue, 01 Sep 2026 08:00:00 GMT' }),
+    ).toBe(expected);
+    expect(
+      getServerDateMsFromHeaders({
+        get: (name: string) =>
+          name === 'date' ? 'Tue, 01 Sep 2026 08:00:00 GMT' : null,
+      }),
+    ).toBe(expected);
+    expect(getServerDateMsFromHeaders({ date: 'not-a-date' })).toBeUndefined();
+  });
+
+  it('uses local sequence as a tie-breaker for equal server dates', () => {
+    const serverDateMs = Date.parse('Tue, 01 Sep 2026 08:00:00 GMT');
+    const older = { serverDateMs, localSeq: 1 };
+    const newer = { serverDateMs, localSeq: 2 };
+    expect(isAssetSnapshotNewer(newer, older)).toBe(true);
+    expect(isAssetSnapshotNewer(older, newer)).toBe(false);
+    expect(compareAssetSnapshotMeta(older, newer)).toBeLessThan(0);
+  });
+
+  it('keeps request order ahead of a later Date from a slow older response', () => {
+    const olderResponseDate = Date.parse('Tue, 01 Sep 2026 08:00:01 GMT');
+    const newerRequest = {
+      localSeq: 2,
+      serverDateMs: olderResponseDate - 1000,
+    };
+    const olderRequest = { localSeq: 1, serverDateMs: olderResponseDate };
+    expect(isAssetSnapshotNewer(newerRequest, olderRequest)).toBe(true);
+    expect(isAssetSnapshotNewer(olderRequest, newerRequest)).toBe(false);
+  });
+
+  it('uses the server Date only when request sequences are equal', () => {
+    const older = {
+      localSeq: 1,
+      serverDateMs: Date.parse('Tue, 01 Sep 2026 08:00:00 GMT'),
+    };
+    const newer = {
+      localSeq: 1,
+      serverDateMs: Date.parse('Tue, 01 Sep 2026 08:00:01 GMT'),
+    };
+    expect(isAssetSnapshotNewer(newer, older)).toBe(true);
+  });
+
+  it('falls back to the local sequence when one response has no header', () => {
+    expect(
+      isAssetSnapshotNewer(
+        { localSeq: 99 },
+        { serverDateMs: Date.now(), localSeq: 1 },
+      ),
+    ).toBe(true);
+  });
+
+  it('treats malformed metadata as unversioned', () => {
+    const malformed = { localSeq: Number.NaN };
+    const versioned = { localSeq: 10 };
+    expect(normalizeAssetSnapshotMeta(malformed)).toBeUndefined();
+    expect(compareAssetSnapshotMeta(malformed, versioned)).toBeLessThan(0);
+    expect(getNewestAssetSnapshotMeta(malformed, versioned)).toEqual(versioned);
+  });
+
+  it('lets a legacy write initialize an unversioned key but never clobber a versioned one', () => {
+    expect(canApplyAssetSnapshotMeta(undefined, undefined)).toBe(true);
+    expect(canApplyAssetSnapshotMeta(undefined, { localSeq: Number.NaN })).toBe(
+      true,
+    );
+    expect(canApplyAssetSnapshotMeta(undefined, { localSeq: 1 })).toBe(false);
+    expect(canApplyAssetSnapshotMeta({ localSeq: 2 }, { localSeq: 1 })).toBe(
+      true,
+    );
+    expect(canApplyAssetSnapshotMeta({ localSeq: 1 }, { localSeq: 2 })).toBe(
+      false,
+    );
+  });
+
+  it('recovers the mint counter after observing a persisted future sequence (clock rollback)', () => {
+    // Simulate a snapshot persisted by a previous session whose wall clock
+    // was ahead of this session's seed.
+    const futureSeq = Date.now() * 1000 + 10 ** 12;
+    const persistedFutureMeta = { localSeq: futureSeq };
+
+    // A freshly minted meta initially loses to the persisted future one …
+    const before = createAssetSnapshotMeta();
+    expect(isAssetSnapshotNewer(before, persistedFutureMeta)).toBe(false);
+
+    // … but that comparison lifts the watermark, so the next minted meta
+    // orders after the persisted snapshot and refreshes win again.
+    const after = createAssetSnapshotMeta();
+    expect(after.localSeq).toBeGreaterThan(futureSeq);
+    expect(isAssetSnapshotNewer(after, persistedFutureMeta)).toBe(true);
+  });
+
+  it('admits an equal marker as same-or-newer but never an older or missing one', () => {
+    const older = { localSeq: 1 };
+    const same = { localSeq: 2 };
+    const newer = { localSeq: 3 };
+    expect(isAssetSnapshotSameOrNewer(same, same)).toBe(true);
+    expect(isAssetSnapshotSameOrNewer(newer, same)).toBe(true);
+    expect(isAssetSnapshotSameOrNewer(older, same)).toBe(false);
+    expect(isAssetSnapshotSameOrNewer(undefined, same)).toBe(false);
+    expect(isAssetSnapshotSameOrNewer(same, undefined)).toBe(true);
+    expect(isAssetSnapshotSameOrNewer(undefined, undefined)).toBe(true);
+  });
+});

--- a/packages/shared/src/utils/assetSnapshotFreshness.ts
+++ b/packages/shared/src/utils/assetSnapshotFreshness.ts
@@ -1,0 +1,190 @@
+import type { IAssetSnapshotMeta } from '@onekeyhq/shared/types/assetSnapshot';
+
+// Seed above persisted sequences so a process restart can still order
+// header-less writes after snapshots from a previous process in normal cases.
+let nextLocalSeq = Date.now() * 1000;
+
+// The wall-clock seed is not monotonic across runtime restarts: a backward
+// clock jump (NTP correction, manual change, drifted RTC) would reseed the
+// counter BELOW sequences already persisted by a previous session, and every
+// new write would then lose the freshness comparison — silently freezing the
+// persisted snapshot. Self-heal by lifting the counter above any persisted
+// sequence observed during a comparison, so the very next minted sequence
+// orders after the stored watermark.
+function observeLocalSeqWatermark(meta: IAssetSnapshotMeta | undefined): void {
+  if (!meta) {
+    return;
+  }
+  const localSeq = Number(meta.localSeq);
+  if (Number.isFinite(localSeq) && localSeq > nextLocalSeq) {
+    nextLocalSeq = localSeq;
+  }
+}
+
+export function createAssetSnapshotMeta(options?: {
+  serverDateMs?: number;
+  localSeq?: number;
+}): IAssetSnapshotMeta {
+  const localSeq = options?.localSeq ?? (nextLocalSeq += 1);
+  if (localSeq > nextLocalSeq) {
+    nextLocalSeq = localSeq;
+  }
+  const serverDateMs = normalizeServerDateMs(options?.serverDateMs);
+  return serverDateMs === undefined ? { localSeq } : { localSeq, serverDateMs };
+}
+
+export function normalizeServerDateMs(value: unknown): number | undefined {
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return undefined;
+  }
+  const timestamp =
+    typeof value === 'number' ? value : new Date(value).getTime();
+  return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : undefined;
+}
+
+/** Extract the HTTP Date header from AxiosHeaders, Fetch Headers, or a plain map. */
+export function getServerDateMsFromHeaders(
+  headers: unknown,
+): number | undefined {
+  if (!headers || typeof headers !== 'object') {
+    return undefined;
+  }
+
+  const headerMap = headers as {
+    date?: unknown;
+    Date?: unknown;
+    get?: (name: string) => unknown;
+  };
+  let rawDate: unknown = headerMap.date ?? headerMap.Date;
+  if (rawDate === undefined && typeof headerMap.get === 'function') {
+    try {
+      rawDate = headerMap.get('date');
+    } catch {
+      rawDate = undefined;
+    }
+  }
+  if (Array.isArray(rawDate)) {
+    rawDate = rawDate[0];
+  }
+  return normalizeServerDateMs(rawDate);
+}
+
+/**
+ * Drop malformed metadata (legacy persisted records, corrupted entries) so a
+ * bogus marker is treated the same as an unversioned one.
+ */
+export function normalizeAssetSnapshotMeta(
+  meta: IAssetSnapshotMeta | undefined,
+): IAssetSnapshotMeta | undefined {
+  if (!meta) {
+    return undefined;
+  }
+  const localSeq = Number(meta.localSeq);
+  if (!Number.isFinite(localSeq)) {
+    return undefined;
+  }
+  const serverDateMs = normalizeServerDateMs(meta.serverDateMs);
+  return serverDateMs === undefined ? { localSeq } : { localSeq, serverDateMs };
+}
+
+/**
+ * Compare an incoming snapshot against the persisted snapshot for one key.
+ * A positive result means the incoming snapshot is newer. Malformed metadata
+ * is tolerated and compared as unversioned.
+ */
+export function compareAssetSnapshotMeta(
+  incoming: IAssetSnapshotMeta | undefined,
+  existing: IAssetSnapshotMeta | undefined,
+): number {
+  const next = normalizeAssetSnapshotMeta(incoming);
+  const previous = normalizeAssetSnapshotMeta(existing);
+  observeLocalSeqWatermark(next);
+  observeLocalSeqWatermark(previous);
+  if (!next && !previous) {
+    return 0;
+  }
+  if (!next) {
+    return -1;
+  }
+  if (!previous) {
+    return 1;
+  }
+
+  // The sequence is assigned before the request starts, so it captures the
+  // refresh order. It must be primary: a slow older request can finish later
+  // and therefore carry a later HTTP Date header, even though its payload is
+  // stale. The server date is retained as a cross-source tie-breaker and for
+  // diagnostics, but is not a payload version.
+  if (next.localSeq !== previous.localSeq) {
+    return next.localSeq - previous.localSeq;
+  }
+
+  const incomingServerDate = next.serverDateMs;
+  const existingServerDate = previous.serverDateMs;
+  if (
+    incomingServerDate !== undefined &&
+    existingServerDate !== undefined &&
+    incomingServerDate !== existingServerDate
+  ) {
+    return incomingServerDate - existingServerDate;
+  }
+
+  return 0;
+}
+
+export function isAssetSnapshotNewer(
+  incoming: IAssetSnapshotMeta | undefined,
+  existing: IAssetSnapshotMeta | undefined,
+): boolean {
+  return compareAssetSnapshotMeta(incoming, existing) > 0;
+}
+
+/**
+ * Admission for keys a full snapshot supplies. Progressive per-key merges may
+ * already have written the same responses, so the snapshot's markers can EQUAL
+ * the stored ones; only strictly older input is stale. Keep
+ * `isAssetSnapshotNewer` for the eviction guard of keys the snapshot omits.
+ */
+export function isAssetSnapshotSameOrNewer(
+  incoming: IAssetSnapshotMeta | undefined,
+  existing: IAssetSnapshotMeta | undefined,
+): boolean {
+  return compareAssetSnapshotMeta(incoming, existing) >= 0;
+}
+
+/**
+ * A write without metadata is legacy: it may initialize an unversioned key,
+ * but must never clobber a versioned snapshot.
+ */
+export function canApplyAssetSnapshotMeta(
+  incoming: IAssetSnapshotMeta | undefined,
+  existing: IAssetSnapshotMeta | undefined,
+): boolean {
+  if (!normalizeAssetSnapshotMeta(existing)) {
+    return true;
+  }
+  return compareAssetSnapshotMeta(incoming, existing) > 0;
+}
+
+export function sameAssetSnapshotMeta(
+  left: IAssetSnapshotMeta | undefined,
+  right: IAssetSnapshotMeta | undefined,
+): boolean {
+  return compareAssetSnapshotMeta(left, right) === 0;
+}
+
+/** Pick the newest well-formed marker; ties keep the earliest argument. */
+export function getNewestAssetSnapshotMeta(
+  ...metas: Array<IAssetSnapshotMeta | undefined>
+): IAssetSnapshotMeta | undefined {
+  let result: IAssetSnapshotMeta | undefined;
+  metas.forEach((meta) => {
+    const normalized = normalizeAssetSnapshotMeta(meta);
+    if (normalized && compareAssetSnapshotMeta(normalized, result) > 0) {
+      result = normalized;
+    }
+  });
+  return result;
+}
+
+export type { IAssetSnapshotMeta };

--- a/packages/shared/types/assetSnapshot.ts
+++ b/packages/shared/types/assetSnapshot.ts
@@ -1,0 +1,12 @@
+/**
+ * Freshness metadata attached to a persisted wallet asset snapshot.
+ *
+ * `serverDateMs` is the validated HTTP Date header observed for the response
+ * that produced the snapshot. It is a best-effort source marker, not a server
+ * data version. `localSeq` records request/refresh order and is the primary
+ * ordering key; the server marker is used only when sequences are equal.
+ */
+export interface IAssetSnapshotMeta {
+  serverDateMs?: number;
+  localSeq: number;
+}

--- a/packages/shared/types/token.ts
+++ b/packages/shared/types/token.ts
@@ -2,6 +2,8 @@ import type { ICustomTokenDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entit
 import type { IRiskTokenManagementDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityRiskTokenManagement';
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 
+import type { IAssetSnapshotMeta } from './assetSnapshot';
+
 export enum ETokenListSortType {
   Name = 'name',
   Price = 'price',
@@ -129,6 +131,8 @@ export type IFetchAccountTokensResp = {
     }
   >;
   aggregateTokenMap?: Record<string, ITokenFiat>;
+  /** Client-only metadata for ordering persistence writes. */
+  assetSnapshotMeta?: IAssetSnapshotMeta;
 };
 
 export type IFetchTokenDetailParams = {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61576](https://onekeyhq.atlassian.net/browse/OK-61576)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Commit the authoritative Home asset snapshot before running non-critical wallet asset-status analytics.
- Serialize Home all-network refresh requests across debounce and in-flight windows so explicit refreshes are not dropped.
- Introduce per-key asset snapshot freshness metadata (`localSeq` + HTTP Date marker) and apply last-writer-wins admission at every persistence/state layer, so an out-of-order stale response can no longer overwrite newer data.
- Harden the failure paths surfaced by review: restore the last-good published result when an accepted refresh fails, guard against stale debounced runners from a previous owner, and self-heal the sequence counter after a device clock rollback.

## Intent & Context
Users reported that wallet balances and prices could remain stale or inconsistent after repeated refreshes, app background/foreground transitions, and switching between mobile and desktop. The investigation showed successful token-list API responses followed by delayed or missing UI publication.

## Root Cause
1. The Home refresh path awaited a slow asset-status analytics workflow before publishing the already-built authoritative snapshot. A logged `getAllHdHwQrWallets` call took about 93 seconds, and iOS suspension amplified the delay.
2. `useAllNetworkRequests` allowed manual/event refreshes to overlap its internal debounce and in-flight queue; queued must-run intent could be lost or filtered as a redundant run while the previous result remained visible.
3. With refreshes now firing more aggressively, out-of-order responses could overwrite newer persisted data (token-list cache, account values, overview worth) with stale payloads.

## Design Decisions
- Move the non-critical analytics work after the authoritative snapshot commit and refresh-state update so UI freshness does not depend on analytics latency.
- Route Home refreshes through the existing queue and preserve explicit refresh flags, without changing the generic `usePromiseResult` behavior or unrelated consumers. The Home-only flag is named `clearRetainedResultOnAcceptedRun` to avoid confusion with `usePromiseResult`'s same-named-but-different `undefinedResultIfReRun` option.
- Mint one monotonic `localSeq` per token fetch in the background runtime (the single sequencer) and attach it to responses as `assetSnapshotMeta`. Every write layer (`SimpleDbEntityLocalTokens`, `SimpleDbEntityAccountValue`, `activeAccountValueAtom` via `ServiceAccountProfile`, `accountWorthAtom` via accountOverview actions) admits a write only when it is newer than the stored marker; unversioned legacy writes may initialize a key but never clobber versioned data.
- A full-snapshot replacement (which may delete omitted keys) requires an aggregate marker proving every enabled network was observed by the same refresh; otherwise the write degrades to a per-network merge.
- The freshness admission helpers live in `@onekeyhq/shared/src/utils/assetSnapshotFreshness` and are shared by all layers, so the comparison semantics cannot drift.
- Clock-rollback resilience: comparing against a persisted marker lifts the in-memory sequence watermark, so after a backward clock jump the very next refresh mints a newer sequence instead of being rejected indefinitely.
- Keep the OTA change limited to shared JavaScript; no persistence schema (SimpleDB fields are additive/optional), native watchdog, dependency, or unrelated refactor changes are included.

## Changes Detail
Refresh scheduling and publication:
- `packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx`: opt Home into retained-result handling, publish the authoritative snapshot before asset-status analytics, and drop the duplicate `AddDBAccountsToWallet` refresh (the hook-level wallet-scoped listener already forces one fan-out with an accounts-cache bypass; only the LP token list keeps a dedicated trigger).
- `packages/kit/src/hooks/useAllNetwork.ts`: reserve debounce windows, merge queued must-run configuration, distinguish accepted refreshes from redundant runs; restore the last-good published result when an accepted fan-out fails before publication; bail out stale runners whose closure belongs to a previous owner (they could otherwise clear the new owner's result and run a ghost fan-out).
- `packages/kit/src/hooks/allNetworkRunResultUtils.ts`: pure `resolveAllNetworkFailedRunRestore` decision + tests.

Snapshot freshness admission:
- `packages/shared/src/utils/assetSnapshotFreshness.ts` (+ `packages/shared/types/assetSnapshot.ts`): sequence minting, header parsing, tolerant comparison, shared admission helpers (`canApplyAssetSnapshotMeta`, `getNewestAssetSnapshotMeta`, …), clock-rollback watermark self-heal.
- `packages/kit-bg/src/services/ServiceToken.ts`: mint the marker before each fetch, thread it through responses and the local token cache; failed debounced cache flushes merge back and reschedule persistence.
- `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalTokens.ts` / `SimpleDbEntityAccountValue.ts`: versioned admission inside the entity mutex for token-list slices and account values (full-replace vs per-network merge).
- `packages/kit-bg/src/services/ServiceAccountProfile.ts`: mutex-serialized active-account-value atom updates with owner-aware freshness admission; the old "value can only go up" heuristic is replaced by the freshness gate (legitimate balance decreases now propagate).
- `packages/kit/src/states/jotai/contexts/accountOverview/actions.ts` / `atoms.ts`: worth-map admission with per-key and aggregate markers; create-at-network scalar recomputed from materialized absolute values.
- `packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx`: persist per-network values by compound key with their markers; filtered TokenSelector responses no longer persist as canonical network totals (`packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx`).

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension (shared Home, all-network, and persistence code paths)
- **Risk Areas**: Refresh scheduling and result publication during account/network switches, app lifecycle transitions, and concurrent manual/dependency triggers; freshness admission on the token-list cache and account-value persistence (stale writes are now rejected by design). Native runtime suspension can still delay JavaScript execution until resume.

## Test plan
- [x] `yarn jest packages/kit/src/views/Home/components/TokenListBlock packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAssetSnapshot.test.ts packages/kit-bg/src/services/ServiceAccountProfile.updateAllNetworkAccountValue.test.ts packages/kit/src/states/jotai/contexts/accountOverview/actions.test.tsx packages/shared/src/utils/assetSnapshotFreshness.test.ts packages/kit/src/hooks/allNetworkRunResultUtils.test.ts --runInBand` (12 suites, 96 tests passed)
- [x] `yarn agent:check --profile commit` (lint-worktree-ts, lint-staged, tsc-staged all passed)
- [ ] Verify repeated refresh and background/foreground recovery on iOS and desktop release builds
- [ ] Failure recovery: force `getAllNetworkAccounts` / `onStarted` to fail mid-refresh; the list must keep the last authoritative snapshot and later pull-to-refresh must still commit
- [ ] Switch accounts within 1s of a pull-to-refresh; the new account's data must not be cleared
- [ ] Clock rollback: set the device clock forward, refresh, set it back, restart; balances must keep updating
- [ ] Single-network balance decrease propagates after the removal of the "only increase" guard; OTA upgrade from a build with unversioned caches admits the first versioned write

[OK-61576]: https://onekeyhq.atlassian.net/browse/OK-61576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ