### PR TITLE
fix: keep web subscriptions active on window blur

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -147,8 +147,9 @@ const persistTabsToSimpleDbDebounced = debounce(
 // Flush the pending debounced persist before the JS runtime can be suspended
 // or the window closes. Routed through `onVisibilityStateChange` so we cover
 // all four platforms uniformly (mobile AppState, desktop Electron focus,
-// web document.hidden + window blur) — a bare RN `AppState.addEventListener`
-// is silent dead code on desktop and incomplete on web.
+// web document.hidden, extension document.hidden + window blur) — a bare RN
+// `AppState.addEventListener` is silent dead code on desktop and incomplete on
+// web and extension.
 //
 // iOS in particular may freeze the bridge in <500ms after backgrounding,
 // which would otherwise drop the last user action (open/close/reorder tab).

--- a/packages/shared/src/utils/appVisibility.test.ts
+++ b/packages/shared/src/utils/appVisibility.test.ts
@@ -1,19 +1,51 @@
+import platformEnv from '../platformEnv';
+
 import { onVisibilityStateChange } from './appVisibility';
 
 jest.mock('../platformEnv', () => ({
   __esModule: true,
   default: {
     isDesktop: false,
+    isExtension: false,
     isNative: false,
   },
 }));
 
-describe('onVisibilityStateChange on web', () => {
+const mockPlatformEnv = platformEnv as {
+  isDesktop: boolean;
+  isExtension: boolean;
+  isNative: boolean;
+};
+
+function installBrowserEventTargets() {
+  const documentTarget = new EventTarget();
+  const windowTarget = new EventTarget();
+  const testDocument = Object.assign(documentTarget, {
+    visibilityState: 'visible' as DocumentVisibilityState,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: testDocument,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: windowTarget,
+  });
+  return { documentTarget, testDocument, windowTarget };
+}
+
+describe('onVisibilityStateChange in browser runtimes', () => {
   const originalDocument = Object.getOwnPropertyDescriptor(
     globalThis,
     'document',
   );
   const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+  beforeEach(() => {
+    mockPlatformEnv.isDesktop = false;
+    mockPlatformEnv.isExtension = false;
+    mockPlatformEnv.isNative = false;
+  });
 
   afterEach(() => {
     if (originalDocument) {
@@ -29,19 +61,8 @@ describe('onVisibilityStateChange on web', () => {
   });
 
   it('ignores window focus changes and reacts to document visibility changes', () => {
-    const documentTarget = new EventTarget();
-    const windowTarget = new EventTarget();
-    const testDocument = Object.assign(documentTarget, {
-      visibilityState: 'visible' as DocumentVisibilityState,
-    });
-    Object.defineProperty(globalThis, 'document', {
-      configurable: true,
-      value: testDocument,
-    });
-    Object.defineProperty(globalThis, 'window', {
-      configurable: true,
-      value: windowTarget,
-    });
+    const { documentTarget, testDocument, windowTarget } =
+      installBrowserEventTargets();
     const listener = jest.fn();
     const unsubscribe = onVisibilityStateChange(listener);
 
@@ -60,5 +81,27 @@ describe('onVisibilityStateChange on web', () => {
     unsubscribe();
     documentTarget.dispatchEvent(new Event('visibilitychange'));
     expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves window focus changes for extension UI runtimes', () => {
+    mockPlatformEnv.isExtension = true;
+    const { documentTarget, testDocument, windowTarget } =
+      installBrowserEventTargets();
+    const listener = jest.fn();
+    const unsubscribe = onVisibilityStateChange(listener);
+
+    windowTarget.dispatchEvent(new Event('blur'));
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    windowTarget.dispatchEvent(new Event('focus'));
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    testDocument.visibilityState = 'hidden';
+    documentTarget.dispatchEvent(new Event('visibilitychange'));
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    unsubscribe();
+    windowTarget.dispatchEvent(new Event('focus'));
+    expect(listener).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/shared/src/utils/appVisibility.test.ts
+++ b/packages/shared/src/utils/appVisibility.test.ts
@@ -1,0 +1,64 @@
+import { onVisibilityStateChange } from './appVisibility';
+
+jest.mock('../platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDesktop: false,
+    isNative: false,
+  },
+}));
+
+describe('onVisibilityStateChange on web', () => {
+  const originalDocument = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'document',
+  );
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+  afterEach(() => {
+    if (originalDocument) {
+      Object.defineProperty(globalThis, 'document', originalDocument);
+    } else {
+      Reflect.deleteProperty(globalThis, 'document');
+    }
+    if (originalWindow) {
+      Object.defineProperty(globalThis, 'window', originalWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  });
+
+  it('ignores window focus changes and reacts to document visibility changes', () => {
+    const documentTarget = new EventTarget();
+    const windowTarget = new EventTarget();
+    const testDocument = Object.assign(documentTarget, {
+      visibilityState: 'visible' as DocumentVisibilityState,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: testDocument,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: windowTarget,
+    });
+    const listener = jest.fn();
+    const unsubscribe = onVisibilityStateChange(listener);
+
+    windowTarget.dispatchEvent(new Event('blur'));
+    windowTarget.dispatchEvent(new Event('focus'));
+    expect(listener).not.toHaveBeenCalled();
+
+    testDocument.visibilityState = 'hidden';
+    documentTarget.dispatchEvent(new Event('visibilitychange'));
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    testDocument.visibilityState = 'visible';
+    documentTarget.dispatchEvent(new Event('visibilitychange'));
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    unsubscribe();
+    documentTarget.dispatchEvent(new Event('visibilitychange'));
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/src/utils/appVisibility.ts
+++ b/packages/shared/src/utils/appVisibility.ts
@@ -7,7 +7,7 @@ import platformEnv from '../platformEnv';
 //   onVisibilityStateChange(cb) — subscribe to transitions
 //
 // Platform signals:
-//   Web / desktop renderer → document.visibilitychange + window focus/blur
+//   Web / desktop renderer → document.visibilitychange
 //   Desktop (Electron)     → desktopApi.onAppState (main-process focus)
 //   Mobile (RN)            → AppState 'change' event
 //   Extension service worker / unknown → defaults to visible (no signal)
@@ -80,27 +80,17 @@ export function onVisibilityStateChange(
     const handleVisibilityStateChange = () => {
       callback(document.visibilityState === 'visible');
     };
-    const windowFocus = () => callback(true);
-    const windowBlur = () => callback(false);
     document.addEventListener(
       'visibilitychange',
       handleVisibilityStateChange,
       false,
     );
-    if (typeof globalThis.window !== 'undefined') {
-      globalThis.window.addEventListener('focus', windowFocus);
-      globalThis.window.addEventListener('blur', windowBlur);
-    }
     return () => {
       document.removeEventListener(
         'visibilitychange',
         handleVisibilityStateChange,
         false,
       );
-      if (typeof globalThis.window !== 'undefined') {
-        globalThis.window.removeEventListener('focus', windowFocus);
-        globalThis.window.removeEventListener('blur', windowBlur);
-      }
     };
   }
   return () => {};

--- a/packages/shared/src/utils/appVisibility.ts
+++ b/packages/shared/src/utils/appVisibility.ts
@@ -10,6 +10,7 @@ import platformEnv from '../platformEnv';
 //   Web / desktop renderer → document.visibilitychange
 //   Desktop (Electron)     → desktopApi.onAppState (main-process focus)
 //   Mobile (RN)            → AppState 'change' event
+//   Extension UI           → document.visibilitychange + window focus/blur
 //   Extension service worker / unknown → defaults to visible (no signal)
 
 let _visible = true;
@@ -80,17 +81,27 @@ export function onVisibilityStateChange(
     const handleVisibilityStateChange = () => {
       callback(document.visibilityState === 'visible');
     };
+    const handleWindowFocus = () => callback(true);
+    const handleWindowBlur = () => callback(false);
+    const extensionWindow =
+      platformEnv.isExtension && typeof globalThis.window !== 'undefined'
+        ? globalThis.window
+        : undefined;
     document.addEventListener(
       'visibilitychange',
       handleVisibilityStateChange,
       false,
     );
+    extensionWindow?.addEventListener('focus', handleWindowFocus);
+    extensionWindow?.addEventListener('blur', handleWindowBlur);
     return () => {
       document.removeEventListener(
         'visibilitychange',
         handleVisibilityStateChange,
         false,
       );
+      extensionWindow?.removeEventListener('focus', handleWindowFocus);
+      extensionWindow?.removeEventListener('blur', handleWindowBlur);
     };
   }
   return () => {};


### PR DESCRIPTION
## Summary

- keep Web visibility unchanged when the browser window loses focus
- continue pausing visibility-aware work when document.visibilityState becomes hidden
- preserve Extension UI focus/blur notifications for popup persistence flushing
- preserve Desktop desktopApi and Native AppState behavior
- add regression coverage for Web and Extension visibility contracts

## Test plan

- yarn jest packages/shared/src/utils/appVisibility.test.ts --runInBand
- npx oxlint --tsconfig ./tsconfig.json --type-aware packages/shared/src/utils/appVisibility.ts packages/shared/src/utils/appVisibility.test.ts packages/kit/src/states/jotai/contexts/discovery/actions.ts --deny-warnings
- npx oxfmt --check packages/shared/src/utils/appVisibility.ts packages/shared/src/utils/appVisibility.test.ts packages/kit/src/states/jotai/contexts/discovery/actions.ts
- yarn agent:check --profile commit: lint, format, agent context, background API contract, and staged lint passed; local tsc-staged remains blocked by existing errors in untouched Electron, BottomTabs, updater, and native device utility files