### PR TITLE
Support Infini native asset payments

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -22085,6 +22085,7 @@
     "packages/kit/src/views/Prime/hooks/getPrimePaymentApiKey.ts": 6103,
     "packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts": 6104,
     "packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.ts": 6105,
+    "packages/kit/src/views/Prime/hooks/primeInfiniPaymentNavigation.ts": 7931,
     "packages/kit/src/views/Prime/hooks/primeInfiniPaymentReload.ts": 6106,
     "packages/kit/src/views/Prime/hooks/primeInfiniPaymentReplacement.ts": 6107,
     "packages/kit/src/views/Prime/hooks/primeInfiniPaymentRestore.ts": 6108,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
@@ -1372,6 +1372,23 @@ describe('SimpleDbEntityPrime Infini pending payment session', () => {
     ).rejects.toThrow();
   });
 
+  test('rejects a native payment whose chain conflicts with its network', async () => {
+    const { entity } = createSessionStore();
+    const nativeSession = createNativePaymentSession();
+    nativeSession.asset.chain = 'BSC';
+    nativeSession.asset.key = getPrimeInfiniPaymentAssetKey(
+      nativeSession.asset,
+    );
+    nativeSession.payment.chain = 'BSC';
+
+    await expect(
+      entity.setInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        session: nativeSession,
+      }),
+    ).rejects.toThrow();
+  });
+
   test('anchors legacy lifecycle fields before a validation refresh and never renews retention', async () => {
     const createdAt = Date.now();
     const { entity, read } = createSessionStore({

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
@@ -1284,6 +1284,94 @@ describe('SimpleDbEntityPrime Infini pending payment session', () => {
     return { entity, read: () => stored };
   }
 
+  function createNativePaymentSession() {
+    const asset = { ...session.asset, token: 'ETH', contractAddress: '' };
+    asset.key = getPrimeInfiniPaymentAssetKey(asset);
+    return {
+      ...session,
+      asset,
+      paymentCacheKey: { ...session.paymentCacheKey, contractAddress: '' },
+      payment: {
+        ...session.payment,
+        token: 'ETH',
+        amountDue: '0.01',
+        expiresAt: Date.now() + 60_000,
+      },
+    };
+  }
+
+  test('persists, restores, and claims a native payment without permitting replacement after sending', async () => {
+    const { entity } = createSessionStore();
+    const nativeSession = createNativePaymentSession();
+    const saved = await entity.setInfiniPendingPaymentSession({
+      onekeyUserId: 'user-1',
+      session: nativeSession,
+    });
+    await expect(
+      entity.getInfiniPendingPaymentSession({ onekeyUserId: 'user-1' }),
+    ).resolves.toEqual(saved);
+    await expect(
+      entity.markInfiniPendingPaymentSessionSendStarted({
+        onekeyUserId: 'user-1',
+        paymentCacheKey: saved.paymentCacheKey,
+        transferClaim: {
+          ...transferClaim,
+          contractAddress: '',
+          amount: '0.01',
+        },
+        latestPayment: nativeSession.payment,
+        purchaseStatusSnapshot,
+      }),
+    ).resolves.toMatchObject({ sendStarted: true });
+    await expect(
+      entity.discardUnsentInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        expectedPaymentCacheIdentity: saved.paymentCacheKey,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test('discards an unsent native payment and prevents a stale writer from restoring it', async () => {
+    const { entity } = createSessionStore();
+    const nativeSession = createNativePaymentSession();
+    const saved = await entity.setInfiniPendingPaymentSession({
+      onekeyUserId: 'user-1',
+      session: nativeSession,
+    });
+    await expect(
+      entity.discardUnsentInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        expectedPaymentCacheIdentity: saved.paymentCacheKey,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      entity.getInfiniPendingPaymentSession({ onekeyUserId: 'user-1' }),
+    ).resolves.toBeUndefined();
+    await expect(
+      entity.setInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        session: nativeSession,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('does not treat a token with a missing contract as a native payment', async () => {
+    const { entity } = createSessionStore();
+    const nativeSession = createNativePaymentSession();
+    nativeSession.asset.token = 'USDC';
+    nativeSession.asset.key = getPrimeInfiniPaymentAssetKey(
+      nativeSession.asset,
+    );
+    nativeSession.payment.token = 'USDC';
+
+    await expect(
+      entity.setInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        session: nativeSession,
+      }),
+    ).rejects.toThrow();
+  });
+
   test('anchors legacy lifecycle fields before a validation refresh and never renews retention', async () => {
     const createdAt = Date.now();
     const { entity, read } = createSessionStore({

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
@@ -17,6 +17,7 @@ import {
   isSamePrimeInfiniPaymentAssetIdentity,
   isSamePrimeInfiniPaymentCacheKey,
   isSamePrimeInfiniPaymentTransferSnapshot,
+  isValidPrimeInfiniPaymentContract,
   mergePrimeInfiniPaymentProgressSnapshot,
 } from '@onekeyhq/shared/src/utils/primeInfiniPaymentCacheUtils';
 import {
@@ -183,7 +184,8 @@ function isValidInfiniPaymentCacheIdentity(
     identity &&
     isNonEmptyString(identity.paymentId) &&
     isNonEmptyString(identity.networkId) &&
-    isNonEmptyString(identity.contractAddress),
+    (identity.contractAddress === '' ||
+      isNonEmptyString(identity.contractAddress)),
   );
 }
 
@@ -312,7 +314,7 @@ function isValidInfiniPendingPaymentSession(
     !isNonEmptyString(session.asset?.chain) ||
     !isNonEmptyString(session.asset?.token) ||
     !isNonEmptyString(session.asset?.networkId) ||
-    !isNonEmptyString(session.asset?.contractAddress) ||
+    !isValidPrimeInfiniPaymentContract(session.asset) ||
     !isNonEmptyString(session.payment?.paymentId) ||
     !isNonEmptyString(session.payment?.address) ||
     !isNonEmptyString(session.payment?.chain) ||
@@ -320,13 +322,7 @@ function isValidInfiniPendingPaymentSession(
     !isNonEmptyString(session.payment?.amountDue) ||
     !isNonEmptyString(session.payerAccountId) ||
     !isNonEmptyString(session.payerAddress) ||
-    !isNonEmptyString(session.paymentCacheKey?.paymentId) ||
-    !isNonEmptyString(session.paymentCacheKey?.bindingId) ||
-    !isNonEmptyString(session.paymentCacheKey?.networkId) ||
-    !isNonEmptyString(session.paymentCacheKey?.contractAddress) ||
-    !isNonEmptyString(session.paymentCacheKey?.onekeyUserId) ||
-    !isNonEmptyString(session.paymentCacheKey?.payerAccountId) ||
-    !isNonEmptyString(session.paymentCacheKey?.payerAddress) ||
+    !isValidInfiniPaymentCacheKey(session.paymentCacheKey) ||
     !Number.isFinite(session.payment?.expiresAt) ||
     !Number.isFinite(session.updatedAt) ||
     !isOptionalFiniteNumber(session.createdAt) ||

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -1430,6 +1430,40 @@ describe('ServicePrime Infini payment APIs', () => {
     expect(get).toHaveBeenCalledWith('/prime/v1/infini/payment/options');
   });
 
+  it.each([
+    { symbol: ' eth ' },
+    { symbol: 'ETH', contract: '' },
+    { symbol: 'ETH', contract: null },
+    { symbol: 'ETH', contract: ' ' },
+  ])(
+    'normalizes a native payment option with contract $contract',
+    async (token) => {
+      const { service } = createInfiniService();
+      const get = jest.fn(async () => ({
+        data: {
+          data: {
+            chains: [
+              {
+                chain: 'ETHEREUM',
+                networkId: 'evm--1',
+                tokens: [token],
+              },
+            ],
+          },
+        },
+      }));
+      service.getPrimeClient = jest.fn(async () => ({ get }));
+
+      await expect(service.apiGetInfiniPaymentOptions()).resolves.toEqual([
+        {
+          chain: 'ETHEREUM',
+          networkId: 'evm--1',
+          tokens: [{ symbol: 'ETH', contract: '' }],
+        },
+      ]);
+    },
+  );
+
   it('drops malformed payment options at the service boundary', async () => {
     const { service } = createInfiniService();
     const get = jest.fn(async () => ({
@@ -1445,6 +1479,10 @@ describe('ServicePrime Infini payment APIs', () => {
                   contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
                 },
                 { symbol: 'USDT', contract: '' },
+                { symbol: 'USDT' },
+                { symbol: 'ETH', contract: 123 },
+                { symbol: 'ETH', contract: {} },
+                { symbol: 'ETH', contract: false },
                 123,
               ],
             },

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -1464,6 +1464,26 @@ describe('ServicePrime Infini payment APIs', () => {
     },
   );
 
+  it('drops a native payment option when the chain conflicts with the network', async () => {
+    const { service } = createInfiniService();
+    const get = jest.fn(async () => ({
+      data: {
+        data: {
+          chains: [
+            {
+              chain: 'BSC',
+              networkId: 'evm--1',
+              tokens: [{ symbol: 'ETH', contract: '' }],
+            },
+          ],
+        },
+      },
+    }));
+    service.getPrimeClient = jest.fn(async () => ({ get }));
+
+    await expect(service.apiGetInfiniPaymentOptions()).resolves.toEqual([]);
+  });
+
   it('drops malformed payment options at the service boundary', async () => {
     const { service } = createInfiniService();
     const get = jest.fn(async () => ({

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -49,6 +49,7 @@ import {
   isOneKeyIdOAuthIdentityBound,
 } from '@onekeyhq/shared/src/utils/oauthProviderUtils';
 import { isLegacyOneKeyIdAccountMissingOAuthIdentity } from '@onekeyhq/shared/src/utils/oneKeyIdAccountUtils';
+import { isValidPrimeInfiniPaymentContract } from '@onekeyhq/shared/src/utils/primeInfiniPaymentCacheUtils';
 import { getPrimeInfiniPaymentSafeError } from '@onekeyhq/shared/src/utils/primeInfiniPaymentDiagnostics';
 import {
   createPrimeInfiniPaymentValidationError,
@@ -5486,6 +5487,7 @@ class ServicePrime extends ServiceBase {
       ) {
         return [];
       }
+      const networkId = option.networkId.trim();
       const tokens = option.tokens.flatMap((tokenValue) => {
         if (!tokenValue || typeof tokenValue !== 'object') {
           return [];
@@ -5494,15 +5496,27 @@ class ServicePrime extends ServiceBase {
         if (
           !isString(token.symbol) ||
           !token.symbol.trim() ||
-          !isString(token.contract) ||
-          !token.contract.trim()
+          (token.contract !== undefined &&
+            token.contract !== null &&
+            !isString(token.contract))
+        ) {
+          return [];
+        }
+        const symbol = token.symbol.trim().toUpperCase();
+        const contract = isString(token.contract) ? token.contract.trim() : '';
+        if (
+          !isValidPrimeInfiniPaymentContract({
+            networkId,
+            token: symbol,
+            contractAddress: contract,
+          })
         ) {
           return [];
         }
         return [
           {
-            symbol: token.symbol.trim().toUpperCase(),
-            contract: token.contract.trim(),
+            symbol,
+            contract,
           },
         ];
       });
@@ -5512,7 +5526,7 @@ class ServicePrime extends ServiceBase {
       return [
         {
           chain: option.chain.trim().toUpperCase(),
-          networkId: option.networkId.trim(),
+          networkId,
           tokens,
         },
       ];

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -5487,6 +5487,7 @@ class ServicePrime extends ServiceBase {
       ) {
         return [];
       }
+      const chain = option.chain.trim().toUpperCase();
       const networkId = option.networkId.trim();
       const tokens = option.tokens.flatMap((tokenValue) => {
         if (!tokenValue || typeof tokenValue !== 'object') {
@@ -5506,6 +5507,7 @@ class ServicePrime extends ServiceBase {
         const contract = isString(token.contract) ? token.contract.trim() : '';
         if (
           !isValidPrimeInfiniPaymentContract({
+            chain,
             networkId,
             token: symbol,
             contractAddress: contract,
@@ -5525,7 +5527,7 @@ class ServicePrime extends ServiceBase {
       }
       return [
         {
-          chain: option.chain.trim().toUpperCase(),
+          chain,
           networkId,
           tokens,
         },

--- a/packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts
+++ b/packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts
@@ -181,6 +181,30 @@ const decodedTx = {
   outputActions: [],
 } as unknown as IDecodedTx;
 
+function createNativePaymentFixture() {
+  return {
+    paymentCacheKey: { ...paymentCacheKey, contractAddress: '' },
+    payment: { ...latestPayment, token: 'ETH', amountDue: '0.01' },
+    decodedTx: {
+      ...decodedTx,
+      actions: decodedTx.actions.map((action) => ({
+        ...action,
+        assetTransfer: action.assetTransfer
+          ? {
+              ...action.assetTransfer,
+              sends: action.assetTransfer.sends.map((transfer) => ({
+                ...transfer,
+                tokenIdOnNetwork: '',
+                isNative: true,
+                amount: '0.01',
+              })),
+            }
+          : undefined,
+      })),
+    },
+  };
+}
+
 function buildTronEncodedTx(contractCount: number): IEncodedTxTron {
   return {
     raw_data: {
@@ -301,6 +325,135 @@ function createDeferred<T>() {
 describe('ServiceSend.signAndSendTransaction broadcastDeadline', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  test('verifies and durably claims a native ETH payment before broadcasting', async () => {
+    const { service, vault, backgroundApi } = makeService();
+    const native = createNativePaymentFixture();
+    vault.buildDecodedTx.mockResolvedValue(native.decodedTx);
+    backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot.mockResolvedValue(
+      {
+        payment: native.payment,
+        purchaseStatusSnapshot,
+      },
+    );
+
+    await expect(
+      signAndSend(service, {
+        beforeBroadcastAction: {
+          ...beforeBroadcastAction,
+          paymentCacheKey: native.paymentCacheKey,
+        },
+      }),
+    ).resolves.toMatchObject({ txid: '0xtxid' });
+    expect(
+      backgroundApi.simpleDb.prime.markInfiniPendingPaymentSessionSendStarted,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentCacheKey: native.paymentCacheKey,
+        transferClaim: expect.objectContaining({
+          contractAddress: '',
+          amount: '0.01',
+          toAddress: native.payment.address,
+        }),
+      }),
+    );
+    expect(vault.broadcastTransaction).toHaveBeenCalledTimes(1);
+    expect(
+      backgroundApi.simpleDb.prime.markInfiniPendingPaymentSessionSendStarted
+        .mock.invocationCallOrder[0],
+    ).toBeLessThan(vault.broadcastTransaction.mock.invocationCallOrder[0]);
+  });
+
+  test.each([
+    { label: 'a token transfer', changes: { isNative: false } },
+    { label: 'a missing native flag', changes: { isNative: undefined } },
+    { label: 'a nonempty contract', changes: { tokenIdOnNetwork: '0xtoken' } },
+    { label: 'a whitespace contract', changes: { tokenIdOnNetwork: ' ' } },
+    { label: 'an NFT transfer', changes: { isNFT: true } },
+  ])(
+    'rejects $label for a native invoice before claiming or broadcasting',
+    async ({ changes }) => {
+      const { service, vault, backgroundApi } = makeService();
+      const native = createNativePaymentFixture();
+      const transfer = native.decodedTx.actions[0].assetTransfer?.sends[0];
+      if (!transfer) {
+        throw new OneKeyLocalError('Missing native transfer fixture');
+      }
+      Object.assign(transfer, changes);
+      vault.buildDecodedTx.mockResolvedValue(native.decodedTx);
+      backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot.mockResolvedValue(
+        {
+          payment: native.payment,
+          purchaseStatusSnapshot,
+        },
+      );
+
+      await expect(
+        signAndSend(service, {
+          beforeBroadcastAction: {
+            ...beforeBroadcastAction,
+            paymentCacheKey: native.paymentCacheKey,
+          },
+        }),
+      ).rejects.toThrow('Infini payment transaction cannot be verified');
+      expect(
+        backgroundApi.simpleDb.prime.markInfiniPendingPaymentSessionSendStarted,
+      ).not.toHaveBeenCalled();
+      expect(vault.broadcastTransaction).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    { label: 'token symbol', changes: { token: 'USDC' } },
+    { label: 'recipient', changes: { address: '0xotherrecipient' } },
+    { label: 'amount', changes: { amountDue: '0.02' } },
+  ])(
+    'rejects a native payment with a changed $label before claiming or broadcasting',
+    async ({ changes }) => {
+      const { service, vault, backgroundApi } = makeService();
+      const native = createNativePaymentFixture();
+      vault.buildDecodedTx.mockResolvedValue(native.decodedTx);
+      backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot.mockResolvedValue(
+        {
+          payment: { ...native.payment, ...changes },
+          purchaseStatusSnapshot,
+        },
+      );
+
+      await expect(
+        signAndSend(service, {
+          beforeBroadcastAction: {
+            ...beforeBroadcastAction,
+            paymentCacheKey: native.paymentCacheKey,
+          },
+        }),
+      ).rejects.toThrow();
+      expect(
+        backgroundApi.simpleDb.prime.markInfiniPendingPaymentSessionSendStarted,
+      ).not.toHaveBeenCalled();
+      expect(vault.broadcastTransaction).not.toHaveBeenCalled();
+    },
+  );
+
+  test('does not substitute a native transfer for a token invoice', async () => {
+    const { service, vault, backgroundApi } = makeService();
+    const native = createNativePaymentFixture();
+    vault.buildDecodedTx.mockResolvedValue(native.decodedTx);
+    backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot.mockResolvedValue(
+      {
+        payment: { ...latestPayment, amountDue: native.payment.amountDue },
+        purchaseStatusSnapshot,
+      },
+    );
+
+    await expect(
+      signAndSend(service, { beforeBroadcastAction }),
+    ).rejects.toThrow('Infini payment transaction cannot be verified');
+    expect(
+      backgroundApi.simpleDb.prime.markInfiniPendingPaymentSessionSendStarted,
+    ).not.toHaveBeenCalled();
+    expect(vault.broadcastTransaction).not.toHaveBeenCalled();
   });
 
   test('keeps existing callers unchanged when deadline is omitted', async () => {

--- a/packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts
+++ b/packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts
@@ -406,6 +406,7 @@ describe('ServiceSend.signAndSendTransaction broadcastDeadline', () => {
 
   test.each([
     { label: 'token symbol', changes: { token: 'USDC' } },
+    { label: 'chain', changes: { chain: 'BSC' } },
     { label: 'recipient', changes: { address: '0xotherrecipient' } },
     { label: 'amount', changes: { amountDue: '0.02' } },
   ])(

--- a/packages/kit-bg/src/services/ServiceSend.ts
+++ b/packages/kit-bg/src/services/ServiceSend.ts
@@ -530,6 +530,7 @@ class ServiceSend extends ServiceBase {
         const transfer = action?.assetTransfer?.sends[0];
         const isExpectedTransferAsset =
           isValidPrimeInfiniPaymentContract({
+            chain: latestPayment.chain,
             networkId,
             token: latestPayment.token,
             contractAddress: paymentCacheKey.contractAddress,

--- a/packages/kit-bg/src/services/ServiceSend.ts
+++ b/packages/kit-bg/src/services/ServiceSend.ts
@@ -50,6 +50,7 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import {
   isPrimeInfiniPaymentPreBroadcastSnapshotSendable,
   isSamePrimeInfiniNetworkAddress,
+  isValidPrimeInfiniPaymentContract,
 } from '@onekeyhq/shared/src/utils/primeInfiniPaymentCacheUtils';
 import {
   createPrimeInfiniPaymentValidationError,
@@ -527,7 +528,18 @@ class ServiceSend extends ServiceBase {
         infiniPaymentExpiresAt = latestPayment.expiresAt;
         const action = decodedTx.actions[0];
         const transfer = action?.assetTransfer?.sends[0];
-        const isExpectedSingleTokenTransfer =
+        const isExpectedTransferAsset =
+          isValidPrimeInfiniPaymentContract({
+            networkId,
+            token: latestPayment.token,
+            contractAddress: paymentCacheKey.contractAddress,
+          }) &&
+          typeof transfer?.tokenIdOnNetwork === 'string' &&
+          (paymentCacheKey.contractAddress === ''
+            ? transfer.isNative === true && transfer.tokenIdOnNetwork === ''
+            : transfer.isNative !== true &&
+              Boolean(transfer.tokenIdOnNetwork.trim()));
+        const isExpectedSingleAssetTransfer =
           decodedTx.networkId === networkId &&
           decodedTx.accountId === accountId &&
           isSamePrimeInfiniNetworkAddress({
@@ -545,10 +557,9 @@ class ServiceSend extends ServiceBase {
           Boolean(transfer) &&
           Boolean(transfer?.from.trim()) &&
           Boolean(transfer?.to.trim()) &&
-          Boolean(transfer?.tokenIdOnNetwork.trim()) &&
+          isExpectedTransferAsset &&
           new BigNumber(transfer?.amount ?? '').isFinite() &&
           new BigNumber(transfer?.amount ?? '').gt(0) &&
-          transfer?.isNative !== true &&
           transfer?.isNFT !== true &&
           (!transfer?.networkId || transfer.networkId === networkId) &&
           isSamePrimeInfiniNetworkAddress({
@@ -561,7 +572,7 @@ class ServiceSend extends ServiceBase {
             first: action.assetTransfer?.to ?? '',
             second: transfer?.to ?? '',
           });
-        if (!isExpectedSingleTokenTransfer || !transfer) {
+        if (!isExpectedSingleAssetTransfer || !transfer) {
           throw new OneKeyLocalError({
             message: 'Infini payment transaction cannot be verified',
             autoToast: false,

--- a/packages/kit/src/components/TokenSelectorFilter/utils.test.ts
+++ b/packages/kit/src/components/TokenSelectorFilter/utils.test.ts
@@ -103,6 +103,31 @@ describe('fetchSpecifiedTokenSelectorTokens', () => {
     jest.clearAllMocks();
   });
 
+  it('requests native coin balances alongside token balances without dropping the empty contract', async () => {
+    const response = buildTokenResponse('evm--1');
+    mocks.fetchAccountTokens.mockResolvedValue(response);
+
+    const result = await fetchSpecifiedTokenSelectorTokens({
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      targets: [
+        { networkId: 'evm--1', contractAddress: '' },
+        { networkId: 'evm--1', contractAddress: '0xusdc' },
+        { networkId: 'evm--1', contractAddress: '' },
+      ],
+    });
+
+    expect(mocks.fetchAccountTokens).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchAccountTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkId: 'evm--1',
+        contractList: ['', '0xusdc'],
+      }),
+    );
+    expect(result.responsesByNetworkId['evm--1']).toBe(response);
+    expect(result.issues).toEqual([]);
+  });
+
   it('uses the same token-selector account-token request as Send', async () => {
     mocks.fetchAccountTokens.mockResolvedValue(buildTokenResponse('evm--1'));
 

--- a/packages/kit/src/views/Prime/components/PrimeInfiniPaymentWarnings.test.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeInfiniPaymentWarnings.test.tsx
@@ -1,5 +1,5 @@
 /* cspell:ignore Infini */
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createIntl } from 'react-intl';
@@ -17,14 +17,23 @@ const mockShow = jest.fn<
   ]
 >();
 
-jest.mock('@onekeyhq/components', () => ({
-  Dialog: {
-    show: (...args: Parameters<typeof mockShow>) => mockShow(...args),
-    ScrollView: 'div',
-  },
-  SizableText: 'span',
-  YStack: 'div',
-}));
+jest.mock('@onekeyhq/components', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  function UnOrderedList({ children }: { children?: ReactNode }) {
+    return React.createElement('ul', null, children);
+  }
+  UnOrderedList.Item = ({ children }: { children?: ReactNode }) =>
+    React.createElement('li', null, children);
+
+  return {
+    Dialog: {
+      show: (...args: Parameters<typeof mockShow>) => mockShow(...args),
+      ScrollView: 'div',
+    },
+    UnOrderedList,
+  };
+});
 
 const messages: Record<string, string> = {
   'global.warning': 'Warning',

--- a/packages/kit/src/views/Prime/components/PrimeInfiniPaymentWarnings.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeInfiniPaymentWarnings.tsx
@@ -1,5 +1,5 @@
 /* cspell:ignore Infini */
-import { Dialog, SizableText, YStack } from '@onekeyhq/components';
+import { Dialog, UnOrderedList } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import type { IntlShape } from 'react-intl';
@@ -16,13 +16,13 @@ export function showPrimeInfiniPaymentWarnings(
       tone: 'warning',
       renderContent: (
         <Dialog.ScrollView maxHeight={360}>
-          <YStack gap="$3">
+          <UnOrderedList>
             {warningMessages.map((message, index) => (
-              <SizableText key={index} size="$bodyMd">
+              <UnOrderedList.Item key={index} titleSize="$bodyMd">
                 {message}
-              </SizableText>
+              </UnOrderedList.Item>
             ))}
-          </YStack>
+          </UnOrderedList>
         </Dialog.ScrollView>
       ),
       showCancelButton: true,

--- a/packages/kit/src/views/Prime/components/PrimeInfiniWalletPayment.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeInfiniWalletPayment.tsx
@@ -34,6 +34,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { useAccountSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickStack';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import { TokenListItem } from '@onekeyhq/kit/src/components/TokenListItem';
 import { useSpecifiedTokenSelectorBalances } from '@onekeyhq/kit/src/components/TokenSelectorFilter';
@@ -44,6 +45,7 @@ import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector/actions';
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector/atoms';
 import {
+  useDevSettingsPersistAtom,
   usePrimePersistAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -175,6 +177,11 @@ const PRIME_PAYMENT_MODAL_CLOSE_DELAY_MS = 300;
 const PRIME_PAYMENT_BUTTON_NUMERIC_STYLE = getFontVariantStyle([
   'tabular-nums',
 ]);
+const PRIME_INFINI_MOCK_WARNING_MESSAGES = [
+  'Mock warning: verify that the selected network and token match the invoice before paying.',
+  'Mock warning: keep enough native tokens to cover network fees. Fees are not included in the subscription price.',
+  'Mock warning: this is a real payment flow. Continuing will open the normal transaction confirmation or external checkout.',
+];
 
 function getPrimeInfiniPaymentLogContext({
   payment,
@@ -862,6 +869,8 @@ function PrimeInfiniWalletPaymentContent({
   paymentContextErrorTitle,
   isPaymentContextRetrying,
   onRetryPaymentContext,
+  fallbackWarningMessages,
+  onEnableMockPaymentWarnings,
 }: {
   plan: IPrimeInfiniSubscriptionPlan;
   selectedSubscriptionPeriod: ISubscriptionPeriod;
@@ -895,6 +904,8 @@ function PrimeInfiniWalletPaymentContent({
   paymentContextErrorTitle?: string;
   isPaymentContextRetrying: boolean;
   onRetryPaymentContext: () => Promise<void>;
+  fallbackWarningMessages?: readonly string[];
+  onEnableMockPaymentWarnings: () => void;
 }) {
   const flowContextRef = useRef(useContext(PrimeInfiniPaymentFlowContext));
   const intl = useIntl();
@@ -1626,6 +1637,7 @@ function PrimeInfiniWalletPaymentContent({
   const displaySelectionIdentityRef = useRef(displaySelectionIdentity);
   displaySelectionIdentityRef.current = displaySelectionIdentity;
   const isPaymentButtonPreparing = shouldShowPrimeInfiniPaymentButtonSkeleton({
+    hasPaymentAccount: Boolean(isOwnAccount && accountAddress),
     hasCurrentPayment: Boolean(displayPayment),
     isOptionsRefreshing,
     isBalanceLoading,
@@ -3034,6 +3046,7 @@ function PrimeInfiniWalletPaymentContent({
       if (
         !(await confirmPrimeInfiniPaymentWarnings({
           payment: currentPayment,
+          fallbackWarningMessages,
           confirmWarnings: (messages) =>
             showPrimeInfiniPaymentWarnings(messages, intl),
           shouldContinue: isAttemptCurrent,
@@ -3411,6 +3424,7 @@ function PrimeInfiniWalletPaymentContent({
     balanceDetail,
     baseline.onekeyUserId,
     canContinue,
+    fallbackWarningMessages,
     featureName,
     intl,
     onExitPreventedChange,
@@ -3669,7 +3683,13 @@ function PrimeInfiniWalletPaymentContent({
           featureName,
           beforeCheckout: async () => {
             if (!currentPayment) {
-              return isAttemptOwned();
+              return confirmPrimeInfiniPaymentWarnings({
+                payment: {},
+                fallbackWarningMessages,
+                confirmWarnings: (messages) =>
+                  showPrimeInfiniPaymentWarnings(messages, intl),
+                shouldContinue: isAttemptOwned,
+              });
             }
             const result = await resolvePrimeInfiniPaymentReplacement({
               currentPayment,
@@ -3680,6 +3700,7 @@ function PrimeInfiniWalletPaymentContent({
               confirmLatestPayment: (latestPayment) =>
                 confirmPrimeInfiniPaymentWarnings({
                   payment: latestPayment,
+                  fallbackWarningMessages,
                   confirmWarnings: (messages) =>
                     showPrimeInfiniPaymentWarnings(messages, intl),
                   shouldContinue: isAttemptOwned,
@@ -3825,6 +3846,7 @@ function PrimeInfiniWalletPaymentContent({
       discardPaymentSessionForSelectionChange,
       captureTerminalPaymentSessionRevision,
       discardTerminalPaymentSessionForSelectionChange,
+      fallbackWarningMessages,
       featureName,
       intl,
       onClose,
@@ -4088,11 +4110,18 @@ function PrimeInfiniWalletPaymentContent({
                 : ETranslations.prime_crypto_monthly_plan__title,
           })}`}
         </SizableText>
-        <SizableText size="$bodySm" color="$textSubdued" maxWidth={720}>
-          {intl.formatMessage({
-            id: ETranslations.prime_crypto_manual_renewal__desc,
-          })}
-        </SizableText>
+        <MultipleClickStack
+          testID="prime-infini-payment-mock-warnings"
+          devSettingsOnly
+          maxWidth={720}
+          onPress={onEnableMockPaymentWarnings}
+        >
+          <SizableText size="$bodySm" color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.prime_crypto_manual_renewal__desc,
+            })}
+          </SizableText>
+        </MultipleClickStack>
       </YStack>
       <YStack gap="$2">
         <SizableText size="$bodyMdMedium">
@@ -4208,7 +4237,27 @@ function PrimeInfiniWalletPaymentRoot({
 }) {
   const flowContextRef = useRef(useContext(PrimeInfiniPaymentFlowContext));
   const intl = useIntl();
+  const [devSettings] = useDevSettingsPersistAtom();
   const [primeUserInfo] = usePrimePersistAtom();
+  // Keep the fallback enabled across content remounts during invoice reloads.
+  const [isMockPaymentWarningsEnabled, setIsMockPaymentWarningsEnabled] =
+    useState(false);
+  const fallbackWarningMessages =
+    devSettings.enabled && isMockPaymentWarningsEnabled
+      ? PRIME_INFINI_MOCK_WARNING_MESSAGES
+      : undefined;
+  const handleEnableMockPaymentWarnings = useCallback(() => {
+    if (!devSettings.enabled || isMockPaymentWarningsEnabled) {
+      return;
+    }
+    setIsMockPaymentWarningsEnabled(true);
+    Toast.success({ title: 'Mock payment warning fallback enabled' });
+  }, [devSettings.enabled, isMockPaymentWarningsEnabled]);
+  useEffect(() => {
+    if (!devSettings.enabled) {
+      setIsMockPaymentWarningsEnabled(false);
+    }
+  }, [devSettings.enabled]);
   const [selectedAssetKey, setSelectedAssetKey] = useState('');
   const [discardedPaymentBindingIds, setDiscardedPaymentBindingIds] = useState<
     ReadonlySet<string>
@@ -5279,6 +5328,8 @@ function PrimeInfiniWalletPaymentRoot({
         paymentContextErrorTitle={paymentContextErrorTitle}
         isPaymentContextRetrying={Boolean(isLoading)}
         onRetryPaymentContext={handleRetryPaymentContext}
+        fallbackWarningMessages={fallbackWarningMessages}
+        onEnableMockPaymentWarnings={handleEnableMockPaymentWarnings}
         shouldCreatePayment={
           !paymentContextErrorTitle &&
           (result.shouldCreatePayment || paymentCreationIntentRef.current)

--- a/packages/kit/src/views/Prime/components/PrimeInfiniWalletPayment.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeInfiniWalletPayment.tsx
@@ -26,7 +26,10 @@ import {
   Toast,
   XStack,
   YStack,
+  closeAllDialogInstances,
   getFontVariantStyle,
+  popToMainRoute,
+  resetToRoute,
   usePreventRemove,
 } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components';
@@ -60,6 +63,9 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EAssetSelectorRoutes,
   EModalRoutes,
+  EOnboardingPagesV2,
+  EOnboardingV2Routes,
+  ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
 import { EPrimeFeatures } from '@onekeyhq/shared/src/routes/prime';
 import type {
@@ -98,12 +104,14 @@ import type { IFetchTokenDetailItem } from '@onekeyhq/shared/types/token';
 
 import {
   isPrimeInfiniPaymentAccountSyncReady,
+  resolvePrimeInfiniAccountSelectionPress,
   resolvePrimeInfiniPaymentAsset,
   resolvePrimeInfiniPaymentDisplaySnapshot,
   resolvePrimeInfiniPaymentPinnedAssetKey,
   shouldShowPrimeInfiniExternalCheckoutLink,
   shouldShowPrimeInfiniPaymentButtonSkeleton,
 } from '../hooks/primeInfiniPaymentDisplaySnapshot';
+import { closePrimeInfiniPaymentOverlaysAndNavigate } from '../hooks/primeInfiniPaymentNavigation';
 import {
   type IPrimeInfiniPaymentReloadRequest,
   resolvePrimeInfiniPaymentReloadCommit,
@@ -1020,6 +1028,7 @@ function PrimeInfiniWalletPaymentContent({
   const accountSyncGenerationRef = useRef(0);
   const accountSelectorOpenRef = useRef(false);
   const accountSelectorInitialIdentityRef = useRef('');
+  const onboardingNavigationInFlightRef = useRef(false);
   const replacementTargetAssetKeyRef = useRef('');
   const balanceErrorToastSelectionRef = useRef('');
   const replacementSourceAssetRef = useRef<
@@ -2387,8 +2396,35 @@ function PrimeInfiniWalletPaymentContent({
     }
   }, [canChangeAccountSelection]);
 
-  const handleShowAccountSelector = useCallback(() => {
-    if (!canChangeAccountSelection) {
+  const handleShowAccountSelector = useCallback(async () => {
+    const action = resolvePrimeInfiniAccountSelectionPress({
+      canChangeAccountSelection,
+      hasWallet: Boolean(activeAccount.wallet),
+    });
+    if (action === 'disabled') {
+      return;
+    }
+    if (action === 'onboarding') {
+      if (onboardingNavigationInFlightRef.current) {
+        return;
+      }
+      onboardingNavigationInFlightRef.current = true;
+      try {
+        await closePrimeInfiniPaymentOverlaysAndNavigate({
+          closeDialogs: closeAllDialogInstances,
+          closeModals: popToMainRoute,
+          navigate: () => {
+            resetToRoute(ERootRoutes.Onboarding, {
+              screen: EOnboardingV2Routes.OnboardingV2,
+              params: {
+                screen: EOnboardingPagesV2.GetStarted,
+              },
+            });
+          },
+        });
+      } finally {
+        onboardingNavigationInFlightRef.current = false;
+      }
       return;
     }
     accountSelectorOpenRef.current = true;
@@ -2397,7 +2433,12 @@ function PrimeInfiniWalletPaymentContent({
         actions.current.getSelectedAccount({ num: 0 }),
       );
     showAccountSelector();
-  }, [actions, canChangeAccountSelection, showAccountSelector]);
+  }, [
+    actions,
+    activeAccount.wallet,
+    canChangeAccountSelection,
+    showAccountSelector,
+  ]);
 
   const preparePaymentForSelection = useCallback(async () => {
     const expectedOneKeyUserId = baseline.onekeyUserId;

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.test.ts
@@ -2,6 +2,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 import {
   isPrimeInfiniPaymentAccountSyncReady,
+  resolvePrimeInfiniAccountSelectionPress,
   resolvePrimeInfiniPaymentAsset,
   resolvePrimeInfiniPaymentDisplaySnapshot,
   resolvePrimeInfiniPaymentPinnedAssetKey,
@@ -110,6 +111,35 @@ describe('isPrimeInfiniPaymentAccountSyncReady', () => {
         selectedNetworkId: 'evm--56',
       }),
     ).toBe(true);
+  });
+});
+
+describe('resolvePrimeInfiniAccountSelectionPress', () => {
+  it('opens onboarding when account sync has established that no wallet exists', () => {
+    expect(
+      resolvePrimeInfiniAccountSelectionPress({
+        canChangeAccountSelection: true,
+        hasWallet: false,
+      }),
+    ).toBe('onboarding');
+  });
+
+  it('keeps the account selector for an existing wallet', () => {
+    expect(
+      resolvePrimeInfiniAccountSelectionPress({
+        canChangeAccountSelection: true,
+        hasWallet: true,
+      }),
+    ).toBe('accountSelector');
+  });
+
+  it('does nothing while account selection is locked', () => {
+    expect(
+      resolvePrimeInfiniAccountSelectionPress({
+        canChangeAccountSelection: false,
+        hasWallet: false,
+      }),
+    ).toBe('disabled');
   });
 });
 

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.test.ts
@@ -1,3 +1,5 @@
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
 import {
   isPrimeInfiniPaymentAccountSyncReady,
   resolvePrimeInfiniPaymentAsset,
@@ -209,9 +211,76 @@ describe('resolvePrimeInfiniPaymentDisplaySnapshot', () => {
 });
 
 describe('shouldShowPrimeInfiniPaymentButtonSkeleton', () => {
+  it.each([
+    { scenario: 'an empty wallet list', accountId: undefined },
+    { scenario: 'a watch-only account', accountId: 'watching--0--account' },
+    { scenario: 'an external account', accountId: 'external--0--account' },
+  ])('stops loading after account sync for $scenario', ({ accountId }) => {
+    const preparationState = {
+      hasPaymentAccount: Boolean(
+        accountId && accountUtils.isOwnAccount({ accountId }),
+      ),
+      hasCurrentPayment: false,
+      isOptionsRefreshing: false,
+      isBalanceLoading: false,
+      accountSyncReady: true,
+      accountSyncFailed: false,
+    };
+
+    expect(shouldShowPrimeInfiniPaymentButtonSkeleton(preparationState)).toBe(
+      false,
+    );
+    expect(
+      shouldShowPrimeInfiniExternalCheckoutLink({
+        canUseExternalCheckout: true,
+        isOptionsRefreshing: preparationState.isOptionsRefreshing,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps loading until account sync can determine whether an account is available', () => {
+    expect(
+      shouldShowPrimeInfiniPaymentButtonSkeleton({
+        hasPaymentAccount: false,
+        hasCurrentPayment: false,
+        isOptionsRefreshing: false,
+        isBalanceLoading: false,
+        accountSyncReady: false,
+        accountSyncFailed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps loading while payment options refresh without an account', () => {
+    expect(
+      shouldShowPrimeInfiniPaymentButtonSkeleton({
+        hasPaymentAccount: false,
+        hasCurrentPayment: false,
+        isOptionsRefreshing: true,
+        isBalanceLoading: false,
+        accountSyncReady: true,
+        accountSyncFailed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps loading while a supported account waits for its quote', () => {
+    expect(
+      shouldShowPrimeInfiniPaymentButtonSkeleton({
+        hasPaymentAccount: true,
+        hasCurrentPayment: false,
+        isOptionsRefreshing: false,
+        isBalanceLoading: false,
+        accountSyncReady: true,
+        accountSyncFailed: false,
+      }),
+    ).toBe(true);
+  });
+
   it('keeps the full button skeleton while local prerequisites are loading', () => {
     expect(
       shouldShowPrimeInfiniPaymentButtonSkeleton({
+        hasPaymentAccount: true,
         hasCurrentPayment: true,
         isOptionsRefreshing: false,
         isBalanceLoading: true,
@@ -221,6 +290,7 @@ describe('shouldShowPrimeInfiniPaymentButtonSkeleton', () => {
     ).toBe(true);
     expect(
       shouldShowPrimeInfiniPaymentButtonSkeleton({
+        hasPaymentAccount: true,
         hasCurrentPayment: true,
         isOptionsRefreshing: false,
         isBalanceLoading: false,
@@ -230,21 +300,26 @@ describe('shouldShowPrimeInfiniPaymentButtonSkeleton', () => {
     ).toBe(true);
   });
 
-  it('shows the real disabled button for a terminal local-data failure', () => {
-    expect(
-      shouldShowPrimeInfiniPaymentButtonSkeleton({
-        hasCurrentPayment: true,
-        isOptionsRefreshing: false,
-        isBalanceLoading: false,
-        accountSyncReady: false,
-        accountSyncFailed: true,
-      }),
-    ).toBe(false);
-  });
+  it.each([false, true])(
+    'shows the real disabled button after account sync fails, with payment: %s',
+    (hasCurrentPayment) => {
+      expect(
+        shouldShowPrimeInfiniPaymentButtonSkeleton({
+          hasPaymentAccount: true,
+          hasCurrentPayment,
+          isOptionsRefreshing: false,
+          isBalanceLoading: false,
+          accountSyncReady: false,
+          accountSyncFailed: true,
+        }),
+      ).toBe(false);
+    },
+  );
 
   it('shows the real button after the quote and local prerequisites are ready', () => {
     expect(
       shouldShowPrimeInfiniPaymentButtonSkeleton({
+        hasPaymentAccount: true,
         hasCurrentPayment: true,
         isOptionsRefreshing: false,
         isBalanceLoading: false,
@@ -258,15 +333,16 @@ describe('shouldShowPrimeInfiniPaymentButtonSkeleton', () => {
 describe('shouldShowPrimeInfiniExternalCheckoutLink', () => {
   it('shows the link without a compatible wallet account or payment quote', () => {
     const preparationState = {
+      hasPaymentAccount: false,
       hasCurrentPayment: false,
       isOptionsRefreshing: false,
       isBalanceLoading: false,
-      accountSyncReady: false,
+      accountSyncReady: true,
       accountSyncFailed: false,
     };
 
     expect(shouldShowPrimeInfiniPaymentButtonSkeleton(preparationState)).toBe(
-      true,
+      false,
     );
     expect(
       shouldShowPrimeInfiniExternalCheckoutLink({
@@ -278,6 +354,7 @@ describe('shouldShowPrimeInfiniExternalCheckoutLink', () => {
 
   it('shows the link while the wallet balance is loading', () => {
     const preparationState = {
+      hasPaymentAccount: true,
       hasCurrentPayment: true,
       isOptionsRefreshing: false,
       isBalanceLoading: true,

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.ts
@@ -46,6 +46,19 @@ export function isPrimeInfiniPaymentAccountSyncReady({
   );
 }
 
+export function resolvePrimeInfiniAccountSelectionPress({
+  canChangeAccountSelection,
+  hasWallet,
+}: {
+  canChangeAccountSelection: boolean;
+  hasWallet: boolean;
+}): 'disabled' | 'onboarding' | 'accountSelector' {
+  if (!canChangeAccountSelection) {
+    return 'disabled';
+  }
+  return hasWallet ? 'accountSelector' : 'onboarding';
+}
+
 export function resolvePrimeInfiniPaymentDisplaySnapshot<
   TSelectionSnapshot,
   TPayment,

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentDisplaySnapshot.ts
@@ -72,12 +72,14 @@ export function resolvePrimeInfiniPaymentDisplaySnapshot<
 }
 
 export function shouldShowPrimeInfiniPaymentButtonSkeleton({
+  hasPaymentAccount,
   hasCurrentPayment,
   isOptionsRefreshing,
   isBalanceLoading,
   accountSyncReady,
   accountSyncFailed,
 }: {
+  hasPaymentAccount: boolean;
   hasCurrentPayment: boolean;
   isOptionsRefreshing: boolean;
   isBalanceLoading: boolean;
@@ -85,10 +87,11 @@ export function shouldShowPrimeInfiniPaymentButtonSkeleton({
   accountSyncFailed: boolean;
 }) {
   return (
-    !hasCurrentPayment ||
     isOptionsRefreshing ||
-    isBalanceLoading ||
-    (!accountSyncReady && !accountSyncFailed)
+    (!accountSyncReady && !accountSyncFailed) ||
+    (hasPaymentAccount &&
+      !accountSyncFailed &&
+      (!hasCurrentPayment || isBalanceLoading))
   );
 }
 

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentNavigation.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentNavigation.test.ts
@@ -1,0 +1,22 @@
+/* cspell:ignore Infini */
+import { closePrimeInfiniPaymentOverlaysAndNavigate } from './primeInfiniPaymentNavigation';
+
+describe('closePrimeInfiniPaymentOverlaysAndNavigate', () => {
+  it('closes dialogs and modals before navigating to onboarding', async () => {
+    const steps: string[] = [];
+
+    await closePrimeInfiniPaymentOverlaysAndNavigate({
+      closeDialogs: async () => {
+        steps.push('dialogs');
+      },
+      closeModals: async () => {
+        steps.push('modals');
+      },
+      navigate: () => {
+        steps.push('navigate');
+      },
+    });
+
+    expect(steps).toEqual(['dialogs', 'modals', 'navigate']);
+  });
+});

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentNavigation.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentNavigation.ts
@@ -1,0 +1,14 @@
+/* cspell:ignore Infini */
+export async function closePrimeInfiniPaymentOverlaysAndNavigate({
+  closeDialogs,
+  closeModals,
+  navigate,
+}: {
+  closeDialogs: () => Promise<void>;
+  closeModals: () => Promise<void>;
+  navigate: () => void;
+}) {
+  await closeDialogs();
+  await closeModals();
+  navigate();
+}

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.test.ts
@@ -51,6 +51,92 @@ const statusOnlyInfiniSubscription = {
 };
 
 describe('primeInfiniPaymentUtils', () => {
+  it.each([
+    { chain: 'ETHEREUM', networkId: networkIdsMap.eth, token: 'ETH' },
+    { chain: 'BASE', networkId: networkIdsMap.base, token: 'ETH' },
+    { chain: 'BSC', networkId: networkIdsMap.bsc, token: 'BNB' },
+    { chain: 'SOLANA', networkId: networkIdsMap.sol, token: 'SOL' },
+    { chain: 'TRON', networkId: networkIdsMap.trx, token: 'TRX' },
+  ])(
+    'keeps the native $token payment asset on $chain',
+    ({ chain, networkId, token }) => {
+      const asset = {
+        chain,
+        networkId,
+        token,
+        contractAddress: '',
+      };
+      const canonicalAsset = {
+        ...asset,
+        key: getPrimeInfiniPaymentAssetKey(asset),
+      };
+
+      expect(
+        getPrimeInfiniPaymentAssets([
+          { chain, networkId, tokens: [{ symbol: token, contract: '' }] },
+        ]),
+      ).toEqual([canonicalAsset]);
+      expect(getCanonicalPrimeInfiniPaymentAsset(canonicalAsset)).toEqual(
+        canonicalAsset,
+      );
+    },
+  );
+
+  it.each([
+    { chain: 'ETHEREUM', networkId: networkIdsMap.eth, token: 'USDC' },
+    { chain: 'BSC', networkId: networkIdsMap.bsc, token: 'ETH' },
+    { chain: 'UNKNOWN', networkId: 'unknown--1', token: 'ETH' },
+    { chain: 'ALL', networkId: networkIdsMap.onekeyall, token: 'ALL NETWORKS' },
+  ])(
+    'rejects an empty contract for a non-native $token asset on $chain',
+    ({ chain, networkId, token }) => {
+      expect(
+        getPrimeInfiniPaymentAssets([
+          { chain, networkId, tokens: [{ symbol: token, contract: '' }] },
+        ]),
+      ).toEqual([]);
+    },
+  );
+
+  it('builds a native ETH transfer without substituting a token contract', () => {
+    const asset = {
+      key: 'ethereum-eth',
+      chain: 'ETHEREUM',
+      token: 'ETH',
+      networkId: networkIdsMap.eth,
+      contractAddress: '',
+    };
+    const nativePayment = { ...payment, token: 'ETH', amountDue: '0.01' };
+    const { transferInfo, transferPayload } =
+      buildPrimeInfiniPaymentTransferIntent({
+        accountId: 'hd-1--0',
+        accountAddress: '0xpayer',
+        asset,
+        payment: nativePayment,
+        tokenInfo: {
+          decimals: 18,
+          name: 'Ethereum',
+          symbol: 'ETH',
+          address: '',
+          isNative: true,
+        },
+      });
+
+    expect(transferInfo).toMatchObject({
+      from: '0xpayer',
+      to: nativePayment.address,
+      amount: '0.01',
+      tokenInfo: { address: '', isNative: true, decimals: 18, symbol: 'ETH' },
+    });
+    expect(transferPayload).toMatchObject({
+      amountToSend: '0.01',
+      isMaxSend: false,
+      isNFT: false,
+      originalRecipient: nativePayment.address,
+    });
+    expect(transferPayload.tokenInfo).toBe(transferInfo.tokenInfo);
+  });
+
   it('builds an explicit non-EVM transfer intent from the displayed payment', () => {
     const asset = {
       key: 'tron-usdt',

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.test.ts
@@ -85,10 +85,11 @@ describe('primeInfiniPaymentUtils', () => {
   it.each([
     { chain: 'ETHEREUM', networkId: networkIdsMap.eth, token: 'USDC' },
     { chain: 'BSC', networkId: networkIdsMap.bsc, token: 'ETH' },
+    { chain: 'BSC', networkId: networkIdsMap.eth, token: 'ETH' },
     { chain: 'UNKNOWN', networkId: 'unknown--1', token: 'ETH' },
     { chain: 'ALL', networkId: networkIdsMap.onekeyall, token: 'ALL NETWORKS' },
   ])(
-    'rejects an empty contract for a non-native $token asset on $chain',
+    'rejects invalid empty-contract $token metadata on $chain ($networkId)',
     ({ chain, networkId, token }) => {
       expect(
         getPrimeInfiniPaymentAssets([

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.ts
@@ -17,6 +17,7 @@ import {
   isPrimeInfiniPurchaseCompletedSnapshot,
   isSamePrimeInfiniPaymentAssetIdentity,
   isSamePrimeInfiniPaymentTransferSnapshot,
+  isValidPrimeInfiniPaymentContract,
 } from '@onekeyhq/shared/src/utils/primeInfiniPaymentCacheUtils';
 import type {
   IPrimeInfiniPayment,
@@ -94,7 +95,11 @@ function buildPrimeInfiniPaymentAsset({
     !normalizedChain ||
     !normalizedToken ||
     !normalizedNetworkId ||
-    !normalizedContractAddress ||
+    !isValidPrimeInfiniPaymentContract({
+      networkId: normalizedNetworkId,
+      token: normalizedToken,
+      contractAddress: normalizedContractAddress,
+    }) ||
     !Object.prototype.hasOwnProperty.call(
       getListedNetworkMap(),
       normalizedNetworkId,

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.ts
@@ -96,6 +96,7 @@ function buildPrimeInfiniPaymentAsset({
     !normalizedToken ||
     !normalizedNetworkId ||
     !isValidPrimeInfiniPaymentContract({
+      chain: normalizedChain,
       networkId: normalizedNetworkId,
       token: normalizedToken,
       contractAddress: normalizedContractAddress,

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentWarnings.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentWarnings.test.ts
@@ -15,11 +15,12 @@ const payment: IPrimeInfiniPayment = {
   amountDue: '29.99',
   expiresAt: 1_800_000_000_000,
 };
+const fallbackWarningMessages = ['First mock warning', 'Second mock warning'];
 
 describe('latest Infini payment warnings', () => {
-  test.each([undefined, []])(
-    'does not interrupt a payment with warnings=%p',
-    async (warningMessages) => {
+  test.each([{ warningMessages: undefined }, { warningMessages: [] }])(
+    'does not interrupt a payment with warnings=$warningMessages',
+    async ({ warningMessages }) => {
       const confirmWarnings = jest.fn(async () => true);
       await expect(
         confirmPrimeInfiniPaymentWarnings({
@@ -55,19 +56,79 @@ describe('latest Infini payment warnings', () => {
     },
   );
 
-  test('does not continue a flow that became stale while the warning was open', async () => {
-    let isCurrent = true;
+  test('uses server warnings instead of the enabled fallback', async () => {
+    const warningMessages = ['First API warning', 'Second API warning'];
+    const confirmWarnings = jest.fn(async () => true);
     await expect(
       confirmPrimeInfiniPaymentWarnings({
-        payment: { ...payment, warningMessages: ['Warning'] },
-        confirmWarnings: async () => {
-          isCurrent = false;
-          return true;
-        },
-        shouldContinue: () => isCurrent,
+        payment: { ...payment, warningMessages },
+        fallbackWarningMessages,
+        confirmWarnings,
+        shouldContinue: () => true,
+      }),
+    ).resolves.toBe(true);
+    expect(confirmWarnings).toHaveBeenCalledWith(warningMessages);
+  });
+
+  test.each([{ warningMessages: undefined }, { warningMessages: [] }])(
+    'confirms the fallback without changing an API snapshot with warnings=$warningMessages',
+    async ({ warningMessages }) => {
+      const snapshot = { ...payment, warningMessages };
+      const fingerprint = getPrimeInfiniPaymentWarningsFingerprint(snapshot);
+      const confirmWarnings = jest.fn<Promise<boolean>, [string[]]>(
+        async () => true,
+      );
+
+      await expect(
+        confirmPrimeInfiniPaymentWarnings({
+          payment: snapshot,
+          fallbackWarningMessages,
+          confirmWarnings,
+          shouldContinue: () => true,
+        }),
+      ).resolves.toBe(true);
+
+      expect(confirmWarnings).toHaveBeenCalledWith(fallbackWarningMessages);
+      expect(confirmWarnings.mock.calls[0][0]).not.toBe(
+        fallbackWarningMessages,
+      );
+      expect(snapshot.warningMessages).toBe(warningMessages);
+      expect(getPrimeInfiniPaymentWarningsFingerprint(snapshot)).toBe(
+        fingerprint,
+      );
+    },
+  );
+
+  test('cancelling fallback warnings stops checkout even without an invoice', async () => {
+    const confirmWarnings = jest.fn(async () => false);
+    await expect(
+      confirmPrimeInfiniPaymentWarnings({
+        payment: {},
+        fallbackWarningMessages,
+        confirmWarnings,
+        shouldContinue: () => true,
       }),
     ).resolves.toBe(false);
+    expect(confirmWarnings).toHaveBeenCalledWith(fallbackWarningMessages);
   });
+
+  test.each([{ warningMessages: ['Warning'] }, { warningMessages: undefined }])(
+    'does not continue a stale flow after confirming warnings=$warningMessages',
+    async ({ warningMessages }) => {
+      let isCurrent = true;
+      await expect(
+        confirmPrimeInfiniPaymentWarnings({
+          payment: { ...payment, warningMessages },
+          fallbackWarningMessages,
+          confirmWarnings: async () => {
+            isCurrent = false;
+            return true;
+          },
+          shouldContinue: () => isCurrent,
+        }),
+      ).resolves.toBe(false);
+    },
+  );
 
   test('does not show a warning for an already abandoned flow', async () => {
     const confirmWarnings = jest.fn(async () => true);
@@ -115,6 +176,27 @@ describe('latest Infini payment warnings', () => {
     expect(
       hasUnconfirmedPrimeInfiniPaymentWarnings({
         payment: acknowledgedPayment,
+      }),
+    ).toBe(true);
+  });
+
+  test('still requires consent for server warnings arriving after mock confirmation', async () => {
+    const snapshot = { ...payment };
+    const confirmedWarningsFingerprint =
+      getPrimeInfiniPaymentWarningsFingerprint(snapshot);
+    await expect(
+      confirmPrimeInfiniPaymentWarnings({
+        payment: snapshot,
+        fallbackWarningMessages,
+        confirmWarnings: async () => true,
+        shouldContinue: () => true,
+      }),
+    ).resolves.toBe(true);
+
+    expect(
+      hasUnconfirmedPrimeInfiniPaymentWarnings({
+        payment: { ...snapshot, warningMessages: ['New API warning'] },
+        confirmedWarningsFingerprint,
       }),
     ).toBe(true);
   });

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentWarnings.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentWarnings.ts
@@ -3,17 +3,22 @@ import type { IPrimeInfiniPayment } from '@onekeyhq/shared/types/prime/primeType
 
 export async function confirmPrimeInfiniPaymentWarnings({
   payment,
+  fallbackWarningMessages,
   confirmWarnings,
   shouldContinue,
 }: {
-  payment: IPrimeInfiniPayment;
+  payment: Pick<IPrimeInfiniPayment, 'warningMessages'>;
+  fallbackWarningMessages?: readonly string[];
   confirmWarnings: (messages: string[]) => Promise<boolean>;
   shouldContinue: () => boolean;
 }) {
   if (!shouldContinue()) {
     return false;
   }
-  const warnings = payment.warningMessages;
+  // Keep fallback text out of the payment snapshot and its consent fingerprint.
+  const warnings = payment.warningMessages?.length
+    ? payment.warningMessages
+    : fallbackWarningMessages;
   if (warnings?.length && !(await confirmWarnings([...warnings]))) {
     return false;
   }

--- a/packages/shared/src/utils/primeInfiniPaymentCacheUtils.test.ts
+++ b/packages/shared/src/utils/primeInfiniPaymentCacheUtils.test.ts
@@ -1,10 +1,13 @@
 /* cspell:ignore Infini */
+import { getNetworkIdsMap } from '../config/networkIds';
+
 import {
   buildPrimeInfiniPaymentCacheKey,
   getPrimeInfiniPaymentAssetKey,
   isPrimeInfiniPaymentFullyConfirmedSnapshot,
   isPrimeInfiniPaymentPreBroadcastSnapshotSendable,
   isPrimeInfiniPaymentTransferClaimForSession,
+  isValidPrimeInfiniPaymentContract,
   mergePrimeInfiniPaymentProgressSnapshot,
 } from './primeInfiniPaymentCacheUtils';
 
@@ -75,6 +78,44 @@ function buildTransferClaim(session: IPrimeInfiniPendingPaymentSession) {
     amount: session.payment.amountDue,
   };
 }
+
+describe('isValidPrimeInfiniPaymentContract', () => {
+  const networkIdsMap = getNetworkIdsMap();
+
+  test.each([
+    [' ethereum ', networkIdsMap.eth, 'ETH'],
+    ['BASE', networkIdsMap.base, 'ETH'],
+    ['BSC', networkIdsMap.bsc, 'BNB'],
+    ['SOLANA', networkIdsMap.sol, 'SOL'],
+    ['TRON', networkIdsMap.trx, 'TRX'],
+  ])('accepts the native %s chain metadata', (chain, networkId, token) => {
+    expect(
+      isValidPrimeInfiniPaymentContract({
+        chain,
+        networkId,
+        token,
+        contractAddress: '',
+      }),
+    ).toBe(true);
+  });
+
+  test.each([
+    ['BSC', networkIdsMap.eth, 'ETH'],
+    ['ETHEREUM', networkIdsMap.base, 'ETH'],
+  ])(
+    'rejects native metadata when %s conflicts with its network',
+    (chain, networkId, token) => {
+      expect(
+        isValidPrimeInfiniPaymentContract({
+          chain,
+          networkId,
+          token,
+          contractAddress: '',
+        }),
+      ).toBe(false);
+    },
+  );
+});
 
 describe('Infini broadcast quote safety window', () => {
   test.each([-1, 0, 1, 29_999, 30_000, 30_001])(

--- a/packages/shared/src/utils/primeInfiniPaymentCacheUtils.ts
+++ b/packages/shared/src/utils/primeInfiniPaymentCacheUtils.ts
@@ -125,10 +125,12 @@ export function normalizePrimeInfiniContractAddress({
 }
 
 export function isValidPrimeInfiniPaymentContract({
+  chain,
   networkId,
   token,
   contractAddress,
 }: {
+  chain: string;
   networkId: string;
   token: string;
   contractAddress: unknown;
@@ -142,12 +144,20 @@ export function isValidPrimeInfiniPaymentContract({
   // An empty contract identifies the native asset, not a token with missing
   // metadata.
   const network = getListedNetworkMap()[networkId.trim()];
+  const normalizedChain = normalizeIdentityValue(chain);
   return Boolean(
     network &&
     !network.isAllNetworks &&
     !network.isAggregateNetwork &&
     typeof network.symbol === 'string' &&
-    normalizeIdentityValue(token) === normalizeIdentityValue(network.symbol),
+    normalizeIdentityValue(token) === normalizeIdentityValue(network.symbol) &&
+    // Native symbols cannot identify a chain because several networks share
+    // symbols such as ETH. Match only the selected network's chain names.
+    [network.name, network.code, network.shortcode, network.shortname].some(
+      (networkChain) =>
+        typeof networkChain === 'string' &&
+        normalizedChain === normalizeIdentityValue(networkChain),
+    ),
   );
 }
 

--- a/packages/shared/src/utils/primeInfiniPaymentCacheUtils.ts
+++ b/packages/shared/src/utils/primeInfiniPaymentCacheUtils.ts
@@ -1,6 +1,7 @@
 /* cspell:ignore Infini */
 import BigNumber from 'bignumber.js';
 
+import { getListedNetworkMap } from '../config/networkIds';
 import { PRIME_INFINI_MIN_PAYMENT_VALIDITY_MS } from '../consts/primeConsts';
 
 import { generateUUID } from './miscUtils';
@@ -121,6 +122,33 @@ export function normalizePrimeInfiniContractAddress({
     networkId,
     address: contractAddress,
   });
+}
+
+export function isValidPrimeInfiniPaymentContract({
+  networkId,
+  token,
+  contractAddress,
+}: {
+  networkId: string;
+  token: string;
+  contractAddress: unknown;
+}): boolean {
+  if (typeof contractAddress !== 'string') {
+    return false;
+  }
+  if (contractAddress !== '') {
+    return Boolean(contractAddress.trim());
+  }
+  // An empty contract identifies the native asset, not a token with missing
+  // metadata.
+  const network = getListedNetworkMap()[networkId.trim()];
+  return Boolean(
+    network &&
+    !network.isAllNetworks &&
+    !network.isAggregateNetwork &&
+    typeof network.symbol === 'string' &&
+    normalizeIdentityValue(token) === normalizeIdentityValue(network.symbol),
+  );
 }
 
 export function isSamePrimeInfiniNetworkAddress({

--- a/packages/shared/types/prime/primeTypes.ts
+++ b/packages/shared/types/prime/primeTypes.ts
@@ -145,6 +145,7 @@ export type IPrimeInfiniPaymentOption = {
   networkId: string;
   tokens: Array<{
     symbol: string;
+    // Empty for the network's native asset.
     contract: string;
   }>;
 };


### PR DESCRIPTION
## Summary

- Accept Infini native-asset options with an empty contract only when the symbol matches the listed network's native asset
- Reject native options whose `chain` conflicts with `networkId`, including service ingestion, UI/session restore, and pre-broadcast verification
- Preserve native assets through balance loading, payment-session persistence, replacement protection, and crash recovery
- Verify the exact native transfer, signer, recipient, amount, and asset type before the durable send claim and broadcast
- Improve unavailable-account loading states and warning confirmation, including developer-only warning flow coverage
- Route empty-wallet account selection to Onboarding after closing all dialogs and modal overlays; keep existing wallets on the account selector

## Testing

- `yarn jest --runInBand <10 targeted Infini payment suites>` — 499 tests passed
- `yarn workspace @onekeyhq/mobile module-id:check --map <Infini navigation module map>` — stable module registry check passed
- `yarn agent:check --profile commit` — agent context, background API contract, lint, formatting, and TypeScript checks passed

Related: OK-61391
Follow-up to #13086
