### PR TITLE
fix: honor megafuel sponsorship for private send like normal send (OK-61643)

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -160,7 +160,6 @@ function TxFeeInfo(props: IProps) {
     transferPayload,
     gasAccountScenario,
   } = props;
-  const isPrivateSendTransfer = transferPayload?.isPrivateSend === true;
   const gasAccountDisabledByScenario =
     isGasAccountDisabledScenario(gasAccountScenario);
   const intl = useIntl();
@@ -580,21 +579,19 @@ function TxFeeInfo(props: IProps) {
         // show "0 network fee" / sponsor badge while the actual broadcast
         // falls back to user-paid.
         const sponsorDisabledForBatch = isMultiTxs;
-        // Private Send supports Gas Account sponsorship (OK-59993, admitted
-        // by the backend via scenario='privateSend'), but megafuel stays
-        // disabled for it: megafuel is an independent BNB-chain sponsor with
-        // no Private Send contract on the backend side.
-        const megafuelDisabledForPrivateSend = isPrivateSendTransfer;
+        // Private Send is treated exactly like a normal send for sponsorship:
+        // its deposit tx is an ordinary transfer broadcast through the same
+        // send-transaction endpoint, so both megafuel (eligibility returned
+        // by the estimate for this very tx) and Gas Account (admitted by the
+        // backend via scenario='privateSend', OK-59993) apply as-is.
+        //
         // `gasAccountTemporarilyDisabled` narrows only the gas-account path.
         // Megafuel is an independent sponsor mechanism and should still be
         // honored when the server indicates `payer='megafuel'`, even when a
         // frontend scenario disables Gas Account.
         //
         // Display payer and submit wiring are derived together from the
-        // post-filtered sponsor state so they cannot drift: when megafuel is
-        // suppressed for Private Send, a server `payer='megafuel'` preference
-        // falls through to an eligible gas account quote instead of silently
-        // degrading to user-paid.
+        // post-filtered sponsor state so they cannot drift.
         const serverPayer: IGasPayer = r.payer ?? 'user';
         const {
           effectiveFeePayer: nextEffectiveFeePayer,
@@ -609,7 +606,6 @@ function TxFeeInfo(props: IProps) {
           isCustomRpcEnabled,
           sponsorDisabledForBatch,
           sponsorDisabledForExternalAccount: isExternalAccount,
-          megafuelDisabledForPrivateSend,
           gasAccountDisabledByScenario,
           gasAccountTemporarilyDisabled,
         });
@@ -623,7 +619,6 @@ function TxFeeInfo(props: IProps) {
         if (
           r.megafuelEligible &&
           !sponsorDisabledForBatch &&
-          !megafuelDisabledForPrivateSend &&
           !isExternalAccount
         ) {
           // if custom rpc is enabled, disable megafuel eligible
@@ -641,11 +636,7 @@ function TxFeeInfo(props: IProps) {
             updateMegafuelEligible(r.megafuelEligible);
           }
         } else {
-          if (
-            sponsorDisabledForBatch ||
-            megafuelDisabledForPrivateSend ||
-            isExternalAccount
-          ) {
+          if (sponsorDisabledForBatch || isExternalAccount) {
             // Megafuel zeroes `gasPrice` in the estimate (real price kept in
             // `originalGasPrice`); restore it so the regular fee UI and the
             // native-balance precheck operate on the real fee.
@@ -923,7 +914,6 @@ function TxFeeInfo(props: IProps) {
       isSecondApproveTxWithFeeInfo,
       isSingleTxWithFeesInfo,
       feeInfoEditable,
-      isPrivateSendTransfer,
       network?.isTestnet,
       networkId,
       unsignedTxs,

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountPayerSelection.test.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountPayerSelection.test.ts
@@ -10,7 +10,6 @@ const baseParams = {
   isCustomRpcEnabled: false,
   sponsorDisabledForBatch: false,
   sponsorDisabledForExternalAccount: false,
-  megafuelDisabledForPrivateSend: false,
   gasAccountDisabledByScenario: false,
   gasAccountTemporarilyDisabled: false,
 };
@@ -61,23 +60,22 @@ describe('isGasAccountQuoteEligible', () => {
     ).toBe(false);
   });
 
-  it('resolves to user/user when the quote object exists without a quoteId', () => {
-    // End-to-end invariant: an id-less quote must never surface the sponsored
-    // UI (effectiveFeePayer) nor wire the submit path (selectedPayer), even
-    // on the Private Send megafuel fallback where the window is widest.
+  it('never wires the gas account submit path on an id-less quote', () => {
+    // End-to-end invariant: an id-less quote must never wire the submit path
+    // (selectedPayer) to gasAccount; megafuel display stays intact since it
+    // does not depend on the quote.
     expect(
       resolveSponsorPayerState({
         ...baseParams,
         serverPayer: 'megafuel',
         megafuelSponsorable: true,
-        megafuelDisabledForPrivateSend: true,
         gasAccountQuoteEligible: isGasAccountQuoteEligible({
           gasAccountEligible: true,
           gasAccountQuote: { ...quote, quoteId: '' },
         }),
       }),
     ).toEqual({
-      effectiveFeePayer: 'user',
+      effectiveFeePayer: 'megafuel',
       selectedPayer: 'user',
     });
   });
@@ -148,6 +146,20 @@ describe('resolveSponsorPayerState', () => {
         }),
       ).toEqual({
         effectiveFeePayer: 'gasAccount',
+        selectedPayer: 'user',
+      });
+    });
+
+    it('surfaces megafuel without an eligible gas account quote', () => {
+      expect(
+        resolveSponsorPayerState({
+          ...baseParams,
+          serverPayer: 'megafuel',
+          megafuelSponsorable: true,
+          gasAccountQuoteEligible: false,
+        }),
+      ).toEqual({
+        effectiveFeePayer: 'megafuel',
         selectedPayer: 'user',
       });
     });
@@ -270,92 +282,30 @@ describe('resolveSponsorPayerState', () => {
         selectedPayer: 'user',
       });
     });
-  });
 
-  describe('private send (megafuel suppressed)', () => {
-    it('falls back to the eligible gas account quote when the server prefers megafuel', () => {
+    it('still surfaces megafuel while gas account is temporarily disabled', () => {
       expect(
         resolveSponsorPayerState({
           ...baseParams,
           serverPayer: 'megafuel',
           megafuelSponsorable: true,
           gasAccountQuoteEligible: true,
-          megafuelDisabledForPrivateSend: true,
-        }),
-      ).toEqual({
-        effectiveFeePayer: 'gasAccount',
-        selectedPayer: 'gasAccount',
-      });
-    });
-
-    it('falls back to user when the server prefers megafuel and no quote is eligible', () => {
-      expect(
-        resolveSponsorPayerState({
-          ...baseParams,
-          serverPayer: 'megafuel',
-          megafuelSponsorable: true,
-          gasAccountQuoteEligible: false,
-          megafuelDisabledForPrivateSend: true,
-        }),
-      ).toEqual({
-        effectiveFeePayer: 'user',
-        selectedPayer: 'user',
-      });
-    });
-
-    it('selects gas account when the server prefers it even with megafuel sponsorable', () => {
-      expect(
-        resolveSponsorPayerState({
-          ...baseParams,
-          serverPayer: 'gasAccount',
-          megafuelSponsorable: true,
-          gasAccountQuoteEligible: true,
-          megafuelDisabledForPrivateSend: true,
-        }),
-      ).toEqual({
-        effectiveFeePayer: 'gasAccount',
-        selectedPayer: 'gasAccount',
-      });
-    });
-
-    it('keeps user payer when the server does not sponsor', () => {
-      expect(
-        resolveSponsorPayerState({
-          ...baseParams,
-          serverPayer: 'user',
-          megafuelDisabledForPrivateSend: true,
-        }),
-      ).toEqual({
-        effectiveFeePayer: 'user',
-        selectedPayer: 'user',
-      });
-    });
-
-    it('does not fall back to gas account when a custom RPC is enabled', () => {
-      expect(
-        resolveSponsorPayerState({
-          ...baseParams,
-          serverPayer: 'megafuel',
-          megafuelSponsorable: true,
-          gasAccountQuoteEligible: true,
-          megafuelDisabledForPrivateSend: true,
-          isCustomRpcEnabled: true,
-        }),
-      ).toEqual({
-        effectiveFeePayer: 'user',
-        selectedPayer: 'user',
-      });
-    });
-
-    it('does not fall back to gas account while it is temporarily disabled', () => {
-      expect(
-        resolveSponsorPayerState({
-          ...baseParams,
-          serverPayer: 'megafuel',
-          megafuelSponsorable: true,
-          gasAccountQuoteEligible: true,
-          megafuelDisabledForPrivateSend: true,
           gasAccountTemporarilyDisabled: true,
+        }),
+      ).toEqual({
+        effectiveFeePayer: 'megafuel',
+        selectedPayer: 'user',
+      });
+    });
+
+    it('forces user for megafuel when a custom RPC is enabled', () => {
+      expect(
+        resolveSponsorPayerState({
+          ...baseParams,
+          serverPayer: 'megafuel',
+          megafuelSponsorable: true,
+          gasAccountQuoteEligible: true,
+          isCustomRpcEnabled: true,
         }),
       ).toEqual({
         effectiveFeePayer: 'user',

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountPayerSelection.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountPayerSelection.ts
@@ -34,7 +34,6 @@ export interface IResolveSponsorPayerStateParams {
    * fall back to user-paid.
    */
   sponsorDisabledForExternalAccount: boolean;
-  megafuelDisabledForPrivateSend: boolean;
   gasAccountDisabledByScenario: boolean;
   gasAccountTemporarilyDisabled: boolean;
 }
@@ -52,9 +51,9 @@ export interface ISponsorPayerState {
  *
  * Megafuel wins over a coexisting gas account quote when it is actually
  * available: it sponsors at the chain level (zeroed gas price), so the quote
- * must not be attached on top of it. When megafuel is suppressed for the
- * scenario (Private Send), the server's megafuel preference falls through to
- * an eligible gas account quote instead of silently degrading to user-paid.
+ * must not be attached on top of it. Private Send follows the same rules as a
+ * normal send: it broadcasts through the same send-transaction endpoint, so
+ * sponsor eligibility returned for its deposit tx is honored as-is.
  */
 export function resolveSponsorPayerState({
   serverPayer,
@@ -63,7 +62,6 @@ export function resolveSponsorPayerState({
   isCustomRpcEnabled,
   sponsorDisabledForBatch,
   sponsorDisabledForExternalAccount,
-  megafuelDisabledForPrivateSend,
   gasAccountDisabledByScenario,
   gasAccountTemporarilyDisabled,
 }: IResolveSponsorPayerStateParams): ISponsorPayerState {
@@ -76,20 +74,15 @@ export function resolveSponsorPayerState({
   const megafuelSuppressed =
     isCustomRpcEnabled ||
     sponsorDisabledForBatch ||
-    sponsorDisabledForExternalAccount ||
-    megafuelDisabledForPrivateSend;
+    sponsorDisabledForExternalAccount;
 
   const megafuelAvailable = !megafuelSuppressed && megafuelSponsorable;
-  const payerPreference =
-    megafuelDisabledForPrivateSend && serverPayer === 'megafuel'
-      ? 'gasAccount'
-      : serverPayer;
 
   const selectedPayer: 'user' | 'gasAccount' =
     gasAccountQuoteEligible &&
     !gasAccountSuppressed &&
     !megafuelAvailable &&
-    payerPreference === 'gasAccount'
+    serverPayer === 'gasAccount'
       ? 'gasAccount'
       : 'user';
 
@@ -103,8 +96,6 @@ export function resolveSponsorPayerState({
     (gasAccountTemporarilyDisabled && serverPayer === 'gasAccount')
   ) {
     effectiveFeePayer = 'user';
-  } else if (megafuelDisabledForPrivateSend && serverPayer === 'megafuel') {
-    effectiveFeePayer = selectedPayer === 'gasAccount' ? 'gasAccount' : 'user';
   }
 
   return { effectiveFeePayer, selectedPayer };


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61643](https://onekeyhq.atlassian.net/browse/OK-61643)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

On BSC, private send never received megafuel gas sponsorship while a normal send from the same account did — even though the estimate response is identical in both flows (`megafuelEligible.sponsorable=true`, `payer="megafuel"`).

**Root cause**: a client-side gate in `TxFeeInfo` (`megafuelDisabledForPrivateSend = isPrivateSendTransfer`) unconditionally dropped `megafuelEligible` and restored `originalGasPrice` for private send, so the tx always signed user-paid. The gate dates from the private send launch (OK-55149, "user-paid by contract") and was kept in OK-59993 on the assumption that megafuel had no private-send contract on the backend. That premise no longer holds: the estimate runs on the actual private-send deposit `encodedTx` (with `scenario='privateSend'`) and the paymaster still reports it sponsorable, and the broadcast goes through the same `send-transaction` endpoint with only an extra `isPrivateSend` flag.

**Change**: private send now follows exactly the same sponsorship rules as a normal send.

- `TxFeeInfo`: remove the `megafuelDisabledForPrivateSend` gate and its strip/restore branches.
- `resolveSponsorPayerState`: remove the parameter and the megafuel-suppressed → gas-account-quote fallthrough logic that only existed to serve it (simplifies the function back to the shared rules).
- Tests: the private-send suppression block is dissolved; its non-duplicate cases (megafuel without an eligible quote, megafuel vs `gasAccountTemporarilyDisabled`, megafuel vs custom RPC) moved into the default-flow / global-suppression groups.

Unchanged suppressions: batch flows, external-wallet accounts, custom RPC, and the Gas Account scenario gates all still force user-paid as before.

## Test Plan

- [x] TDD: rewrote the payer-selection expectations first (5 failing on the old behavior), then removed the gate
- [x] 72 tests green across `gasAccountPayerSelection` / `gasAccountAnalytics` / `useSignatureConfirm` / `ServiceSend.broadcastDeadline`
- [x] `yarn agent:check --profile pr` pass
- [x] Manually verified on the web dev build: BSC private send now shows the BNB Chain sponsor badge with zero network fee, broadcast succeeds; normal send behavior unchanged

[OK-61643]: https://onekeyhq.atlassian.net/browse/OK-61643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ