### PR TITLE
feat: withdraw Perps USDC over Hyperliquid's CCTP rail(OK-61320)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1565,3 +1565,6 @@ navigations
 
 # OpenType tabular-figures feature tag
 tnum
+# Circle Cross-Chain Transfer Protocol, and Hyperliquid's L1
+cctp
+hypercore

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -31,6 +31,7 @@ import type {
 } from '@onekeyhq/shared/src/logger/scopes/perp/scenes/hyperliquid';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { convertHyperLiquidResponse } from '@onekeyhq/shared/src/utils/hyperLiquidErrorResolver';
+import { isUnifiedPortfolioMode } from '@onekeyhq/shared/src/utils/hyperliquidPortfolioUtils';
 import {
   assertValidScaleOrderLegs,
   buildScaleOrderLegs,
@@ -46,7 +47,12 @@ import {
   mapTriggerOrderType,
   parseSignatureToRSV,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
-import { SPOT_ASSET_ID_OFFSET } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import {
+  CCTP_DOMAIN_ARBITRUM,
+  CCTP_WITHDRAW_GAS_LIMIT,
+  CCTP_WITHDRAW_HOOK_DATA,
+  SPOT_ASSET_ID_OFFSET,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IApiErrorResponse,
   IApiRequestResult,
@@ -85,11 +91,14 @@ import type { IHyperLiquidSignatureRSV } from '@onekeyhq/shared/types/hyperliqui
 import { ERookieTaskType } from '@onekeyhq/shared/types/rookieGuide';
 
 import {
+  perpsAbstractionModeAtom,
   perpsActiveAccountAtom,
   perpsActiveAccountStatusAtom,
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
+import { getUsdcWithdrawRoute } from './usdcWithdrawRoute';
+import type { IUsdcWithdrawRoute } from './usdcWithdrawRoute';
 import { createLoggedHyperLiquidClient } from './utils/logHyperLiquidApiFailure';
 
 import type {
@@ -1734,6 +1743,32 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     );
   }
 
+  // The withdraw form needs the rail to show the right fee; the result is cached
+  // in the route module, so repeat opens do not re-request it.
+  @backgroundMethod()
+  async getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+    return getUsdcWithdrawRoute();
+  }
+
+  // `sendToEvmWithData` requires an explicit source balance, where `withdraw3`
+  // let Hyperliquid pick one. Mirror perpsComputedAccountValueAtom: unified and
+  // portfolio-margin accounts report the spot-side USDC balance as withdrawable,
+  // every other mode reports the perp clearinghouse. Sourcing from a balance the
+  // withdraw form never validated against would let the action exceed what the
+  // user was shown as available.
+  private async _resolveWithdrawSourceDex(
+    userAddress: string | undefined,
+  ): Promise<'' | 'spot'> {
+    const modeData = await perpsAbstractionModeAtom.get();
+    const isModeForThisAccount =
+      Boolean(userAddress) &&
+      modeData?.accountAddress?.toLowerCase() === userAddress?.toLowerCase();
+    if (!isModeForThisAccount) {
+      return '';
+    }
+    return isUnifiedPortfolioMode(modeData?.mode) ? 'spot' : '';
+  }
+
   @backgroundMethod()
   async withdraw(params: IWithdrawParams): Promise<void> {
     await this.checkAccountCanTrade();
@@ -1749,17 +1784,46 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       }),
     );
     const context = await this._buildLogContext();
+    // Resolved inside the try so a failure here is reported like any other
+    // withdrawal failure instead of escaping without a log.
+    let route: IUsdcWithdrawRoute | undefined;
+    // Which balance the action drew from is the field most worth having when a
+    // withdrawal misbehaves, and the one a signature prompt may not surface.
+    let sourceDex: '' | 'spot' | undefined;
     try {
-      await convertHyperLiquidResponse(() => exchangeClient.withdraw3(params));
+      const [resolvedRoute, userAddress] = await Promise.all([
+        getUsdcWithdrawRoute(),
+        wallet.getAddress(),
+      ]);
+      route = resolvedRoute;
+      await convertHyperLiquidResponse(async () => {
+        if (route === 'cctp') {
+          sourceDex = await this._resolveWithdrawSourceDex(userAddress);
+          return exchangeClient.sendToEvmWithData({
+            token: 'USDC',
+            amount: params.amount,
+            sourceDex,
+            destinationRecipient: params.destination,
+            addressEncoding: 'hex',
+            destinationChainId: CCTP_DOMAIN_ARBITRUM,
+            gasLimit: CCTP_WITHDRAW_GAS_LIMIT,
+            data: CCTP_WITHDRAW_HOOK_DATA,
+          });
+        }
+        return exchangeClient.withdraw3({
+          amount: params.amount,
+          destination: params.destination,
+        });
+      });
       defaultLogger.perp.hyperliquid.withdraw({
         ...context,
-        request: params,
+        request: { ...params, route, sourceDex },
         response: { success: true },
       });
     } catch (error) {
       defaultLogger.perp.hyperliquid.withdraw({
         ...context,
-        request: params,
+        request: { ...params, route, sourceDex },
         response: extractHyperLiquidErrorResponse<IApiErrorResponse>(error),
         error: serializeHyperLiquidError(error),
       });

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -1756,8 +1756,6 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     );
   }
 
-  // The withdraw form needs the rail to show the right fee; the result is cached
-  // in the route module, so repeat opens do not re-request it.
   @backgroundMethod()
   async getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
     return getUsdcWithdrawRoute();
@@ -1786,12 +1784,8 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     return getUsdcWithdrawFee(params.destinationId, this._callHyperEvmRpc);
   }
 
-  // `sendToEvmWithData` requires an explicit source balance, where `withdraw3`
-  // let Hyperliquid pick one. Mirror perpsComputedAccountValueAtom: unified and
-  // portfolio-margin accounts report the spot-side USDC balance as withdrawable,
-  // every other mode reports the perp clearinghouse. Sourcing from a balance the
-  // withdraw form never validated against would let the action exceed what the
-  // user was shown as available.
+  // Mirrors perpsComputedAccountValueAtom so the action spends the same balance
+  // the withdraw form validated the amount against.
   private async _resolveWithdrawSourceDex(
     userAddress: string | undefined,
   ): Promise<'' | 'spot'> {
@@ -1823,11 +1817,8 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       }),
     );
     const context = await this._buildLogContext();
-    // Resolved inside the try so a failure here is reported like any other
-    // withdrawal failure instead of escaping without a log.
+    // Declared outside the try so a failure before the action still logs them.
     let route: IUsdcWithdrawRoute | undefined;
-    // Which balance the action drew from is the field most worth having when a
-    // withdrawal misbehaves, and the one a signature prompt may not surface.
     let sourceDex: '' | 'spot' | undefined;
     try {
       const [resolvedRoute, userAddress] = await Promise.all([

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -7,6 +7,7 @@ import {
   backgroundClass,
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
   DISABLE_PERPS_WALLET_BIND,
   type EHyperLiquidAgentName,
@@ -48,10 +49,12 @@ import {
   parseSignatureToRSV,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import {
-  CCTP_DOMAIN_ARBITRUM,
-  CCTP_WITHDRAW_GAS_LIMIT,
-  CCTP_WITHDRAW_HOOK_DATA,
+  HYPEREVM_SYSTEM_ADDRESS,
   SPOT_ASSET_ID_OFFSET,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IUsdcWithdrawDestinationId,
+  IUsdcWithdrawFeeQuote,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IApiErrorResponse,
@@ -97,14 +100,24 @@ import {
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
-import { getUsdcWithdrawRoute } from './usdcWithdrawRoute';
-import type { IUsdcWithdrawRoute } from './usdcWithdrawRoute';
+import {
+  buildCctpWithdrawDestination,
+  getLiveUsdcWithdrawFee,
+  getUsdcWithdrawFee,
+  requireUsdcWithdrawDestination,
+} from './cctpWithdraw';
+import {
+  getLiveUsdcWithdrawRoute,
+  getUsdcWithdrawRoute,
+} from './usdcWithdrawRoute';
 import { createLoggedHyperLiquidClient } from './utils/logHyperLiquidApiFailure';
 
+import type { IHyperEvmRpcCall } from './cctpWithdraw';
 import type {
   WalletHyperliquidOnekey,
   WalletHyperliquidProxy,
 } from './ServiceHyperliquidWallet';
+import type { IUsdcWithdrawRoute } from './usdcWithdrawRoute';
 import type { IBackgroundApi } from '../../apis/IBackgroundApi';
 
 interface IOrderLogOptions {
@@ -1750,6 +1763,29 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     return getUsdcWithdrawRoute();
   }
 
+  private _callHyperEvmRpc: IHyperEvmRpcCall = async (method, params) => {
+    const [result] = await this.backgroundApi.serviceDApp.proxyRPCCall<unknown>(
+      {
+        networkId: getNetworkIdsMap().hyperevm,
+        request: {
+          jsonrpc: '2.0',
+          id: 0,
+          method,
+          params,
+        },
+        origin: 'onekey://perps',
+      },
+    );
+    return result;
+  };
+
+  @backgroundMethod()
+  async getUsdcWithdrawFee(params: {
+    destinationId: IUsdcWithdrawDestinationId;
+  }): Promise<IUsdcWithdrawFeeQuote> {
+    return getUsdcWithdrawFee(params.destinationId, this._callHyperEvmRpc);
+  }
+
   // `sendToEvmWithData` requires an explicit source balance, where `withdraw3`
   // let Hyperliquid pick one. Mirror perpsComputedAccountValueAtom: unified and
   // portfolio-margin accounts report the spot-side USDC balance as withdrawable,
@@ -1772,6 +1808,9 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
   @backgroundMethod()
   async withdraw(params: IWithdrawParams): Promise<void> {
     await this.checkAccountCanTrade();
+    const destinationConfig = requireUsdcWithdrawDestination(
+      params.destinationId,
+    );
     const wallet =
       await this.backgroundApi.serviceHyperliquidWallet.getOnekeyWallet({
         userAccountId: params.userAccountId,
@@ -1780,7 +1819,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       new ExchangeClient({
         transport: new HttpTransport(),
         wallet,
-        signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
+        signatureChainId: destinationConfig.signatureChainId,
       }),
     );
     const context = await this._buildLogContext();
@@ -1792,27 +1831,86 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     let sourceDex: '' | 'spot' | undefined;
     try {
       const [resolvedRoute, userAddress] = await Promise.all([
-        getUsdcWithdrawRoute(),
+        destinationConfig.transferType === 'cctp'
+          ? getLiveUsdcWithdrawRoute()
+          : Promise.resolve(undefined),
         wallet.getAddress(),
       ]);
       route = resolvedRoute;
+      if (
+        destinationConfig.transferType === 'cctp' &&
+        (!params.expectedRoute || route !== params.expectedRoute)
+      ) {
+        throw new OneKeyLocalError(
+          'Withdrawal route changed. Review the updated fee and try again.',
+        );
+      }
+      if (
+        destinationConfig.transferType === 'cctp' &&
+        route === 'bridge' &&
+        !destinationConfig.supportsLegacyBridge
+      ) {
+        throw new OneKeyLocalError(
+          `${destinationConfig.name} withdrawals require the CCTP route`,
+        );
+      }
+      if (destinationConfig.transferType === 'cctp' && route === 'cctp') {
+        const liveFeeQuote = await getLiveUsdcWithdrawFee(
+          params.destinationId,
+          this._callHyperEvmRpc,
+        );
+        const cctpFee = liveFeeQuote.components.find(
+          (component) => component.kind === 'cctpForwarding',
+        );
+        if (!cctpFee?.amount) {
+          throw new OneKeyLocalError('Unable to quote CCTP withdrawal fee');
+        }
+        if (
+          !params.expectedCctpFee ||
+          !new BigNumber(params.expectedCctpFee).eq(cctpFee.amount)
+        ) {
+          throw new OneKeyLocalError(
+            'Withdrawal fee changed. Review the updated fee and try again.',
+          );
+        }
+        if (new BigNumber(params.amount).lte(cctpFee.amount)) {
+          throw new OneKeyLocalError(
+            'Withdrawal amount must exceed the CCTP fee',
+          );
+        }
+      }
       await convertHyperLiquidResponse(async () => {
+        if (destinationConfig.transferType === 'hyperEvm') {
+          sourceDex = await this._resolveWithdrawSourceDex(userAddress);
+          return exchangeClient.sendAsset({
+            destination: HYPEREVM_SYSTEM_ADDRESS,
+            sourceDex,
+            destinationDex: 'spot',
+            token: 'USDC',
+            amount: params.amount,
+            fromSubAccount: '',
+          });
+        }
         if (route === 'cctp') {
           sourceDex = await this._resolveWithdrawSourceDex(userAddress);
+          const destination = buildCctpWithdrawDestination({
+            destinationId: params.destinationId,
+            ownerAddress: userAddress,
+          });
           return exchangeClient.sendToEvmWithData({
             token: 'USDC',
             amount: params.amount,
             sourceDex,
-            destinationRecipient: params.destination,
-            addressEncoding: 'hex',
-            destinationChainId: CCTP_DOMAIN_ARBITRUM,
-            gasLimit: CCTP_WITHDRAW_GAS_LIMIT,
-            data: CCTP_WITHDRAW_HOOK_DATA,
+            destinationRecipient: destination.destinationRecipient,
+            addressEncoding: destination.addressEncoding,
+            destinationChainId: destination.destinationChainId,
+            gasLimit: destination.gasLimit,
+            data: destination.data,
           });
         }
         return exchangeClient.withdraw3({
           amount: params.amount,
-          destination: params.destination,
+          destination: userAddress,
         });
       });
       defaultLogger.perp.hyperliquid.withdraw({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/cctpWithdraw.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/cctpWithdraw.ts
@@ -174,8 +174,8 @@ export async function getUsdcWithdrawFee(
   };
 }
 
-// Submission must not rely on a cached or static CCTP fallback fee. The contract
-// can update per-domain USDC fees, while direct HyperEVM sends have no CCTP fee.
+// The contract can update per-domain fees, so submission must not quote a cached
+// or fallback value.
 export async function getLiveUsdcWithdrawFee(
   destinationId: IUsdcWithdrawDestinationId,
   rpcCall: IHyperEvmRpcCall,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/cctpWithdraw.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/cctpWithdraw.ts
@@ -1,0 +1,242 @@
+import BigNumber from 'bignumber.js';
+
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  CCTP_WITHDRAW_GAS_LIMIT,
+  CCTP_WITHDRAW_HOOK_DATA,
+  USDC_WITHDRAW_GAS_RESERVE,
+  getUsdcWithdrawDestination,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  ICctpWithdrawDestinationConfig,
+  IUsdcWithdrawDestinationConfig,
+  IUsdcWithdrawDestinationId,
+  IUsdcWithdrawFeeComponent,
+  IUsdcWithdrawFeeQuote,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+const CORE_DEPOSIT_WALLET_ADDRESS =
+  '0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24';
+const CCTP_WITHDRAW_FEE_SELECTOR = 'e26f7d23';
+const CCTP_WITHDRAW_FEE_CACHE_TTL_MS = 5 * 60 * 1000;
+const USDC_DECIMALS = 6;
+
+export type IHyperEvmRpcCall = (
+  method: string,
+  params: unknown[],
+) => Promise<unknown>;
+
+interface ICctpWithdrawFeeCacheEntry {
+  fee: number;
+  fetchedAt: number;
+}
+
+export interface ICctpWithdrawDestinationActionFields {
+  config: ICctpWithdrawDestinationConfig;
+  destinationRecipient: string;
+  addressEncoding: 'hex';
+  destinationChainId: number;
+  gasLimit: number;
+  data: IHex;
+}
+
+const cachedFees = new Map<
+  IUsdcWithdrawDestinationId,
+  ICctpWithdrawFeeCacheEntry
+>();
+const inFlightFeeRequests = new Map<
+  IUsdcWithdrawDestinationId,
+  Promise<IUsdcWithdrawFeeComponent>
+>();
+
+export function requireUsdcWithdrawDestination(
+  destinationId: string,
+): IUsdcWithdrawDestinationConfig {
+  const config = getUsdcWithdrawDestination(destinationId);
+  if (!config) {
+    throw new OneKeyLocalError(
+      `Unsupported USDC withdrawal destination: ${destinationId}`,
+    );
+  }
+  return config;
+}
+
+function encodeWithdrawFeeCall(destinationDomain: number): IHex {
+  const useForwarding = '1'.padStart(64, '0');
+  const domain = destinationDomain.toString(16).padStart(64, '0');
+  return `0x${CCTP_WITHDRAW_FEE_SELECTOR}${useForwarding}${domain}` as IHex;
+}
+
+function parseWithdrawFee(result: unknown): number {
+  if (typeof result !== 'string' || !/^0x[0-9a-fA-F]+$/.test(result)) {
+    throw new OneKeyLocalError('Invalid CCTP withdrawal fee response');
+  }
+  const fee = new BigNumber(result.slice(2), 16)
+    .shiftedBy(-USDC_DECIMALS)
+    .toNumber();
+  if (!Number.isFinite(fee) || fee < 0) {
+    throw new OneKeyLocalError('Invalid CCTP withdrawal fee value');
+  }
+  return fee;
+}
+
+async function fetchCctpWithdrawFee(
+  config: ICctpWithdrawDestinationConfig,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<number> {
+  const result = await rpcCall('eth_call', [
+    {
+      to: CORE_DEPOSIT_WALLET_ADDRESS,
+      data: encodeWithdrawFeeCall(config.domain),
+    },
+    'latest',
+  ]);
+  return parseWithdrawFee(result);
+}
+
+async function getCctpWithdrawFee(
+  destinationId: IUsdcWithdrawDestinationId,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<IUsdcWithdrawFeeComponent> {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType !== 'cctp') {
+    throw new OneKeyLocalError(
+      `Destination does not have a CCTP fee: ${destinationId}`,
+    );
+  }
+  const cached = cachedFees.get(destinationId);
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < CCTP_WITHDRAW_FEE_CACHE_TTL_MS) {
+    return {
+      kind: 'cctpForwarding',
+      amount: cached.fee.toString(),
+      token: 'USDC',
+      debitedFrom: 'withdrawAmount',
+      isEstimate: false,
+    };
+  }
+
+  const inFlight = inFlightFeeRequests.get(destinationId);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = fetchCctpWithdrawFee(config, rpcCall)
+    .then((fee) => {
+      cachedFees.set(destinationId, { fee, fetchedAt: Date.now() });
+      return {
+        kind: 'cctpForwarding' as const,
+        amount: fee.toString(),
+        token: 'USDC' as const,
+        debitedFrom: 'withdrawAmount' as const,
+        isEstimate: false,
+      };
+    })
+    .catch(() => ({
+      kind: 'cctpForwarding' as const,
+      amount: config.fallbackFee.toString(),
+      token: 'USDC' as const,
+      debitedFrom: 'withdrawAmount' as const,
+      isEstimate: true,
+    }))
+    .finally(() => {
+      inFlightFeeRequests.delete(destinationId);
+    });
+  inFlightFeeRequests.set(destinationId, request);
+  return request;
+}
+
+export async function getUsdcWithdrawFee(
+  destinationId: IUsdcWithdrawDestinationId,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<IUsdcWithdrawFeeQuote> {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType === 'hyperEvm') {
+    return {
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: Date.now(),
+    };
+  }
+  const cctpFee = await getCctpWithdrawFee(destinationId, rpcCall);
+  return {
+    components: [cctpFee],
+    quotedAt: Date.now(),
+  };
+}
+
+// Submission must not rely on a cached or static CCTP fallback fee. The contract
+// can update per-domain USDC fees, while direct HyperEVM sends have no CCTP fee.
+export async function getLiveUsdcWithdrawFee(
+  destinationId: IUsdcWithdrawDestinationId,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<IUsdcWithdrawFeeQuote> {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType === 'hyperEvm') {
+    return {
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: Date.now(),
+    };
+  }
+  const cctpFee = await fetchCctpWithdrawFee(config, rpcCall);
+  cachedFees.set(destinationId, { fee: cctpFee, fetchedAt: Date.now() });
+  return {
+    components: [
+      {
+        kind: 'cctpForwarding',
+        amount: cctpFee.toString(),
+        token: 'USDC',
+        debitedFrom: 'withdrawAmount',
+        isEstimate: false,
+      },
+    ],
+    quotedAt: Date.now(),
+  };
+}
+
+export function buildCctpWithdrawDestination({
+  destinationId,
+  ownerAddress,
+}: {
+  destinationId: IUsdcWithdrawDestinationId;
+  ownerAddress: string;
+}): ICctpWithdrawDestinationActionFields {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType !== 'cctp') {
+    throw new OneKeyLocalError(
+      `Destination does not use CCTP: ${destinationId}`,
+    );
+  }
+
+  return {
+    config,
+    destinationRecipient: ownerAddress,
+    addressEncoding: config.addressEncoding,
+    destinationChainId: config.domain,
+    gasLimit: CCTP_WITHDRAW_GAS_LIMIT,
+    data: CCTP_WITHDRAW_HOOK_DATA,
+  };
+}
+
+export function clearUsdcWithdrawFeeCacheForTest() {
+  cachedFees.clear();
+  inFlightFeeRequests.clear();
+}

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
@@ -105,6 +105,24 @@ describe('usdc withdraw route resolution', () => {
     jest.spyOn(Date, 'now').mockRestore();
   });
 
+  // A 200 we cannot read is not a rail change; treating it as one would pin the
+  // user to the more expensive bridge for the whole cache window.
+  it('keeps the confirmed rail when a later response is unreadable', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.now() + 10 * 60 * 1000);
+    requestMock.mockResolvedValue({ status: 'err', response: 'boom' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+
+    // Still not cached, so the next lookup asks again rather than serving it.
+    requestMock.mockResolvedValue({ withdrawalRoute: 'bridge' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+    nowSpy.mockRestore();
+  });
+
   it('shares one in-flight lookup between concurrent callers', async () => {
     requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
     const [first, second] = await Promise.all([

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
@@ -1,0 +1,83 @@
+import {
+  clearUsdcWithdrawRouteCacheForTest,
+  getUsdcWithdrawRoute,
+} from './usdcWithdrawRoute';
+
+const requestMock = jest.fn<Promise<unknown>, unknown[]>();
+
+jest.mock('@nktkas/hyperliquid', () => ({
+  HttpTransport: jest.fn().mockImplementation(() => ({
+    request: (...args: unknown[]) => requestMock(...args),
+  })),
+}));
+
+describe('usdc withdraw route resolution', () => {
+  beforeEach(() => {
+    clearUsdcWithdrawRouteCacheForTest();
+    requestMock.mockReset();
+  });
+
+  it('follows the rail Hyperliquid is serving', async () => {
+    requestMock.mockResolvedValue({
+      depositRoute: 'cctp',
+      withdrawalRoute: 'cctp',
+    });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+    expect(requestMock).toHaveBeenCalledWith('info', { type: 'usdcRouting' });
+  });
+
+  it('follows a switch back to the legacy bridge', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'bridge' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+  });
+
+  // A rail we do not implement must not be forwarded to the exchange call.
+  it('falls back to the legacy bridge for an unrecognized rail', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'something-new' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+  });
+
+  it('falls back to the legacy bridge when the request fails', async () => {
+    requestMock.mockRejectedValue(new Error('network down'));
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+  });
+
+  it('caches the resolved rail instead of asking on every withdrawal', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
+    await getUsdcWithdrawRoute();
+    await getUsdcWithdrawRoute();
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A failure must not be cached, or one flaky response would pin every later
+  // withdrawal to the more expensive rail for the whole cache window.
+  it('retries after a failed lookup', async () => {
+    requestMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+    requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
+
+  // Downgrading a user to the deprecated rail because one lookup failed would
+  // silently quadruple their fee.
+  it('keeps the last confirmed rail when a later lookup fails', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+
+    jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 10 * 60 * 1000);
+    requestMock.mockRejectedValue(new Error('network down'));
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+    jest.spyOn(Date, 'now').mockRestore();
+  });
+
+  it('shares one in-flight lookup between concurrent callers', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
+    const [first, second] = await Promise.all([
+      getUsdcWithdrawRoute(),
+      getUsdcWithdrawRoute(),
+    ]);
+    expect([first, second]).toEqual(['cctp', 'cctp']);
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
@@ -83,8 +83,7 @@ describe('usdc withdraw route resolution', () => {
     }
   });
 
-  // A failure must not be cached, or one flaky response would pin every later
-  // withdrawal to the more expensive rail for the whole cache window.
+  // Caching a failure would pin later withdrawals to the pricier rail.
   it('retries after a failed lookup', async () => {
     requestMock.mockRejectedValueOnce(new Error('network down'));
     await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
@@ -93,8 +92,7 @@ describe('usdc withdraw route resolution', () => {
     expect(requestMock).toHaveBeenCalledTimes(2);
   });
 
-  // Downgrading a user to the deprecated rail because one lookup failed would
-  // silently quadruple their fee.
+  // One failed lookup must not quadruple the user's fee.
   it('keeps the last confirmed rail when a later lookup fails', async () => {
     requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
     await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
@@ -105,8 +103,7 @@ describe('usdc withdraw route resolution', () => {
     jest.spyOn(Date, 'now').mockRestore();
   });
 
-  // A 200 we cannot read is not a rail change; treating it as one would pin the
-  // user to the more expensive bridge for the whole cache window.
+  // An unreadable 200 is not a rail change.
   it('keeps the confirmed rail when a later response is unreadable', async () => {
     requestMock.mockResolvedValue({ withdrawalRoute: 'cctp' });
     await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
@@ -1,9 +1,23 @@
 import {
+  USDC_WITHDRAW_DESTINATIONS,
+  USDC_WITHDRAW_GAS_RESERVE,
+  getUsdcWithdrawDestination,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+
+import {
+  buildCctpWithdrawDestination,
+  clearUsdcWithdrawFeeCacheForTest,
+  getLiveUsdcWithdrawFee,
+  getUsdcWithdrawFee,
+} from './cctpWithdraw';
+import {
   clearUsdcWithdrawRouteCacheForTest,
+  getLiveUsdcWithdrawRoute,
   getUsdcWithdrawRoute,
 } from './usdcWithdrawRoute';
 
 const requestMock = jest.fn<Promise<unknown>, unknown[]>();
+const rpcCallMock = jest.fn<Promise<unknown>, [string, unknown[]]>();
 
 jest.mock('@nktkas/hyperliquid', () => ({
   HttpTransport: jest.fn().mockImplementation(() => ({
@@ -49,6 +63,26 @@ describe('usdc withdraw route resolution', () => {
     expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses the resolved rail for five minutes', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    try {
+      requestMock
+        .mockResolvedValueOnce({ withdrawalRoute: 'cctp' })
+        .mockResolvedValueOnce({ withdrawalRoute: 'bridge' });
+
+      await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+      nowSpy.mockReturnValue(1000 + 5 * 60 * 1000 - 1);
+      await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+      expect(requestMock).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockReturnValue(1000 + 5 * 60 * 1000);
+      await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+      expect(requestMock).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   // A failure must not be cached, or one flaky response would pin every later
   // withdrawal to the more expensive rail for the whole cache window.
   it('retries after a failed lookup', async () => {
@@ -79,5 +113,146 @@ describe('usdc withdraw route resolution', () => {
     ]);
     expect([first, second]).toEqual(['cctp', 'cctp']);
     expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the live rail before submission instead of using the UI cache', async () => {
+    requestMock.mockResolvedValueOnce({ withdrawalRoute: 'cctp' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+
+    requestMock.mockResolvedValueOnce({ withdrawalRoute: 'bridge' });
+    await expect(getLiveUsdcWithdrawRoute()).resolves.toBe('bridge');
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an unknown live rail instead of silently falling back', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'something-new' });
+    await expect(getLiveUsdcWithdrawRoute()).rejects.toThrow(
+      'Unsupported Hyperliquid withdrawal route',
+    );
+  });
+});
+
+describe('usdc withdraw destinations and fees', () => {
+  beforeEach(() => {
+    clearUsdcWithdrawFeeCacheForTest();
+    rpcCallMock.mockReset();
+  });
+
+  it('supports HyperEVM instead of Solana', () => {
+    expect(USDC_WITHDRAW_DESTINATIONS.map((item) => item.id)).toEqual([
+      'ethereum',
+      'avalanche',
+      'optimism',
+      'arbitrum',
+      'base',
+      'hyperevm',
+    ]);
+    expect(getUsdcWithdrawDestination('solana')).toBeUndefined();
+    expect(getUsdcWithdrawDestination('hyperevm')).toEqual({
+      id: 'hyperevm',
+      name: 'HyperEVM',
+      networkId: 'evm--999',
+      transferType: 'hyperEvm',
+      signatureChainId: '0xa4b1',
+    });
+    expect(
+      USDC_WITHDRAW_DESTINATIONS.filter(
+        (item) => item.transferType === 'cctp',
+      ).map((item) => [item.id, item.domain, item.fallbackFee]),
+    ).toEqual([
+      ['ethereum', 0, 1.2],
+      ['avalanche', 1, 0.2],
+      ['optimism', 2, 0.2],
+      ['arbitrum', 3, 0.2],
+      ['base', 6, 0.2],
+    ]);
+  });
+
+  it('builds the selected external CCTP destination', () => {
+    expect(
+      buildCctpWithdrawDestination({
+        destinationId: 'arbitrum',
+        ownerAddress: '0x0000000000000000000000000000000000000001',
+      }),
+    ).toMatchObject({
+      destinationRecipient: '0x0000000000000000000000000000000000000001',
+      addressEncoding: 'hex',
+      destinationChainId: 3,
+      gasLimit: 200_000,
+      data: '0x',
+    });
+    expect(() =>
+      buildCctpWithdrawDestination({
+        destinationId: 'hyperevm',
+        ownerAddress: '0x0000000000000000000000000000000000000001',
+      }),
+    ).toThrow('Destination does not use CCTP: hyperevm');
+  });
+
+  it('quotes only the CCTP forwarding fee through RPC', async () => {
+    rpcCallMock.mockResolvedValue('0x30d40');
+
+    await expect(getUsdcWithdrawFee('arbitrum', rpcCallMock)).resolves.toEqual({
+      components: [
+        {
+          kind: 'cctpForwarding',
+          amount: '0.2',
+          token: 'USDC',
+          debitedFrom: 'withdrawAmount',
+          isEstimate: false,
+        },
+      ],
+      quotedAt: expect.any(Number),
+    });
+    expect(rpcCallMock).toHaveBeenCalledTimes(1);
+    expect(rpcCallMock.mock.calls.map(([method]) => method)).toEqual([
+      'eth_call',
+    ]);
+    const cctpRequest = rpcCallMock.mock.calls.find(
+      ([method]) => method === 'eth_call',
+    );
+    expect((cctpRequest?.[1][0] as { data: string }).data).toBe(
+      `0xe26f7d23${'1'.padStart(64, '0')}${'3'.padStart(64, '0')}`,
+    );
+  });
+
+  it('marks the CCTP fallback as estimated', async () => {
+    rpcCallMock.mockRejectedValue(new Error('network down'));
+    await expect(getUsdcWithdrawFee('ethereum', rpcCallMock)).resolves.toEqual({
+      components: [
+        {
+          kind: 'cctpForwarding',
+          amount: '1.2',
+          token: 'USDC',
+          debitedFrom: 'withdrawAmount',
+          isEstimate: true,
+        },
+      ],
+      quotedAt: expect.any(Number),
+    });
+  });
+
+  it('shows a sub-cent HyperEVM fee without making an RPC call', async () => {
+    await expect(getUsdcWithdrawFee('hyperevm', rpcCallMock)).resolves.toEqual({
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: expect.any(Number),
+    });
+    expect(rpcCallMock).not.toHaveBeenCalled();
+  });
+
+  it('does not use an estimated fallback for the submission fee check', async () => {
+    rpcCallMock.mockRejectedValue(new Error('network down'));
+    await expect(
+      getLiveUsdcWithdrawFee('arbitrum', rpcCallMock),
+    ).rejects.toThrow('network down');
   });
 });

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
@@ -1,0 +1,75 @@
+import { HttpTransport } from '@nktkas/hyperliquid';
+
+import { requestLoggedHyperLiquidTransport } from './utils/logHyperLiquidApiFailure';
+
+// Hyperliquid moved USDC to Circle CCTP and marked the legacy Arbitrum bridge
+// deprecated, but kept serving the active rail from `info/usdcRouting` so it can
+// be switched back. Follow that switch instead of pinning a rail in the bundle.
+export type IUsdcWithdrawRoute = 'bridge' | 'cctp';
+
+// `usdcRouting` is absent from the pinned @nktkas/hyperliquid info client, so the
+// request goes through the transport directly rather than bumping the SDK on a
+// release branch.
+interface IUsdcRoutingResponse {
+  depositRoute?: string;
+  withdrawalRoute?: string;
+}
+
+const ROUTE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+// An unreachable or unparsable response tells us nothing new, so fall back to the
+// rail that has been working in production all along. It costs the legacy $1 fee
+// instead of risking a rail Hyperliquid may have turned off.
+const FALLBACK_ROUTE: IUsdcWithdrawRoute = 'bridge';
+
+let cachedRoute: { route: IUsdcWithdrawRoute; fetchedAt: number } | undefined;
+// A rail Hyperliquid confirmed earlier beats the blind fallback: once cctp has
+// been observed live, a later lookup failure must not silently downgrade the
+// user to a rail that is on its way out.
+let lastResolvedRoute: IUsdcWithdrawRoute | undefined;
+let inFlightRequest: Promise<IUsdcWithdrawRoute> | undefined;
+
+function parseRoute(value: unknown): IUsdcWithdrawRoute | undefined {
+  return value === 'cctp' || value === 'bridge' ? value : undefined;
+}
+
+async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+  const response =
+    await requestLoggedHyperLiquidTransport<IUsdcRoutingResponse>(
+      new HttpTransport(),
+      'info',
+      { type: 'usdcRouting' },
+      { action: 'usdcRouting' },
+    );
+  return parseRoute(response?.withdrawalRoute) ?? FALLBACK_ROUTE;
+}
+
+export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+  const now = Date.now();
+  if (cachedRoute && now - cachedRoute.fetchedAt < ROUTE_CACHE_TTL_MS) {
+    return cachedRoute.route;
+  }
+  if (!inFlightRequest) {
+    inFlightRequest = fetchWithdrawRoute()
+      .then((route) => {
+        cachedRoute = { route, fetchedAt: Date.now() };
+        lastResolvedRoute = route;
+        return route;
+      })
+      .catch(() => {
+        // requestLoggedHyperLiquidTransport already reported the failure; a
+        // withdrawal must still resolve to a usable rail.
+        return lastResolvedRoute ?? FALLBACK_ROUTE;
+      })
+      .finally(() => {
+        inFlightRequest = undefined;
+      });
+  }
+  return inFlightRequest;
+}
+
+export function clearUsdcWithdrawRouteCacheForTest() {
+  cachedRoute = undefined;
+  lastResolvedRoute = undefined;
+  inFlightRequest = undefined;
+}

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
@@ -1,5 +1,7 @@
 import { HttpTransport } from '@nktkas/hyperliquid';
 
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 import { requestLoggedHyperLiquidTransport } from './utils/logHyperLiquidApiFailure';
 
 // Hyperliquid moved USDC to Circle CCTP and marked the legacy Arbitrum bridge
@@ -33,7 +35,11 @@ function parseRoute(value: unknown): IUsdcWithdrawRoute | undefined {
   return value === 'cctp' || value === 'bridge' ? value : undefined;
 }
 
-async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+async function fetchWithdrawRoute({
+  allowFallback,
+}: {
+  allowFallback: boolean;
+}): Promise<IUsdcWithdrawRoute> {
   const response =
     await requestLoggedHyperLiquidTransport<IUsdcRoutingResponse>(
       new HttpTransport(),
@@ -41,7 +47,11 @@ async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
       { type: 'usdcRouting' },
       { action: 'usdcRouting' },
     );
-  return parseRoute(response?.withdrawalRoute) ?? FALLBACK_ROUTE;
+  const route = parseRoute(response?.withdrawalRoute);
+  if (!route && !allowFallback) {
+    throw new OneKeyLocalError('Unsupported Hyperliquid withdrawal route');
+  }
+  return route ?? FALLBACK_ROUTE;
 }
 
 export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
@@ -50,7 +60,7 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
     return cachedRoute.route;
   }
   if (!inFlightRequest) {
-    inFlightRequest = fetchWithdrawRoute()
+    inFlightRequest = fetchWithdrawRoute({ allowFallback: true })
       .then((route) => {
         cachedRoute = { route, fetchedAt: Date.now() };
         lastResolvedRoute = route;
@@ -66,6 +76,15 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
       });
   }
   return inFlightRequest;
+}
+
+// A submission must be bound to the route that Hyperliquid is serving now.
+// Falling back here could silently change both the rail and the charged fee.
+export async function getLiveUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+  const route = await fetchWithdrawRoute({ allowFallback: false });
+  cachedRoute = { route, fetchedAt: Date.now() };
+  lastResolvedRoute = route;
+  return route;
 }
 
 export function clearUsdcWithdrawRouteCacheForTest() {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
@@ -4,14 +4,12 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
 import { requestLoggedHyperLiquidTransport } from './utils/logHyperLiquidApiFailure';
 
-// Hyperliquid moved USDC to Circle CCTP and marked the legacy Arbitrum bridge
-// deprecated, but kept serving the active rail from `info/usdcRouting` so it can
-// be switched back. Follow that switch instead of pinning a rail in the bundle.
+// Hyperliquid deprecated the legacy Arbitrum bridge for CCTP but kept a switch to
+// revert, so follow `info/usdcRouting` instead of pinning a rail in the bundle.
 export type IUsdcWithdrawRoute = 'bridge' | 'cctp';
 
-// `usdcRouting` is absent from the pinned @nktkas/hyperliquid info client, so the
-// request goes through the transport directly rather than bumping the SDK on a
-// release branch.
+// Absent from the pinned SDK's info client, so the request goes through the
+// transport rather than bumping @nktkas/hyperliquid on a release branch.
 interface IUsdcRoutingResponse {
   depositRoute?: string;
   withdrawalRoute?: string;
@@ -19,15 +17,13 @@ interface IUsdcRoutingResponse {
 
 const ROUTE_CACHE_TTL_MS = 5 * 60 * 1000;
 
-// An unreachable or unparsable response tells us nothing new, so fall back to the
-// rail that has been working in production all along. It costs the legacy $1 fee
-// instead of risking a rail Hyperliquid may have turned off.
+// A failed lookup teaches us nothing, so fall back to the rail that has always
+// worked rather than one Hyperliquid may have turned off.
 const FALLBACK_ROUTE: IUsdcWithdrawRoute = 'bridge';
 
 let cachedRoute: { route: IUsdcWithdrawRoute; fetchedAt: number } | undefined;
-// A rail Hyperliquid confirmed earlier beats the blind fallback: once cctp has
-// been observed live, a later lookup failure must not silently downgrade the
-// user to a rail that is on its way out.
+// A rail seen live beats the blind fallback, so one failed lookup cannot
+// downgrade the user to the 5x more expensive bridge.
 let lastResolvedRoute: IUsdcWithdrawRoute | undefined;
 let inFlightRequest: Promise<IUsdcWithdrawRoute> | undefined;
 
@@ -35,10 +31,8 @@ function parseRoute(value: unknown): IUsdcWithdrawRoute | undefined {
   return value === 'cctp' || value === 'bridge' ? value : undefined;
 }
 
-// Resolves to undefined when Hyperliquid answers with something we cannot read,
-// which callers must not confuse with a genuine switch to the legacy bridge:
-// `requestLoggedHyperLiquidTransport` reports `{ status: 'err' }` bodies but
-// still returns them, and a missing or unknown `withdrawalRoute` lands here too.
+// Undefined for anything unreadable, which callers must not confuse with a real
+// switch to the bridge: error-shaped bodies are logged but still returned.
 async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute | undefined> {
   const response =
     await requestLoggedHyperLiquidTransport<IUsdcRoutingResponse>(
@@ -59,8 +53,7 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
     inFlightRequest = fetchWithdrawRoute()
       .then((route) => {
         if (!route) {
-          // Neither cache nor remember an unreadable answer, or one malformed
-          // response would pin the user to the fallback rail for the whole TTL.
+          // Caching this would pin the user to the fallback for the whole TTL.
           return lastResolvedRoute ?? FALLBACK_ROUTE;
         }
         cachedRoute = { route, fetchedAt: Date.now() };
@@ -68,8 +61,7 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
         return route;
       })
       .catch(() => {
-        // requestLoggedHyperLiquidTransport already reported the failure; a
-        // withdrawal must still resolve to a usable rail.
+        // Already reported upstream; a withdrawal still needs a usable rail.
         return lastResolvedRoute ?? FALLBACK_ROUTE;
       })
       .finally(() => {
@@ -79,8 +71,8 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
   return inFlightRequest;
 }
 
-// A submission must be bound to the route that Hyperliquid is serving now.
-// Falling back here could silently change both the rail and the charged fee.
+// Submission binds to the rail being served now; a fallback here would silently
+// change both the rail and the charged fee.
 export async function getLiveUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
   const route = await fetchWithdrawRoute();
   if (!route) {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
@@ -35,11 +35,11 @@ function parseRoute(value: unknown): IUsdcWithdrawRoute | undefined {
   return value === 'cctp' || value === 'bridge' ? value : undefined;
 }
 
-async function fetchWithdrawRoute({
-  allowFallback,
-}: {
-  allowFallback: boolean;
-}): Promise<IUsdcWithdrawRoute> {
+// Resolves to undefined when Hyperliquid answers with something we cannot read,
+// which callers must not confuse with a genuine switch to the legacy bridge:
+// `requestLoggedHyperLiquidTransport` reports `{ status: 'err' }` bodies but
+// still returns them, and a missing or unknown `withdrawalRoute` lands here too.
+async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute | undefined> {
   const response =
     await requestLoggedHyperLiquidTransport<IUsdcRoutingResponse>(
       new HttpTransport(),
@@ -47,11 +47,7 @@ async function fetchWithdrawRoute({
       { type: 'usdcRouting' },
       { action: 'usdcRouting' },
     );
-  const route = parseRoute(response?.withdrawalRoute);
-  if (!route && !allowFallback) {
-    throw new OneKeyLocalError('Unsupported Hyperliquid withdrawal route');
-  }
-  return route ?? FALLBACK_ROUTE;
+  return parseRoute(response?.withdrawalRoute);
 }
 
 export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
@@ -60,8 +56,13 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
     return cachedRoute.route;
   }
   if (!inFlightRequest) {
-    inFlightRequest = fetchWithdrawRoute({ allowFallback: true })
+    inFlightRequest = fetchWithdrawRoute()
       .then((route) => {
+        if (!route) {
+          // Neither cache nor remember an unreadable answer, or one malformed
+          // response would pin the user to the fallback rail for the whole TTL.
+          return lastResolvedRoute ?? FALLBACK_ROUTE;
+        }
         cachedRoute = { route, fetchedAt: Date.now() };
         lastResolvedRoute = route;
         return route;
@@ -81,7 +82,10 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
 // A submission must be bound to the route that Hyperliquid is serving now.
 // Falling back here could silently change both the rail and the charged fee.
 export async function getLiveUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
-  const route = await fetchWithdrawRoute({ allowFallback: false });
+  const route = await fetchWithdrawRoute();
+  if (!route) {
+    throw new OneKeyLocalError('Unsupported Hyperliquid withdrawal route');
+  }
   cachedRoute = { route, fetchedAt: Date.now() };
   lastResolvedRoute = route;
   return route;

--- a/packages/kit-bg/src/states/jotai/atoms/perps.test.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.test.ts
@@ -17,6 +17,7 @@ import {
   perpsActiveAccountStatusInfoAtom,
   perpsActiveAccountSummaryAtom,
   perpsComputedAccountValueAtom,
+  perpsCustomSettingsAtom,
   perpsShouldShowEnableTradingButtonAtom,
   perpsSpotBalancesAtom,
   tradingModeAtom,
@@ -43,6 +44,17 @@ describe('tradingModeAtom', () => {
     expect(atomsConfig[EAtomNames.tradingModeAtom]?.mergeInitialValue).toBe(
       false,
     );
+  });
+});
+
+describe('perpsCustomSettingsAtom', () => {
+  it('persists Arbitrum as the initial USDC withdrawal destination', () => {
+    const atom = perpsCustomSettingsAtom.atom() as unknown as IJotaiAtomPro<{
+      lastUsdcWithdrawDestinationId: string;
+    }>;
+
+    expect(atom.persist).toBe(true);
+    expect(atom.initialValue.lastUsdcWithdrawDestinationId).toBe('arbitrum');
   });
 });
 

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -20,7 +20,11 @@ import {
   EPerpUserType,
   ETriggerOrderType,
 } from '@onekeyhq/shared/types/hyperliquid';
-import { DEFAULT_PERP_TOKEN_ACTIVE_TAB } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import {
+  DEFAULT_PERP_TOKEN_ACTIVE_TAB,
+  DEFAULT_USDC_WITHDRAW_DESTINATION_ID,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IUsdcWithdrawDestinationId } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 import { EAtomNames } from '../atomNames';
@@ -979,6 +983,7 @@ export interface IPerpsCustomSettings {
   showChartLines: boolean;
   lastTriggerOrderType: ETriggerOrderType;
   lastAdvancedOrderType?: IPerpsLastAdvancedOrderType;
+  lastUsdcWithdrawDestinationId: IUsdcWithdrawDestinationId;
 }
 export const {
   target: perpsCustomSettingsAtom,
@@ -992,6 +997,7 @@ export const {
     showChartLines: true,
     lastTriggerOrderType: ETriggerOrderType.TRIGGER_MARKET,
     lastAdvancedOrderType: ETriggerOrderType.TRIGGER_MARKET,
+    lastUsdcWithdrawDestinationId: DEFAULT_USDC_WITHDRAW_DESTINATION_ID,
   },
 });
 

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -82,6 +82,7 @@ import type {
   ISpotUniverse,
 } from '@onekeyhq/shared/types/hyperliquid';
 import { SUB_DEX_LIST } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IUsdcWithdrawDestinationId } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type * as HL from '@onekeyhq/shared/types/hyperliquid/sdk';
 import {
   EPerpsSizeInputMode,
@@ -3469,7 +3470,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       params: {
         userAccountId: string;
         amount: string;
-        destination: `0x${string}`;
+        destinationId: IUsdcWithdrawDestinationId;
+        expectedRoute?: 'bridge' | 'cctp';
+        expectedCctpFee?: string;
       },
     ) => {
       return withToast({
@@ -3477,7 +3480,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           await backgroundApiProxy.serviceHyperliquidExchange.withdraw({
             userAccountId: params.userAccountId,
             amount: params.amount,
-            destination: params.destination,
+            destinationId: params.destinationId,
+            expectedRoute: params.expectedRoute,
+            expectedCctpFee: params.expectedCctpFee,
           });
         },
         actionType: EActionType.WITHDRAW,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
@@ -158,6 +158,13 @@ const TYPE_CONFIG_DATA = new Map<string, ITypeConfigRaw>([
     },
   ],
   [
+    'sendOut',
+    {
+      translationId: ETranslations.perp_account_action_tranfer,
+      isIncrease: false,
+    },
+  ],
+  [
     'liquidation',
     {
       translationId: ETranslations.perp_account_history_liquidation,
@@ -188,6 +195,19 @@ const getDisplayType = (
   delta: IUserNonFundingLedgerUpdate['delta'],
   currentAddress?: string | null,
 ): string => {
+  // A `send` carries both directions on the same ledger. Outgoing ones include
+  // CCTP withdrawals and Core -> HyperEVM transfers, which would otherwise render
+  // as money coming in. Transfers between the user's own balances keep the
+  // existing rendering, since neither direction describes them.
+  if (deltaType === 'send') {
+    const isSentToOthers =
+      'user' in delta &&
+      'destination' in delta &&
+      currentAddress &&
+      delta.user.toLowerCase() === currentAddress.toLowerCase() &&
+      delta.destination.toLowerCase() !== currentAddress.toLowerCase();
+    return isSentToOthers ? 'sendOut' : 'send';
+  }
   if (!TRANSFER_TYPES.has(deltaType)) {
     return deltaType;
   }

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
@@ -195,10 +195,8 @@ const getDisplayType = (
   delta: IUserNonFundingLedgerUpdate['delta'],
   currentAddress?: string | null,
 ): string => {
-  // A `send` carries both directions on the same ledger. Outgoing ones include
-  // CCTP withdrawals and Core -> HyperEVM transfers, which would otherwise render
-  // as money coming in. Transfers between the user's own balances keep the
-  // existing rendering, since neither direction describes them.
+  // `send` carries both directions, and the shared config renders money coming
+  // in — so a withdrawal would show as a credit. Self-transfers are neither.
   if (deltaType === 'send') {
     const isSentToOthers =
       'user' in delta &&

--- a/packages/kit/src/views/Perp/components/Portfolio/portfolioStats.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/portfolioStats.ts
@@ -240,10 +240,9 @@ export function buildPerpPortfolioFillsStats({
   };
 }
 
-// "Total deposits minus total withdrawals during this period", per the stat's
-// own tooltip, so an account's internal perp/spot moves must not count. USDC
-// leaves HyperCore as a `send` to the HyperEVM system address and comes back as
-// a `spotTransfer` from it, and both legs are needed or a round trip drifts.
+// Per its own tooltip this is deposits minus withdrawals, so internal perp/spot
+// moves must not count. USDC leaves HyperCore as a `send` to the system address
+// and returns as a `spotTransfer` from it; both legs or a round trip drifts.
 export function sumPerpsNetDeposits(
   updates: IUserNonFundingLedgerUpdatesResponse | undefined | null,
 ): number | null {

--- a/packages/kit/src/views/Perp/components/Portfolio/portfolioStats.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/portfolioStats.ts
@@ -1,10 +1,12 @@
 import BigNumber from 'bignumber.js';
 
 import { isSpotInstrument } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { HYPEREVM_SYSTEM_ADDRESS } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IFill,
   IPortfolio,
   IPortfolioMetrics,
+  IUserNonFundingLedgerUpdatesResponse,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 export type IPortfolioTimePeriod = 'day' | 'week' | 'month' | 'allTime';
@@ -236,4 +238,43 @@ export function buildPerpPortfolioFillsStats({
     spotRealizedPnl,
     totalTrades: filteredFills.length,
   };
+}
+
+// "Total deposits minus total withdrawals during this period", per the stat's
+// own tooltip, so an account's internal perp/spot moves must not count. USDC
+// leaves HyperCore as a `send` to the HyperEVM system address and comes back as
+// a `spotTransfer` from it, and both legs are needed or a round trip drifts.
+export function sumPerpsNetDeposits(
+  updates: IUserNonFundingLedgerUpdatesResponse | undefined | null,
+): number | null {
+  if (!updates) {
+    return null;
+  }
+  const systemAddress = HYPEREVM_SYSTEM_ADDRESS.toLowerCase();
+  return updates
+    .reduce((sum, update) => {
+      const { delta } = update;
+      if (delta.type === 'deposit' && delta.usdc) {
+        return sum.plus(delta.usdc);
+      }
+      if (delta.type === 'withdraw' && delta.usdc) {
+        return sum.minus(delta.usdc);
+      }
+      if (delta.type === 'send' && delta.token === 'USDC' && delta.amount) {
+        if (delta.destination?.toLowerCase() === systemAddress) {
+          return sum.minus(delta.amount);
+        }
+        return sum;
+      }
+      if (
+        delta.type === 'spotTransfer' &&
+        delta.token === 'USDC' &&
+        delta.user?.toLowerCase() === systemAddress &&
+        delta.amount
+      ) {
+        return sum.plus(delta.amount);
+      }
+      return sum;
+    }, new BigNumber(0))
+    .toNumber();
 }

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.test.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.test.ts
@@ -3,6 +3,7 @@ import type { IFill } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import {
   buildPerpPortfolioFillsStats,
   buildPortfolioChartData,
+  sumPerpsNetDeposits,
 } from './portfolioStats';
 
 const NOW = 1_700_000_000_000;
@@ -197,5 +198,161 @@ describe('buildPortfolioChartData', () => {
       [1_700_000_060, 5],
     ]);
     expect(chartData?.vlm).toBe('100');
+  });
+});
+
+describe('sumPerpsNetDeposits', () => {
+  const SYSTEM = '0x2000000000000000000000000000000000000000';
+  const ME = '0x4ef880525383ab4e3d94b7689e3146bf899a296e';
+
+  const ledger = (deltas: Record<string, unknown>[]) =>
+    deltas.map((delta, index) => ({
+      time: NOW + index,
+      hash: `0x${index}`,
+      delta,
+    })) as unknown as Parameters<typeof sumPerpsNetDeposits>[0];
+
+  it('counts bridge deposits and legacy withdrawals', () => {
+    expect(
+      sumPerpsNetDeposits(
+        ledger([
+          { type: 'deposit', usdc: '100' },
+          { type: 'withdraw', usdc: '30', fee: '1.0' },
+        ]),
+      ),
+    ).toBe(70);
+  });
+
+  // A CCTP withdrawal is a `send` to the system address, not a `withdraw`.
+  it('counts a CCTP withdrawal as an outflow', () => {
+    expect(
+      sumPerpsNetDeposits(
+        ledger([
+          { type: 'deposit', usdc: '100' },
+          {
+            type: 'send',
+            user: ME,
+            destination: SYSTEM,
+            sourceDex: 'spot',
+            destinationDex: 'spot',
+            token: 'USDC',
+            amount: '40',
+          },
+        ]),
+      ),
+    ).toBe(60);
+  });
+
+  // The source balance must not matter: withdrawals from a unified account are
+  // sourced from spot, and dropping those would hide every withdrawal we make.
+  it('counts a withdrawal whichever balance it is sourced from', () => {
+    const fromSpot = sumPerpsNetDeposits(
+      ledger([
+        {
+          type: 'send',
+          user: ME,
+          destination: SYSTEM,
+          sourceDex: 'spot',
+          destinationDex: 'spot',
+          token: 'USDC',
+          amount: '10',
+        },
+      ]),
+    );
+    const fromPerp = sumPerpsNetDeposits(
+      ledger([
+        {
+          type: 'send',
+          user: ME,
+          destination: SYSTEM,
+          sourceDex: '',
+          destinationDex: 'spot',
+          token: 'USDC',
+          amount: '10',
+        },
+      ]),
+    );
+    expect(fromSpot).toBe(-10);
+    expect(fromPerp).toBe(-10);
+  });
+
+  // HyperEVM credits come back as a `spotTransfer` sent by the system address.
+  it('nets a Core/HyperEVM round trip to zero', () => {
+    expect(
+      sumPerpsNetDeposits(
+        ledger([
+          {
+            type: 'send',
+            user: ME,
+            destination: SYSTEM,
+            sourceDex: 'spot',
+            destinationDex: 'spot',
+            token: 'USDC',
+            amount: '25',
+          },
+          {
+            type: 'spotTransfer',
+            user: SYSTEM,
+            destination: ME,
+            token: 'USDC',
+            amount: '25',
+            usdcValue: '25',
+          },
+        ]),
+      ),
+    ).toBe(0);
+  });
+
+  // Moving between one's own perp and spot balances is neither a deposit nor a
+  // withdrawal, and counting it double-subtracted spot-sourced withdrawals.
+  it('ignores transfers between the account own balances', () => {
+    expect(
+      sumPerpsNetDeposits(
+        ledger([
+          { type: 'deposit', usdc: '100' },
+          { type: 'accountClassTransfer', usdc: '100', toPerp: false },
+          {
+            type: 'send',
+            user: ME,
+            destination: ME,
+            sourceDex: '',
+            destinationDex: 'spot',
+            token: 'USDC',
+            amount: '100',
+          },
+          {
+            type: 'send',
+            user: ME,
+            destination: SYSTEM,
+            sourceDex: 'spot',
+            destinationDex: 'spot',
+            token: 'USDC',
+            amount: '100',
+          },
+        ]),
+      ),
+    ).toBe(0);
+  });
+
+  it('ignores tokens other than USDC', () => {
+    expect(
+      sumPerpsNetDeposits(
+        ledger([
+          {
+            type: 'send',
+            user: ME,
+            destination: SYSTEM,
+            sourceDex: 'spot',
+            destinationDex: 'spot',
+            token: 'HYPE',
+            amount: '5',
+          },
+        ]),
+      ),
+    ).toBe(0);
+  });
+
+  it('returns null before the ledger loads', () => {
+    expect(sumPerpsNetDeposits(undefined)).toBeNull();
   });
 });

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.test.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.test.ts
@@ -243,8 +243,8 @@ describe('sumPerpsNetDeposits', () => {
     ).toBe(60);
   });
 
-  // The source balance must not matter: withdrawals from a unified account are
-  // sourced from spot, and dropping those would hide every withdrawal we make.
+  // Unified accounts withdraw from spot, so filtering on source would hide
+  // every withdrawal the app itself makes.
   it('counts a withdrawal whichever balance it is sourced from', () => {
     const fromSpot = sumPerpsNetDeposits(
       ledger([
@@ -303,8 +303,8 @@ describe('sumPerpsNetDeposits', () => {
     ).toBe(0);
   });
 
-  // Moving between one's own perp and spot balances is neither a deposit nor a
-  // withdrawal, and counting it double-subtracted spot-sourced withdrawals.
+  // Neither a deposit nor a withdrawal, and counting it double-subtracted
+  // spot-sourced withdrawals.
   it('ignores transfers between the account own balances', () => {
     expect(
       sumPerpsNetDeposits(

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -9,6 +9,7 @@ import {
   usePerpsActiveAccountSummaryAtom,
   usePerpsTradesHistoryDataAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { HYPEREVM_SYSTEM_ADDRESS } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type { IUserNonFundingLedgerUpdatesResponse } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import {
@@ -126,6 +127,22 @@ export function usePerpPortfolioData(
         }
         if (delta.type === 'withdraw' && delta.usdc) {
           return sum.minus(delta.usdc);
+        }
+        // CCTP withdrawals leave HyperCore as a `send` to the HyperEVM system
+        // address, not as a `withdraw`. Without this they never reduce net
+        // deposits, so the balance drop reads as a trading loss. A plain
+        // Core -> HyperEVM transfer takes the same shape and is equally an
+        // outflow. Both legs are counted so a round trip nets to zero rather
+        // than showing phantom profit; the inbound leg is matched on the system
+        // address as the sender, mirroring the outbound shape.
+        if (delta.type === 'send' && delta.token === 'USDC' && delta.amount) {
+          const systemAddress = HYPEREVM_SYSTEM_ADDRESS.toLowerCase();
+          if (delta.destination?.toLowerCase() === systemAddress) {
+            return sum.minus(delta.amount);
+          }
+          if (delta.user?.toLowerCase() === systemAddress) {
+            return sum.plus(delta.amount);
+          }
         }
         if (
           delta.type === 'accountClassTransfer' &&

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -129,20 +129,21 @@ export function usePerpPortfolioData(
           return sum.minus(delta.usdc);
         }
         // CCTP withdrawals leave HyperCore as a `send` to the HyperEVM system
-        // address, not as a `withdraw`. Without this they never reduce net
-        // deposits, so the balance drop reads as a trading loss. A plain
-        // Core -> HyperEVM transfer takes the same shape and is equally an
-        // outflow. Both legs are counted so a round trip nets to zero rather
-        // than showing phantom profit; the inbound leg is matched on the system
-        // address as the sender, mirroring the outbound shape.
-        if (delta.type === 'send' && delta.token === 'USDC' && delta.amount) {
-          const systemAddress = HYPEREVM_SYSTEM_ADDRESS.toLowerCase();
-          if (delta.destination?.toLowerCase() === systemAddress) {
-            return sum.minus(delta.amount);
-          }
-          if (delta.user?.toLowerCase() === systemAddress) {
-            return sum.plus(delta.amount);
-          }
+        // address, not as a `withdraw`, so without this they stop counting the
+        // moment we switch rails and this stat drifts up on every withdrawal.
+        // Only the outbound leg is matched: the inbound EVM -> Core credit
+        // arrives as a `spotTransfer` from the system address, and counting it
+        // would double up against the `accountClassTransfer` branch below. That
+        // asymmetry, and this reducer's mixed perp-scope / whole-account scope,
+        // predate this change and are tracked separately.
+        if (
+          delta.type === 'send' &&
+          delta.token === 'USDC' &&
+          delta.destination?.toLowerCase() ===
+            HYPEREVM_SYSTEM_ADDRESS.toLowerCase() &&
+          delta.amount
+        ) {
+          return sum.minus(delta.amount);
         }
         if (
           delta.type === 'accountClassTransfer' &&

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -140,6 +140,18 @@ export function usePerpPortfolioData(
         ) {
           return sum.minus(delta.amount);
         }
+        // The matching inbound leg. HyperEVM -> Core credits arrive as a
+        // `spotTransfer` sent by the system address rather than a `send` from
+        // it, so without this a Core/HyperEVM round trip subtracts on the way
+        // out and never adds on the way back.
+        if (
+          delta.type === 'spotTransfer' &&
+          delta.token === 'USDC' &&
+          delta.user?.toLowerCase() === HYPEREVM_SYSTEM_ADDRESS.toLowerCase() &&
+          delta.amount
+        ) {
+          return sum.plus(delta.amount);
+        }
         // `accountClassTransfer` moves USDC between the perp and spot balances
         // of the same account, which is neither a deposit nor a withdrawal.
         // Counting it contradicted this stat's own definition and, now that a

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
 
-import BigNumber from 'bignumber.js';
-
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
@@ -9,13 +7,12 @@ import {
   usePerpsActiveAccountSummaryAtom,
   usePerpsTradesHistoryDataAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { HYPEREVM_SYSTEM_ADDRESS } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
-import type { IUserNonFundingLedgerUpdatesResponse } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import {
   buildPerpPortfolioFillsStats,
   buildPortfolioChartData,
   getStartTimeForPeriod,
+  sumPerpsNetDeposits,
 } from './portfolioStats';
 
 import type { IPortfolioPnlType, IPortfolioTimePeriod } from './portfolioStats';
@@ -117,50 +114,10 @@ export function usePerpPortfolioData(
     };
   }, [chartData]);
 
-  const netDeposits = useMemo(() => {
-    if (!netDepositsData) return null;
-    return netDepositsData
-      .reduce((sum, update: IUserNonFundingLedgerUpdatesResponse[number]) => {
-        const { delta } = update;
-        if (delta.type === 'deposit' && delta.usdc) {
-          return sum.plus(delta.usdc);
-        }
-        if (delta.type === 'withdraw' && delta.usdc) {
-          return sum.minus(delta.usdc);
-        }
-        // CCTP withdrawals leave HyperCore as a `send` to the HyperEVM system
-        // address, not as a `withdraw`, so without this they stop counting the
-        // moment we switch rails and this stat drifts up on every withdrawal.
-        if (
-          delta.type === 'send' &&
-          delta.token === 'USDC' &&
-          delta.destination?.toLowerCase() ===
-            HYPEREVM_SYSTEM_ADDRESS.toLowerCase() &&
-          delta.amount
-        ) {
-          return sum.minus(delta.amount);
-        }
-        // The matching inbound leg. HyperEVM -> Core credits arrive as a
-        // `spotTransfer` sent by the system address rather than a `send` from
-        // it, so without this a Core/HyperEVM round trip subtracts on the way
-        // out and never adds on the way back.
-        if (
-          delta.type === 'spotTransfer' &&
-          delta.token === 'USDC' &&
-          delta.user?.toLowerCase() === HYPEREVM_SYSTEM_ADDRESS.toLowerCase() &&
-          delta.amount
-        ) {
-          return sum.plus(delta.amount);
-        }
-        // `accountClassTransfer` moves USDC between the perp and spot balances
-        // of the same account, which is neither a deposit nor a withdrawal.
-        // Counting it contradicted this stat's own definition and, now that a
-        // withdrawal can be sourced from spot, subtracted such a withdrawal
-        // twice: once on the way to spot and again on the way out.
-        return sum;
-      }, new BigNumber(0))
-      .toNumber();
-  }, [netDepositsData]);
+  const netDeposits = useMemo(
+    () => sumPerpsNetDeposits(netDepositsData),
+    [netDepositsData],
+  );
 
   return {
     chartData,

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -131,11 +131,6 @@ export function usePerpPortfolioData(
         // CCTP withdrawals leave HyperCore as a `send` to the HyperEVM system
         // address, not as a `withdraw`, so without this they stop counting the
         // moment we switch rails and this stat drifts up on every withdrawal.
-        // Only the outbound leg is matched: the inbound EVM -> Core credit
-        // arrives as a `spotTransfer` from the system address, and counting it
-        // would double up against the `accountClassTransfer` branch below. That
-        // asymmetry, and this reducer's mixed perp-scope / whole-account scope,
-        // predate this change and are tracked separately.
         if (
           delta.type === 'send' &&
           delta.token === 'USDC' &&
@@ -145,13 +140,11 @@ export function usePerpPortfolioData(
         ) {
           return sum.minus(delta.amount);
         }
-        if (
-          delta.type === 'accountClassTransfer' &&
-          delta.usdc &&
-          delta.toPerp !== undefined
-        ) {
-          return delta.toPerp ? sum.plus(delta.usdc) : sum.minus(delta.usdc);
-        }
+        // `accountClassTransfer` moves USDC between the perp and spot balances
+        // of the same account, which is neither a deposit nor a withdrawal.
+        // Counting it contradicted this stat's own definition and, now that a
+        // withdrawal can be sourced from spot, subtracted such a withdrawal
+        // twice: once on the way to spot and again on the way out.
         return sum;
       }, new BigNumber(0))
       .toNumber();

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -141,6 +141,16 @@ function formatWithdrawFeeComponent(
   return `${component.isEstimate ? '≈ ' : ''}$${amount}`;
 }
 
+function getWithdrawFeeKey(
+  destination: IUsdcWithdrawDestinationConfig,
+  route: 'bridge' | 'cctp' | undefined,
+) {
+  if (destination.transferType === 'hyperEvm') {
+    return destination.id;
+  }
+  return route ? `${destination.id}:${route}` : undefined;
+}
+
 // A destination's fee is known before its quote returns, so the row can skip the
 // placeholder frame between two values that reads as a flicker.
 function buildWithdrawFeePreviewQuote({
@@ -418,10 +428,12 @@ function DepositWithdrawContent({
   const [withdrawRoute, setWithdrawRoute] = useState<
     'bridge' | 'cctp' | undefined
   >(undefined);
-  const [withdrawFeeState, setWithdrawFeeState] = useState<{
-    key: string;
-    quote: IUsdcWithdrawFeeQuote;
-  }>();
+  // Keyed by destination rather than a single slot, so switching to one already
+  // quoted has no gap to fill. That gap is what made the row swap between the
+  // estimate and the confirmed number.
+  const [withdrawFeeQuotes, setWithdrawFeeQuotes] = useState<
+    Record<string, IUsdcWithdrawFeeQuote>
+  >({});
   const [depositInputUnit, setDepositInputUnit] = useState<'token' | 'usd'>(
     'usd',
   );
@@ -437,16 +449,24 @@ function DepositWithdrawContent({
       USDC_WITHDRAW_DESTINATIONS[3],
     [withdrawDestinationId],
   );
-  let withdrawFeeKey: string | undefined;
-  if (selectedWithdrawDestination.transferType === 'hyperEvm') {
-    withdrawFeeKey = selectedWithdrawDestination.id;
-  } else if (withdrawRoute) {
-    withdrawFeeKey = `${selectedWithdrawDestination.id}:${withdrawRoute}`;
-  }
-  const withdrawFeeQuote =
-    withdrawFeeState && withdrawFeeState.key === withdrawFeeKey
-      ? withdrawFeeState.quote
-      : undefined;
+  const requestedWithdrawFeeKeysRef = useRef<Set<string>>(new Set());
+  const storeWithdrawFeeQuote = useCallback(
+    (key: string, quote: IUsdcWithdrawFeeQuote) => {
+      setWithdrawFeeQuotes((current) =>
+        isSameWithdrawFeeQuote(current[key], quote)
+          ? current
+          : { ...current, [key]: quote },
+      );
+    },
+    [],
+  );
+  const withdrawFeeKey = getWithdrawFeeKey(
+    selectedWithdrawDestination,
+    withdrawRoute,
+  );
+  const withdrawFeeQuote = withdrawFeeKey
+    ? withdrawFeeQuotes[withdrawFeeKey]
+    : undefined;
   // Display only; submission still binds to the confirmed quote below.
   const withdrawFeeDisplayQuote = useMemo(
     () =>
@@ -2246,6 +2266,41 @@ function DepositWithdrawContent({
     };
   }, [selectedAction]);
 
+  // Quote every destination up front. The rail only changes server-side, so this
+  // runs once per form open and lets a switch land on a confirmed number instead
+  // of the estimate that used to blink in and out of the row.
+  useEffect(() => {
+    if (selectedAction !== 'withdraw' || !withdrawRoute) {
+      return;
+    }
+    let cancelled = false;
+    USDC_WITHDRAW_DESTINATIONS.forEach((destination) => {
+      const key = getWithdrawFeeKey(destination, withdrawRoute);
+      if (!key || requestedWithdrawFeeKeysRef.current.has(key)) {
+        return;
+      }
+      // The legacy bridge quote is local and only Arbitrum can use it, so the
+      // main effect handles that pairing rather than an RPC round trip.
+      if (destination.transferType === 'cctp' && withdrawRoute === 'bridge') {
+        return;
+      }
+      requestedWithdrawFeeKeysRef.current.add(key);
+      void backgroundApiProxy.serviceHyperliquidExchange
+        .getUsdcWithdrawFee({ destinationId: destination.id })
+        .then((quote) => {
+          if (!cancelled) {
+            storeWithdrawFeeQuote(key, quote);
+          }
+        })
+        .catch(() => {
+          requestedWithdrawFeeKeysRef.current.delete(key);
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAction, withdrawRoute, storeWithdrawFeeQuote]);
+
   useEffect(() => {
     if (selectedAction !== 'withdraw') {
       return;
@@ -2260,7 +2315,7 @@ function DepositWithdrawContent({
         withdrawRoute === 'bridge'
       ) {
         if (selectedWithdrawDestination.supportsLegacyBridge) {
-          const bridgeQuote: IUsdcWithdrawFeeQuote = {
+          storeWithdrawFeeQuote(withdrawFeeKey, {
             components: [
               {
                 kind: 'legacyBridge',
@@ -2271,13 +2326,7 @@ function DepositWithdrawContent({
               },
             ],
             quotedAt: Date.now(),
-          };
-          setWithdrawFeeState((current) =>
-            current?.key === withdrawFeeKey &&
-            isSameWithdrawFeeQuote(current.quote, bridgeQuote)
-              ? current
-              : { key: withdrawFeeKey, quote: bridgeQuote },
-          );
+          });
         }
         return;
       }
@@ -2285,21 +2334,10 @@ function DepositWithdrawContent({
         .getUsdcWithdrawFee({ destinationId: withdrawDestinationId })
         .then((feeQuote) => {
           if (!cancelled) {
-            // Reusing the object keeps an unchanged refresh from re-rendering.
-            setWithdrawFeeState((current) =>
-              current?.key === withdrawFeeKey &&
-              isSameWithdrawFeeQuote(current.quote, feeQuote)
-                ? current
-                : { key: withdrawFeeKey, quote: feeQuote },
-            );
+            storeWithdrawFeeQuote(withdrawFeeKey, feeQuote);
           }
         })
         .catch((error) => {
-          if (!cancelled) {
-            setWithdrawFeeState((current) =>
-              current?.key === withdrawFeeKey ? undefined : current,
-            );
-          }
           console.error(
             '[DepositWithdrawModal] Failed to resolve withdraw fee:',
             error,
@@ -2318,6 +2356,7 @@ function DepositWithdrawContent({
   }, [
     selectedAction,
     selectedWithdrawDestination,
+    storeWithdrawFeeQuote,
     withdrawDestinationId,
     withdrawFeeKey,
     withdrawRoute,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -151,62 +151,9 @@ function getWithdrawFeeKey(
   return route ? `${destination.id}:${route}` : undefined;
 }
 
-// A destination's fee is known before its quote returns, so the row can skip the
-// placeholder frame between two values that reads as a flicker.
-function buildWithdrawFeePreviewQuote({
-  destination,
-  route,
-}: {
-  destination: IUsdcWithdrawDestinationConfig;
-  route: 'bridge' | 'cctp' | undefined;
-}): IUsdcWithdrawFeeQuote | undefined {
-  if (destination.transferType === 'hyperEvm') {
-    return {
-      components: [
-        {
-          kind: 'hyperEvmGas',
-          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
-          token: 'USDC',
-          debitedFrom: 'spotHypeOrSourceUsdc',
-          isEstimate: true,
-          displayAsLessThan: true,
-        },
-      ],
-      quotedAt: 0,
-    };
-  }
-  if (route === 'cctp') {
-    return {
-      components: [
-        {
-          kind: 'cctpForwarding',
-          amount: destination.fallbackFee.toString(),
-          token: 'USDC',
-          debitedFrom: 'withdrawAmount',
-          // A static constant until the chain read lands, and the service marks
-          // the same value as an estimate when that read fails.
-          isEstimate: true,
-        },
-      ],
-      quotedAt: 0,
-    };
-  }
-  if (route === 'bridge' && destination.supportsLegacyBridge) {
-    return {
-      components: [
-        {
-          kind: 'legacyBridge',
-          amount: WITHDRAW_FEE.toString(),
-          token: 'USDC',
-          debitedFrom: 'withdrawAmount',
-          isEstimate: false,
-        },
-      ],
-      quotedAt: 0,
-    };
-  }
-  return undefined;
-}
+// Quotes survive the modal unmounting: the fee of a destination does not depend
+// on anything in the form, and refetching it on every open blanks the row.
+const withdrawFeeQuoteCache: Record<string, IUsdcWithdrawFeeQuote> = {};
 
 function isSameWithdrawFeeQuote(
   a: IUsdcWithdrawFeeQuote | undefined,
@@ -428,12 +375,11 @@ function DepositWithdrawContent({
   const [withdrawRoute, setWithdrawRoute] = useState<
     'bridge' | 'cctp' | undefined
   >(undefined);
-  // Keyed by destination rather than a single slot, so switching to one already
-  // quoted has no gap to fill. That gap is what made the row swap between the
-  // estimate and the confirmed number.
+  // Seeded from the module cache so reopening the form does not blank the row
+  // again; the effects below refresh it on every open.
   const [withdrawFeeQuotes, setWithdrawFeeQuotes] = useState<
     Record<string, IUsdcWithdrawFeeQuote>
-  >({});
+  >(() => ({ ...withdrawFeeQuoteCache }));
   const [depositInputUnit, setDepositInputUnit] = useState<'token' | 'usd'>(
     'usd',
   );
@@ -452,6 +398,7 @@ function DepositWithdrawContent({
   const requestedWithdrawFeeKeysRef = useRef<Set<string>>(new Set());
   const storeWithdrawFeeQuote = useCallback(
     (key: string, quote: IUsdcWithdrawFeeQuote) => {
+      withdrawFeeQuoteCache[key] = quote;
       setWithdrawFeeQuotes((current) =>
         isSameWithdrawFeeQuote(current[key], quote)
           ? current
@@ -467,16 +414,6 @@ function DepositWithdrawContent({
   const withdrawFeeQuote = withdrawFeeKey
     ? withdrawFeeQuotes[withdrawFeeKey]
     : undefined;
-  // Display only; submission still binds to the confirmed quote below.
-  const withdrawFeeDisplayQuote = useMemo(
-    () =>
-      withdrawFeeQuote ??
-      buildWithdrawFeePreviewQuote({
-        destination: selectedWithdrawDestination,
-        route: withdrawRoute,
-      }),
-    [withdrawFeeQuote, selectedWithdrawDestination, withdrawRoute],
-  );
   const cctpFeeComponent = withdrawFeeQuote?.components.find(
     (component) => component.kind === 'cctpForwarding',
   );
@@ -2362,14 +2299,11 @@ function DepositWithdrawContent({
     withdrawRoute,
   ]);
 
-  const withdrawFeeText = useMemo(() => {
-    if (!withdrawFeeDisplayQuote) {
-      return '--';
-    }
-    return withdrawFeeDisplayQuote.components
-      .map(formatWithdrawFeeComponent)
-      .join(' + ');
-  }, [withdrawFeeDisplayQuote]);
+  const withdrawFeeText = useMemo(
+    () =>
+      withdrawFeeQuote?.components.map(formatWithdrawFeeComponent).join(' + '),
+    [withdrawFeeQuote],
+  );
 
   const withdrawSubmitDisabled =
     !isValidAmount ||
@@ -2618,15 +2552,19 @@ function DepositWithdrawContent({
             gap="$2.5"
           >
             {withdrawFeeHint}
-            <SizableText
-              size="$bodyLgMedium"
-              color="$text"
-              textAlign="right"
-              numberOfLines={1}
-              flexShrink={1}
-            >
-              {withdrawFeeText}
-            </SizableText>
+            {withdrawFeeQuote ? (
+              <SizableText
+                size="$bodyLgMedium"
+                color="$text"
+                textAlign="right"
+                numberOfLines={1}
+                flexShrink={1}
+              >
+                {withdrawFeeText}
+              </SizableText>
+            ) : (
+              <Skeleton h="$4" w="$16" borderRadius="$1" />
+            )}
           </XStack>
         </YStack>
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -141,10 +141,8 @@ function formatWithdrawFeeComponent(
   return `${component.isEstimate ? '≈ ' : ''}$${amount}`;
 }
 
-// The fee of a destination is known before the quote comes back, so switching
-// destinations can render the new number straight away. Without it the row
-// blanks to a placeholder between the two values and reads as a flicker, even
-// when both destinations charge the same.
+// A destination's fee is known before its quote returns, so the row can skip the
+// placeholder frame between two values that reads as a flicker.
 function buildWithdrawFeePreviewQuote({
   destination,
   route,
@@ -447,8 +445,7 @@ function DepositWithdrawContent({
     withdrawFeeState && withdrawFeeState.key === withdrawFeeKey
       ? withdrawFeeState.quote
       : undefined;
-  // Submission still binds to the confirmed quote; this one only feeds the row,
-  // so a destination switch never blanks the number it is replacing.
+  // Display only; submission still binds to the confirmed quote below.
   const withdrawFeeDisplayQuote = useMemo(
     () =>
       withdrawFeeQuote ??
@@ -1660,10 +1657,8 @@ function DepositWithdrawContent({
 
   const isInsufficientBalance = useMemo(() => {
     const checkBN = selectedAction === 'deposit' ? tokenAmountBN : amountBN;
-    // Withdrawals validate against the gas-reserved maximum, so compare against
-    // the same ceiling. Otherwise an amount inside the reserve leaves the submit
-    // button disabled with nothing explaining why — and the displayed balance is
-    // the untrimmed one, so typing it lands there every time.
+    // Same ceiling the amount is validated against, or typing the displayed
+    // balance disables submit with nothing explaining why.
     const limitBN =
       selectedAction === 'deposit'
         ? availableBalanceBN
@@ -2213,12 +2208,8 @@ function DepositWithdrawContent({
     [setPerpsCustomSettings],
   );
 
-  // The selector always needs the active external withdrawal rail, including
-  // when HyperEVM is selected. Kept on the same refresh as the fee quote: a rail
-  // that flips while the form is open makes submission fail with "route
-  // changed", and without a refresh the retry that error asks for can never
-  // succeed. The background service serves its cached value, so most ticks cost
-  // nothing.
+  // Refreshed alongside the fee: a rail that flips while the form is open fails
+  // submission with "route changed", and the retry it asks for needs this.
   useEffect(() => {
     if (selectedAction !== 'withdraw') {
       return;
@@ -2290,8 +2281,7 @@ function DepositWithdrawContent({
         .getUsdcWithdrawFee({ destinationId: withdrawDestinationId })
         .then((feeQuote) => {
           if (!cancelled) {
-            // The periodic refresh usually returns what is already on screen;
-            // reusing the object keeps that tick from re-rendering the row.
+            // Reusing the object keeps an unchanged refresh from re-rendering.
             setWithdrawFeeState((current) =>
               current?.key === withdrawFeeKey &&
               isSameWithdrawFeeQuote(current.quote, feeQuote)

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -69,11 +69,13 @@ import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import {
+  CCTP_DOMAIN_ARBITRUM,
   HYPERLIQUID_DEPOSIT_ADDRESS,
   MIN_DEPOSIT_AMOUNT,
   MIN_WITHDRAW_AMOUNT,
   USDC_TOKEN_INFO,
   WITHDRAW_FEE,
+  getCctpWithdrawFee,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import { swapDefaultSetTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type { ISwapNativeTokenConfig } from '@onekeyhq/shared/types/swap/types';
@@ -1957,6 +1959,46 @@ function DepositWithdrawContent({
     return buttonText;
   }, [buttonText, intl, shouldShowBuyButton]);
 
+  // Hyperliquid serves the active withdrawal rail, and the two rails charge very
+  // different fees, so resolve it before quoting one. Display only: the amount
+  // validation uses MIN_WITHDRAW_AMOUNT, which covers both rails.
+  const [withdrawRoute, setWithdrawRoute] = useState<
+    'bridge' | 'cctp' | undefined
+  >(undefined);
+  useEffect(() => {
+    if (selectedAction !== 'withdraw') {
+      return;
+    }
+    let cancelled = false;
+    void backgroundApiProxy.serviceHyperliquidExchange
+      .getUsdcWithdrawRoute()
+      .then((route) => {
+        if (!cancelled) {
+          setWithdrawRoute(route);
+        }
+      })
+      .catch((error) => {
+        console.error(
+          '[DepositWithdrawModal] Failed to resolve withdraw route:',
+          error,
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAction]);
+
+  const withdrawFeeText = useMemo(() => {
+    if (!withdrawRoute) {
+      return '--';
+    }
+    const fee =
+      withdrawRoute === 'cctp'
+        ? getCctpWithdrawFee(CCTP_DOMAIN_ARBITRUM)
+        : WITHDRAW_FEE;
+    return `$${fee.toFixed(2)}`;
+  }, [withdrawRoute]);
+
   const withdrawFeeHintTrigger = useMemo(
     () => (
       <DashText
@@ -2205,7 +2247,7 @@ function DepositWithdrawContent({
               numberOfLines={1}
               flexShrink={1}
             >
-              ${WITHDRAW_FEE}
+              {withdrawFeeText}
             </SizableText>
           </XStack>
         </YStack>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -131,9 +131,6 @@ const PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT = 300;
 const WITHDRAW_QUOTE_REFRESH_INTERVAL_MS = 30_000;
 const LIFI_FALLBACK_LOGO = require('@onekeyhq/kit/assets/perps/lifi-logo.png');
 
-// No estimate marker on the CCTP fee: a chain read that fails falls back to the
-// same number, and submission re-reads it and refuses on drift, so the marker
-// only ever blinks in and out without telling the user anything new.
 function formatWithdrawFeeComponent(
   component: IUsdcWithdrawFeeQuote['components'][number],
 ) {
@@ -141,7 +138,7 @@ function formatWithdrawFeeComponent(
   if (component.kind === 'hyperEvmGas') {
     return `< $${amount}`;
   }
-  return `$${amount}`;
+  return `${component.isEstimate ? '≈ ' : ''}$${amount}`;
 }
 
 // A destination's fee is known before its quote returns, so the row can skip the
@@ -176,7 +173,9 @@ function buildWithdrawFeePreviewQuote({
           amount: destination.fallbackFee.toString(),
           token: 'USDC',
           debitedFrom: 'withdrawAmount',
-          isEstimate: false,
+          // A static constant until the chain read lands, and the service marks
+          // the same value as an estimate when that read fails.
+          isEstimate: true,
         },
       ],
       quotedAt: 0,
@@ -464,11 +463,11 @@ function DepositWithdrawContent({
   const shouldReserveWithdrawGas =
     selectedWithdrawDestination.transferType === 'hyperEvm' ||
     withdrawRoute === 'cctp';
-  // Gated on the preview too, or the button greys out for the frame between two
-  // destinations. handleConfirm resolves the confirmed fee before submitting.
+  // Gated on the confirmed quote, never the preview: submitting against a fee the
+  // row never showed would take the difference out of the principal.
   const isWithdrawFeeQuoteComplete =
-    Boolean(withdrawFeeDisplayQuote) &&
-    withdrawFeeDisplayQuote?.components.every((component) =>
+    Boolean(withdrawFeeQuote) &&
+    withdrawFeeQuote?.components.every((component) =>
       Boolean(component.amount),
     );
   const isWithdrawDestinationReady =
@@ -1610,24 +1609,6 @@ function DepositWithdrawContent({
           onClose?.();
         }
       } else {
-        // Submission stays bound to a confirmed fee; only the wait for it moved
-        // here from the button's disabled state.
-        let expectedCctpFee: string | undefined;
-        if (
-          selectedWithdrawDestination.transferType === 'cctp' &&
-          withdrawRoute === 'cctp'
-        ) {
-          expectedCctpFee = cctpFeeComponent?.amount;
-          if (!expectedCctpFee) {
-            const feeQuote =
-              await backgroundApiProxy.serviceHyperliquidExchange.getUsdcWithdrawFee(
-                { destinationId: withdrawDestinationId },
-              );
-            expectedCctpFee = feeQuote.components.find(
-              (component) => component.kind === 'cctpForwarding',
-            )?.amount;
-          }
-        }
         await withdraw({
           userAccountId: selectedAccount.accountId || '',
           amount,
@@ -1636,7 +1617,8 @@ function DepositWithdrawContent({
             selectedWithdrawDestination.transferType === 'cctp'
               ? withdrawRoute
               : undefined,
-          expectedCctpFee,
+          expectedCctpFee:
+            withdrawRoute === 'cctp' ? cctpFeeComponent?.amount : undefined,
         });
         void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
         onClose?.();

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -6,7 +6,11 @@ import { BigNumber } from 'bignumber.js';
 import { useIntl } from 'react-intl';
 import { InputAccessoryView } from 'react-native';
 
-import type { IPageNavigationProp, useInTabDialog } from '@onekeyhq/components';
+import type {
+  IPageNavigationProp,
+  ISelectItem,
+  useInTabDialog,
+} from '@onekeyhq/components';
 import {
   Button,
   DashText,
@@ -17,6 +21,7 @@ import {
   NavBackButton,
   Page,
   Popover,
+  Select,
   SizableText,
   Skeleton,
   Stack,
@@ -52,6 +57,7 @@ import {
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountAtom,
   usePerpsComputedAccountValueAtom,
+  usePerpsCustomSettingsAtom,
   usePerpsDepositTokensAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
@@ -69,13 +75,19 @@ import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import {
-  CCTP_DOMAIN_ARBITRUM,
+  DEFAULT_USDC_WITHDRAW_DESTINATION_ID,
   HYPERLIQUID_DEPOSIT_ADDRESS,
   MIN_DEPOSIT_AMOUNT,
   MIN_WITHDRAW_AMOUNT,
   USDC_TOKEN_INFO,
+  USDC_WITHDRAW_DESTINATIONS,
+  USDC_WITHDRAW_GAS_RESERVE,
   WITHDRAW_FEE,
-  getCctpWithdrawFee,
+  getUsdcWithdrawDestination,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IUsdcWithdrawDestinationId,
+  IUsdcWithdrawFeeQuote,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import { swapDefaultSetTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type { ISwapNativeTokenConfig } from '@onekeyhq/shared/types/swap/types';
@@ -115,6 +127,7 @@ const PERP_DESKTOP_DEPOSIT_AMOUNT_INPUT_BLOCK_HEIGHT = 220;
 const PERP_ANDROID_DEPOSIT_AMOUNT_INPUT_BLOCK_HEIGHT = 176;
 const PERP_DESKTOP_DEPOSIT_SELECT_TOKEN_LIST_HEIGHT = 430;
 const PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT = 300;
+const WITHDRAW_QUOTE_REFRESH_INTERVAL_MS = 30_000;
 const LIFI_FALLBACK_LOGO = require('@onekeyhq/kit/assets/perps/lifi-logo.png');
 
 function hasPositivePerpsDepositTokenAmount(tokenAmount?: string) {
@@ -308,8 +321,22 @@ function DepositWithdrawContent({
   const selectedAction = params.actionType;
   const [computedValue] = usePerpsComputedAccountValueAtom();
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
+  const [perpsCustomSettings, setPerpsCustomSettings] =
+    usePerpsCustomSettingsAtom();
   const withdrawable = computedValue?.withdrawable ?? '';
   const [amount, setAmount] = useState('');
+  const withdrawDestinationId = getUsdcWithdrawDestination(
+    perpsCustomSettings.lastUsdcWithdrawDestinationId,
+  )
+    ? perpsCustomSettings.lastUsdcWithdrawDestinationId
+    : DEFAULT_USDC_WITHDRAW_DESTINATION_ID;
+  const [withdrawRoute, setWithdrawRoute] = useState<
+    'bridge' | 'cctp' | undefined
+  >(undefined);
+  const [withdrawFeeState, setWithdrawFeeState] = useState<{
+    key: string;
+    quote: IUsdcWithdrawFeeQuote;
+  }>();
   const [depositInputUnit, setDepositInputUnit] = useState<'token' | 'usd'>(
     'usd',
   );
@@ -319,6 +346,41 @@ function DepositWithdrawContent({
     'form' | 'selectToken'
   >('form');
   const amountInputRef = useRef<ISendAmountAutoSizeInputRef>(null);
+  const selectedWithdrawDestination = useMemo(
+    () =>
+      getUsdcWithdrawDestination(withdrawDestinationId) ??
+      USDC_WITHDRAW_DESTINATIONS[3],
+    [withdrawDestinationId],
+  );
+  let withdrawFeeKey: string | undefined;
+  if (selectedWithdrawDestination.transferType === 'hyperEvm') {
+    withdrawFeeKey = selectedWithdrawDestination.id;
+  } else if (withdrawRoute) {
+    withdrawFeeKey = `${selectedWithdrawDestination.id}:${withdrawRoute}`;
+  }
+  const withdrawFeeQuote =
+    withdrawFeeState && withdrawFeeState.key === withdrawFeeKey
+      ? withdrawFeeState.quote
+      : undefined;
+  const cctpFeeComponent = withdrawFeeQuote?.components.find(
+    (component) => component.kind === 'cctpForwarding',
+  );
+  const shouldReserveWithdrawGas =
+    selectedWithdrawDestination.transferType === 'hyperEvm' ||
+    withdrawRoute === 'cctp';
+  const isWithdrawFeeQuoteComplete =
+    Boolean(withdrawFeeQuote) &&
+    withdrawFeeQuote?.components.every((component) =>
+      Boolean(component.amount),
+    );
+  const isWithdrawDestinationReady =
+    selectedAction !== 'withdraw' ||
+    (isWithdrawFeeQuoteComplete &&
+      (selectedWithdrawDestination.transferType === 'hyperEvm' ||
+        withdrawRoute === 'cctp' ||
+        (withdrawRoute === 'bridge' &&
+          selectedWithdrawDestination.transferType === 'cctp' &&
+          selectedWithdrawDestination.supportsLegacyBridge)));
   const [
     {
       tokens,
@@ -870,6 +932,18 @@ function DepositWithdrawContent({
     [availableBalance.balance],
   );
 
+  // Hyperliquid may charge the sub-cent Core -> EVM gas outside the requested
+  // amount. Reserve one cent so a full-balance withdrawal does not fail.
+  const maximumWithdrawAmountBN = useMemo(() => {
+    const maximum = shouldReserveWithdrawGas
+      ? availableBalanceBN.minus(USDC_WITHDRAW_GAS_RESERVE)
+      : availableBalanceBN;
+    return BigNumber.maximum(maximum, 0).decimalPlaces(
+      USDC_TOKEN_INFO.decimals,
+      BigNumber.ROUND_DOWN,
+    );
+  }, [availableBalanceBN, shouldReserveWithdrawGas]);
+
   const checkFromTokenFiatValue = useMemo(() => {
     return getPerpsDepositMinimumCheck({
       inputAmount: amount,
@@ -884,6 +958,18 @@ function DepositWithdrawContent({
     currentPerpsDepositSelectedToken?.price,
   ]);
 
+  const minimumWithdrawAmountBN = useMemo(() => {
+    const configuredMinimum = new BigNumber(MIN_WITHDRAW_AMOUNT);
+    if (!cctpFeeComponent?.amount) {
+      return configuredMinimum;
+    }
+    const amountAboveFee = new BigNumber(cctpFeeComponent.amount).plus(
+      '0.000001',
+    );
+    return BigNumber.maximum(configuredMinimum, amountAboveFee);
+  }, [cctpFeeComponent?.amount]);
+  const minimumWithdrawAmountText = minimumWithdrawAmountBN.toFixed();
+
   const isValidAmount = useMemo(() => {
     if (amountBN.isNaN() || amountBN.lte(0)) return false;
 
@@ -895,14 +981,14 @@ function DepositWithdrawContent({
     const isBelowWithdrawMin =
       selectedAction === 'withdraw' &&
       hasActiveAmount &&
-      amountBN.lt(MIN_WITHDRAW_AMOUNT);
+      amountBN.lt(minimumWithdrawAmountBN);
 
     if (selectedAction === 'deposit') {
       return tokenAmountBN.lte(availableBalanceBN) && !isBelowDepositMin;
     }
 
     if (selectedAction === 'withdraw') {
-      return amountBN.lte(availableBalanceBN) && !isBelowWithdrawMin;
+      return amountBN.lte(maximumWithdrawAmountBN) && !isBelowWithdrawMin;
     }
 
     return true;
@@ -913,6 +999,8 @@ function DepositWithdrawContent({
     availableBalanceBN,
     selectedAction,
     checkFromTokenFiatValue.value,
+    maximumWithdrawAmountBN,
+    minimumWithdrawAmountBN,
   ]);
 
   const errorMessage = useMemo(() => {
@@ -935,10 +1023,10 @@ function DepositWithdrawContent({
     }
 
     if (selectedAction === 'withdraw') {
-      if (showMinAmountError && amountBN.lt(MIN_WITHDRAW_AMOUNT)) {
+      if (showMinAmountError && amountBN.lt(minimumWithdrawAmountBN)) {
         return intl.formatMessage(
           { id: ETranslations.perp_mini_withdraw },
-          { num: MIN_WITHDRAW_AMOUNT, token: 'USDC' },
+          { num: minimumWithdrawAmountText, token: 'USDC' },
         );
       }
     }
@@ -953,6 +1041,8 @@ function DepositWithdrawContent({
     checkFromTokenFiatValue.minFromTokenAmount,
     intl,
     currentPerpsDepositSelectedToken?.symbol,
+    minimumWithdrawAmountBN,
+    minimumWithdrawAmountText,
   ]);
 
   const depositQuoteAmountDebounced = useDebounce(tokenAmount, 800);
@@ -1082,12 +1172,18 @@ function DepositWithdrawContent({
         setShowMinAmountError(true);
       } else if (
         selectedAction === 'withdraw' &&
-        amountBN.lt(MIN_WITHDRAW_AMOUNT)
+        amountBN.lt(minimumWithdrawAmountBN)
       ) {
         setShowMinAmountError(true);
       }
     }
-  }, [amount, amountBN, selectedAction, checkFromTokenFiatValue.value]);
+  }, [
+    amount,
+    amountBN,
+    checkFromTokenFiatValue.value,
+    minimumWithdrawAmountBN,
+    selectedAction,
+  ]);
 
   const checkNativeTokenGasToast = useCallback(
     (
@@ -1197,7 +1293,10 @@ function DepositWithdrawContent({
         return;
       }
       if (availableBalance) {
-        const nextAmount = availableBalance.balance || '0';
+        const nextAmount =
+          selectedAction === 'withdraw'
+            ? maximumWithdrawAmountBN.toFixed()
+            : availableBalance.balance || '0';
         setAmount(nextAmount);
       }
     },
@@ -1206,6 +1305,7 @@ function DepositWithdrawContent({
       checkNativeTokenGasToast,
       selectedAction,
       depositInputUnit,
+      maximumWithdrawAmountBN,
       tokenPriceBN,
     ],
   );
@@ -1222,12 +1322,18 @@ function DepositWithdrawContent({
     }
 
     if (selectedAction === 'withdraw') {
-      setShowMinAmountError(amountBN.lt(MIN_WITHDRAW_AMOUNT));
+      setShowMinAmountError(amountBN.lt(minimumWithdrawAmountBN));
       return;
     }
 
     setShowMinAmountError(false);
-  }, [amount, amountBN, checkFromTokenFiatValue.value, selectedAction]);
+  }, [
+    amount,
+    amountBN,
+    checkFromTokenFiatValue.value,
+    minimumWithdrawAmountBN,
+    selectedAction,
+  ]);
 
   const validateAmountBeforeSubmit = useCallback(() => {
     if (amountBN.isNaN() || amountBN.lte(0)) {
@@ -1239,7 +1345,11 @@ function DepositWithdrawContent({
 
     const balanceCheckBN =
       selectedAction === 'deposit' ? tokenAmountBN : amountBN;
-    if (balanceCheckBN.gt(availableBalanceBN)) {
+    const maximumAmountBN =
+      selectedAction === 'deposit'
+        ? availableBalanceBN
+        : maximumWithdrawAmountBN;
+    if (balanceCheckBN.gt(maximumAmountBN)) {
       Toast.error({
         title: intl.formatMessage({
           id: ETranslations.earn_insufficient_balance,
@@ -1261,11 +1371,11 @@ function DepositWithdrawContent({
       return false;
     }
 
-    if (selectedAction === 'withdraw' && amountBN.lt(MIN_WITHDRAW_AMOUNT)) {
+    if (selectedAction === 'withdraw' && amountBN.lt(minimumWithdrawAmountBN)) {
       setShowMinAmountError(true);
       const message = intl.formatMessage(
         { id: ETranslations.perp_mini_withdraw },
-        { num: MIN_WITHDRAW_AMOUNT, token: 'USDC' },
+        { num: minimumWithdrawAmountText, token: 'USDC' },
       );
       Toast.error({ title: message });
       return false;
@@ -1284,6 +1394,9 @@ function DepositWithdrawContent({
     checkFromTokenFiatValue.value,
     currentPerpsDepositSelectedToken?.symbol,
     intl,
+    maximumWithdrawAmountBN,
+    minimumWithdrawAmountBN,
+    minimumWithdrawAmountText,
     selectedAction,
     showMinAmountError,
   ]);
@@ -1306,17 +1419,18 @@ function DepositWithdrawContent({
       >
         {intl.formatMessage(
           { id: ETranslations.perp_size_least },
-          { amount: `${MIN_WITHDRAW_AMOUNT} USDC` },
+          { amount: `${minimumWithdrawAmountText} USDC` },
         )}
       </SizableText>
     );
-  }, [intl, selectedAction]);
+  }, [intl, minimumWithdrawAmountText, selectedAction]);
 
   const handleConfirm = useCallback(async () => {
     if (
       !isValidAmount ||
       !selectedAccount.accountAddress ||
-      !checkAccountSupport
+      !checkAccountSupport ||
+      !isWithdrawDestinationReady
     )
       return;
 
@@ -1401,7 +1515,13 @@ function DepositWithdrawContent({
         await withdraw({
           userAccountId: selectedAccount.accountId || '',
           amount,
-          destination: selectedAccount.accountAddress,
+          destinationId: withdrawDestinationId,
+          expectedRoute:
+            selectedWithdrawDestination.transferType === 'cctp'
+              ? withdrawRoute
+              : undefined,
+          expectedCctpFee:
+            withdrawRoute === 'cctp' ? cctpFeeComponent?.amount : undefined,
         });
         void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
         onClose?.();
@@ -1414,6 +1534,7 @@ function DepositWithdrawContent({
     }
   }, [
     isValidAmount,
+    isWithdrawDestinationReady,
     checkAccountSupport,
     selectedAccount.accountAddress,
     selectedAccount.accountId,
@@ -1424,6 +1545,10 @@ function DepositWithdrawContent({
     isArbitrumUsdcToken,
     normalizeTxConfirm,
     amount,
+    cctpFeeComponent?.amount,
+    selectedWithdrawDestination.transferType,
+    withdrawDestinationId,
+    withdrawRoute,
     tokenAmount,
     handlePerpDepositTxSuccess,
     onClose,
@@ -1448,7 +1573,6 @@ function DepositWithdrawContent({
         id: ETranslations.earn_insufficient_balance,
       });
     }
-
     return errorMessage;
   }, [errorMessage, intl, isInsufficientBalance]);
 
@@ -1592,11 +1716,6 @@ function DepositWithdrawContent({
       resolvedCurrentPerpsDepositSelectedToken.networkId,
     );
   }, [resolvedCurrentPerpsDepositSelectedToken?.networkId]);
-
-  const perpsNetworkInfo = useMemo(
-    () => networkUtils.getLocalNetworkInfo(PERPS_NETWORK_ID),
-    [],
-  );
 
   const openTokenSelectorPage = useCallback(() => {
     if (!checkAccountSupport || balanceLoading) return;
@@ -1959,17 +2078,39 @@ function DepositWithdrawContent({
     return buttonText;
   }, [buttonText, intl, shouldShowBuyButton]);
 
-  // Hyperliquid serves the active withdrawal rail, and the two rails charge very
-  // different fees, so resolve it before quoting one. Display only: the amount
-  // validation uses MIN_WITHDRAW_AMOUNT, which covers both rails.
-  const [withdrawRoute, setWithdrawRoute] = useState<
-    'bridge' | 'cctp' | undefined
-  >(undefined);
+  const withdrawDestinationItems = useMemo<ISelectItem[]>(
+    () =>
+      USDC_WITHDRAW_DESTINATIONS.map((destination) => ({
+        label: destination.name,
+        value: destination.id,
+        disabled:
+          destination.transferType === 'cctp' &&
+          withdrawRoute !== 'cctp' &&
+          !destination.supportsLegacyBridge,
+      })),
+    [withdrawRoute],
+  );
+
+  const handleWithdrawDestinationChange = useCallback(
+    (value: IUsdcWithdrawDestinationId | undefined) => {
+      if (value && getUsdcWithdrawDestination(value)) {
+        setPerpsCustomSettings((previous) => ({
+          ...previous,
+          lastUsdcWithdrawDestinationId: value,
+        }));
+      }
+    },
+    [setPerpsCustomSettings],
+  );
+
+  // The selector always needs the active external withdrawal rail, including
+  // when HyperEVM is selected. The background service serves its cached value.
   useEffect(() => {
     if (selectedAction !== 'withdraw') {
       return;
     }
     let cancelled = false;
+    setWithdrawRoute(undefined);
     void backgroundApiProxy.serviceHyperliquidExchange
       .getUsdcWithdrawRoute()
       .then((route) => {
@@ -1988,16 +2129,95 @@ function DepositWithdrawContent({
     };
   }, [selectedAction]);
 
+  useEffect(() => {
+    if (selectedAction !== 'withdraw') {
+      return;
+    }
+    if (!withdrawFeeKey) {
+      return;
+    }
+    let cancelled = false;
+    const loadWithdrawFee = () => {
+      if (
+        selectedWithdrawDestination.transferType === 'cctp' &&
+        withdrawRoute === 'bridge'
+      ) {
+        if (selectedWithdrawDestination.supportsLegacyBridge) {
+          setWithdrawFeeState({
+            key: withdrawFeeKey,
+            quote: {
+              components: [
+                {
+                  kind: 'legacyBridge',
+                  amount: WITHDRAW_FEE.toString(),
+                  token: 'USDC',
+                  debitedFrom: 'withdrawAmount',
+                  isEstimate: false,
+                },
+              ],
+              quotedAt: Date.now(),
+            },
+          });
+        }
+        return;
+      }
+      void backgroundApiProxy.serviceHyperliquidExchange
+        .getUsdcWithdrawFee({ destinationId: withdrawDestinationId })
+        .then((feeQuote) => {
+          if (!cancelled) {
+            setWithdrawFeeState({ key: withdrawFeeKey, quote: feeQuote });
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setWithdrawFeeState((current) =>
+              current?.key === withdrawFeeKey ? undefined : current,
+            );
+          }
+          console.error(
+            '[DepositWithdrawModal] Failed to resolve withdraw fee:',
+            error,
+          );
+        });
+    };
+    loadWithdrawFee();
+    const refreshInterval = setInterval(
+      loadWithdrawFee,
+      WITHDRAW_QUOTE_REFRESH_INTERVAL_MS,
+    );
+    return () => {
+      cancelled = true;
+      clearInterval(refreshInterval);
+    };
+  }, [
+    selectedAction,
+    selectedWithdrawDestination,
+    withdrawDestinationId,
+    withdrawFeeKey,
+    withdrawRoute,
+  ]);
+
   const withdrawFeeText = useMemo(() => {
-    if (!withdrawRoute) {
+    if (!withdrawFeeQuote) {
       return '--';
     }
-    const fee =
-      withdrawRoute === 'cctp'
-        ? getCctpWithdrawFee(CCTP_DOMAIN_ARBITRUM)
-        : WITHDRAW_FEE;
-    return `$${fee.toFixed(2)}`;
-  }, [withdrawRoute]);
+    return withdrawFeeQuote.components
+      .map((component) => {
+        if (component.kind === 'hyperEvmGas') {
+          return `< $${new BigNumber(component.amount).toFixed(2)}`;
+        }
+        return `${component.isEstimate ? '≈ ' : ''}$${new BigNumber(
+          component.amount,
+        ).toFixed(2)}`;
+      })
+      .join(' + ');
+  }, [withdrawFeeQuote]);
+
+  const withdrawSubmitDisabled =
+    !isValidAmount ||
+    isSubmitting ||
+    shouldShowWithdrawableSkeleton ||
+    !isWithdrawDestinationReady;
 
   const withdrawFeeHintTrigger = useMemo(
     () => (
@@ -2258,9 +2478,7 @@ function DepositWithdrawContent({
               testID="perp-btn"
               variant="primary"
               size={PERP_DIALOG_BUTTON_SIZE}
-              disabled={
-                !isValidAmount || isSubmitting || shouldShowWithdrawableSkeleton
-              }
+              disabled={withdrawSubmitDisabled}
               loading={isSubmitting}
               onPress={handleConfirm}
             >
@@ -2274,9 +2492,7 @@ function DepositWithdrawContent({
             onKeyPress={handleNativeAmountKeyPress}
             onBackspaceLongPress={handleNativeAmountBackspaceLongPress}
             ctaLabel={nativeAmountCtaLabel}
-            ctaDisabled={
-              !isValidAmount || isSubmitting || shouldShowWithdrawableSkeleton
-            }
+            ctaDisabled={withdrawSubmitDisabled}
             ctaLoading={isSubmitting}
             onCtaPress={handleConfirm}
           />
@@ -2472,10 +2688,47 @@ function DepositWithdrawContent({
                     alignItems="center"
                     gap="$1"
                   >
-                    <SizableText size="$bodySm" color="$textSubdued">
-                      {intl.formatMessage({ id: ETranslations.global_to })}{' '}
-                      {perpsNetworkInfo?.name ?? 'Arbitrum'}
-                    </SizableText>
+                    <Select
+                      key={`perp-withdraw-destination-${
+                        withdrawRoute ?? 'loading'
+                      }`}
+                      testID="perp-withdraw-destination-select"
+                      items={withdrawDestinationItems}
+                      value={withdrawDestinationId}
+                      onChange={handleWithdrawDestinationChange}
+                      disabled={isSubmitting || !checkAccountSupport}
+                      title={intl.formatMessage({
+                        id: ETranslations.global_select_network,
+                      })}
+                      renderTrigger={({
+                        onPress,
+                        label,
+                        disabled: disabledTrigger,
+                      }) => (
+                        <XStack
+                          alignItems="center"
+                          gap="$0.5"
+                          onPress={onPress}
+                          disabled={disabledTrigger}
+                          cursor={disabledTrigger ? 'default' : 'pointer'}
+                        >
+                          <SizableText size="$bodySm" color="$textSubdued">
+                            {intl.formatMessage({
+                              id: ETranslations.global_to,
+                            })}{' '}
+                            {label ?? selectedWithdrawDestination.name}
+                          </SizableText>
+                          <Icon
+                            name="ChevronTriangleDownSmallSolid"
+                            size="$4"
+                            color="$iconSubdued"
+                          />
+                        </XStack>
+                      )}
+                      placement="bottom"
+                      offset={16}
+                      floatingPanelProps={{ width: 200 }}
+                    />
                     {errorMessage ? (
                       <SizableText size="$bodySm" color="$textCritical">
                         {errorMessage}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -461,9 +461,11 @@ function DepositWithdrawContent({
   const shouldReserveWithdrawGas =
     selectedWithdrawDestination.transferType === 'hyperEvm' ||
     withdrawRoute === 'cctp';
+  // Gated on the preview too, or the button greys out for the frame between two
+  // destinations. handleConfirm resolves the confirmed fee before submitting.
   const isWithdrawFeeQuoteComplete =
-    Boolean(withdrawFeeQuote) &&
-    withdrawFeeQuote?.components.every((component) =>
+    Boolean(withdrawFeeDisplayQuote) &&
+    withdrawFeeDisplayQuote?.components.every((component) =>
       Boolean(component.amount),
     );
   const isWithdrawDestinationReady =
@@ -1605,6 +1607,24 @@ function DepositWithdrawContent({
           onClose?.();
         }
       } else {
+        // Submission stays bound to a confirmed fee; only the wait for it moved
+        // here from the button's disabled state.
+        let expectedCctpFee: string | undefined;
+        if (
+          selectedWithdrawDestination.transferType === 'cctp' &&
+          withdrawRoute === 'cctp'
+        ) {
+          expectedCctpFee = cctpFeeComponent?.amount;
+          if (!expectedCctpFee) {
+            const feeQuote =
+              await backgroundApiProxy.serviceHyperliquidExchange.getUsdcWithdrawFee(
+                { destinationId: withdrawDestinationId },
+              );
+            expectedCctpFee = feeQuote.components.find(
+              (component) => component.kind === 'cctpForwarding',
+            )?.amount;
+          }
+        }
         await withdraw({
           userAccountId: selectedAccount.accountId || '',
           amount,
@@ -1613,8 +1633,7 @@ function DepositWithdrawContent({
             selectedWithdrawDestination.transferType === 'cctp'
               ? withdrawRoute
               : undefined,
-          expectedCctpFee:
-            withdrawRoute === 'cctp' ? cctpFeeComponent?.amount : undefined,
+          expectedCctpFee,
         });
         void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
         onClose?.();

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -86,6 +86,7 @@ import {
   getUsdcWithdrawDestination,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
+  IUsdcWithdrawDestinationConfig,
   IUsdcWithdrawDestinationId,
   IUsdcWithdrawFeeQuote,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
@@ -129,6 +130,90 @@ const PERP_DESKTOP_DEPOSIT_SELECT_TOKEN_LIST_HEIGHT = 430;
 const PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT = 300;
 const WITHDRAW_QUOTE_REFRESH_INTERVAL_MS = 30_000;
 const LIFI_FALLBACK_LOGO = require('@onekeyhq/kit/assets/perps/lifi-logo.png');
+
+function formatWithdrawFeeComponent(
+  component: IUsdcWithdrawFeeQuote['components'][number],
+) {
+  const amount = new BigNumber(component.amount).toFixed(2);
+  if (component.kind === 'hyperEvmGas') {
+    return `< $${amount}`;
+  }
+  return `${component.isEstimate ? '≈ ' : ''}$${amount}`;
+}
+
+// The fee of a destination is known before the quote comes back, so switching
+// destinations can render the new number straight away. Without it the row
+// blanks to a placeholder between the two values and reads as a flicker, even
+// when both destinations charge the same.
+function buildWithdrawFeePreviewQuote({
+  destination,
+  route,
+}: {
+  destination: IUsdcWithdrawDestinationConfig;
+  route: 'bridge' | 'cctp' | undefined;
+}): IUsdcWithdrawFeeQuote | undefined {
+  if (destination.transferType === 'hyperEvm') {
+    return {
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: 0,
+    };
+  }
+  if (route === 'cctp') {
+    return {
+      components: [
+        {
+          kind: 'cctpForwarding',
+          amount: destination.fallbackFee.toString(),
+          token: 'USDC',
+          debitedFrom: 'withdrawAmount',
+          isEstimate: false,
+        },
+      ],
+      quotedAt: 0,
+    };
+  }
+  if (route === 'bridge' && destination.supportsLegacyBridge) {
+    return {
+      components: [
+        {
+          kind: 'legacyBridge',
+          amount: WITHDRAW_FEE.toString(),
+          token: 'USDC',
+          debitedFrom: 'withdrawAmount',
+          isEstimate: false,
+        },
+      ],
+      quotedAt: 0,
+    };
+  }
+  return undefined;
+}
+
+function isSameWithdrawFeeQuote(
+  a: IUsdcWithdrawFeeQuote | undefined,
+  b: IUsdcWithdrawFeeQuote,
+) {
+  return (
+    a?.components.length === b.components.length &&
+    a.components.every((component, index) => {
+      const next = b.components[index];
+      return (
+        component.kind === next.kind &&
+        component.amount === next.amount &&
+        component.isEstimate === next.isEstimate
+      );
+    })
+  );
+}
 
 function hasPositivePerpsDepositTokenAmount(tokenAmount?: string) {
   if (!tokenAmount) {
@@ -362,6 +447,17 @@ function DepositWithdrawContent({
     withdrawFeeState && withdrawFeeState.key === withdrawFeeKey
       ? withdrawFeeState.quote
       : undefined;
+  // Submission still binds to the confirmed quote; this one only feeds the row,
+  // so a destination switch never blanks the number it is replacing.
+  const withdrawFeeDisplayQuote = useMemo(
+    () =>
+      withdrawFeeQuote ??
+      buildWithdrawFeePreviewQuote({
+        destination: selectedWithdrawDestination,
+        route: withdrawRoute,
+      }),
+    [withdrawFeeQuote, selectedWithdrawDestination, withdrawRoute],
+  );
   const cctpFeeComponent = withdrawFeeQuote?.components.find(
     (component) => component.kind === 'cctpForwarding',
   );
@@ -2169,21 +2265,24 @@ function DepositWithdrawContent({
         withdrawRoute === 'bridge'
       ) {
         if (selectedWithdrawDestination.supportsLegacyBridge) {
-          setWithdrawFeeState({
-            key: withdrawFeeKey,
-            quote: {
-              components: [
-                {
-                  kind: 'legacyBridge',
-                  amount: WITHDRAW_FEE.toString(),
-                  token: 'USDC',
-                  debitedFrom: 'withdrawAmount',
-                  isEstimate: false,
-                },
-              ],
-              quotedAt: Date.now(),
-            },
-          });
+          const bridgeQuote: IUsdcWithdrawFeeQuote = {
+            components: [
+              {
+                kind: 'legacyBridge',
+                amount: WITHDRAW_FEE.toString(),
+                token: 'USDC',
+                debitedFrom: 'withdrawAmount',
+                isEstimate: false,
+              },
+            ],
+            quotedAt: Date.now(),
+          };
+          setWithdrawFeeState((current) =>
+            current?.key === withdrawFeeKey &&
+            isSameWithdrawFeeQuote(current.quote, bridgeQuote)
+              ? current
+              : { key: withdrawFeeKey, quote: bridgeQuote },
+          );
         }
         return;
       }
@@ -2191,7 +2290,14 @@ function DepositWithdrawContent({
         .getUsdcWithdrawFee({ destinationId: withdrawDestinationId })
         .then((feeQuote) => {
           if (!cancelled) {
-            setWithdrawFeeState({ key: withdrawFeeKey, quote: feeQuote });
+            // The periodic refresh usually returns what is already on screen;
+            // reusing the object keeps that tick from re-rendering the row.
+            setWithdrawFeeState((current) =>
+              current?.key === withdrawFeeKey &&
+              isSameWithdrawFeeQuote(current.quote, feeQuote)
+                ? current
+                : { key: withdrawFeeKey, quote: feeQuote },
+            );
           }
         })
         .catch((error) => {
@@ -2224,20 +2330,13 @@ function DepositWithdrawContent({
   ]);
 
   const withdrawFeeText = useMemo(() => {
-    if (!withdrawFeeQuote) {
+    if (!withdrawFeeDisplayQuote) {
       return '--';
     }
-    return withdrawFeeQuote.components
-      .map((component) => {
-        if (component.kind === 'hyperEvmGas') {
-          return `< $${new BigNumber(component.amount).toFixed(2)}`;
-        }
-        return `${component.isEstimate ? '≈ ' : ''}$${new BigNumber(
-          component.amount,
-        ).toFixed(2)}`;
-      })
+    return withdrawFeeDisplayQuote.components
+      .map(formatWithdrawFeeComponent)
       .join(' + ');
-  }, [withdrawFeeQuote]);
+  }, [withdrawFeeDisplayQuote]);
 
   const withdrawSubmitDisabled =
     !isValidAmount ||

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -131,6 +131,9 @@ const PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT = 300;
 const WITHDRAW_QUOTE_REFRESH_INTERVAL_MS = 30_000;
 const LIFI_FALLBACK_LOGO = require('@onekeyhq/kit/assets/perps/lifi-logo.png');
 
+// No estimate marker on the CCTP fee: a chain read that fails falls back to the
+// same number, and submission re-reads it and refuses on drift, so the marker
+// only ever blinks in and out without telling the user anything new.
 function formatWithdrawFeeComponent(
   component: IUsdcWithdrawFeeQuote['components'][number],
 ) {
@@ -138,7 +141,7 @@ function formatWithdrawFeeComponent(
   if (component.kind === 'hyperEvmGas') {
     return `< $${amount}`;
   }
-  return `${component.isEstimate ? '≈ ' : ''}$${amount}`;
+  return `$${amount}`;
 }
 
 // A destination's fee is known before its quote returns, so the row can skip the

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1564,8 +1564,22 @@ function DepositWithdrawContent({
 
   const isInsufficientBalance = useMemo(() => {
     const checkBN = selectedAction === 'deposit' ? tokenAmountBN : amountBN;
-    return checkBN.gt(availableBalanceBN) && checkBN.gt(0);
-  }, [amountBN, tokenAmountBN, availableBalanceBN, selectedAction]);
+    // Withdrawals validate against the gas-reserved maximum, so compare against
+    // the same ceiling. Otherwise an amount inside the reserve leaves the submit
+    // button disabled with nothing explaining why — and the displayed balance is
+    // the untrimmed one, so typing it lands there every time.
+    const limitBN =
+      selectedAction === 'deposit'
+        ? availableBalanceBN
+        : maximumWithdrawAmountBN;
+    return checkBN.gt(limitBN) && checkBN.gt(0);
+  }, [
+    amountBN,
+    tokenAmountBN,
+    availableBalanceBN,
+    maximumWithdrawAmountBN,
+    selectedAction,
+  ]);
 
   const amountInputErrorMessage = useMemo(() => {
     if (isInsufficientBalance) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -2104,28 +2104,40 @@ function DepositWithdrawContent({
   );
 
   // The selector always needs the active external withdrawal rail, including
-  // when HyperEVM is selected. The background service serves its cached value.
+  // when HyperEVM is selected. Kept on the same refresh as the fee quote: a rail
+  // that flips while the form is open makes submission fail with "route
+  // changed", and without a refresh the retry that error asks for can never
+  // succeed. The background service serves its cached value, so most ticks cost
+  // nothing.
   useEffect(() => {
     if (selectedAction !== 'withdraw') {
       return;
     }
     let cancelled = false;
     setWithdrawRoute(undefined);
-    void backgroundApiProxy.serviceHyperliquidExchange
-      .getUsdcWithdrawRoute()
-      .then((route) => {
-        if (!cancelled) {
-          setWithdrawRoute(route);
-        }
-      })
-      .catch((error) => {
-        console.error(
-          '[DepositWithdrawModal] Failed to resolve withdraw route:',
-          error,
-        );
-      });
+    const loadWithdrawRoute = () => {
+      void backgroundApiProxy.serviceHyperliquidExchange
+        .getUsdcWithdrawRoute()
+        .then((route) => {
+          if (!cancelled) {
+            setWithdrawRoute(route);
+          }
+        })
+        .catch((error) => {
+          console.error(
+            '[DepositWithdrawModal] Failed to resolve withdraw route:',
+            error,
+          );
+        });
+    };
+    loadWithdrawRoute();
+    const refreshInterval = setInterval(
+      loadWithdrawRoute,
+      WITHDRAW_QUOTE_REFRESH_INTERVAL_MS,
+    );
     return () => {
       cancelled = true;
+      clearInterval(refreshInterval);
     };
   }, [selectedAction]);
 

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -262,7 +262,10 @@ export class HyperLiquidScene extends BaseScene {
   @LogToServer()
   public withdraw(
     params: IHyperLiquidLogParams<
-      IWithdrawParams,
+      // `route` tells apart the CCTP rail from the legacy Arbitrum bridge, which
+      // fail in different ways and carry different fees; `sourceDex` records
+      // which balance the CCTP rail drew from.
+      IWithdrawParams & { route?: string; sourceDex?: string },
       { success: true } | IApiErrorResponse
     >,
   ) {

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -262,9 +262,8 @@ export class HyperLiquidScene extends BaseScene {
   @LogToServer()
   public withdraw(
     params: IHyperLiquidLogParams<
-      // `route` tells apart the CCTP rail from the legacy Arbitrum bridge, which
-      // fail in different ways and carry different fees; `sourceDex` records
-      // which balance the CCTP rail drew from.
+      // The two new branch points: rails fail differently and charge
+      // differently, and neither choice is visible anywhere else.
       IWithdrawParams & { route?: string; sourceDex?: string },
       { success: true } | IApiErrorResponse
     >,

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -1,5 +1,51 @@
 import type { IHex } from './sdk';
 
+interface IUsdcWithdrawDestinationConfigBase {
+  name: string;
+  networkId: string;
+  signatureChainId: IHex;
+}
+
+export interface ICctpWithdrawDestinationConfig extends IUsdcWithdrawDestinationConfigBase {
+  id: 'ethereum' | 'avalanche' | 'optimism' | 'arbitrum' | 'base';
+  transferType: 'cctp';
+  domain: 0 | 1 | 2 | 3 | 6;
+  addressEncoding: 'hex';
+  fallbackFee: number;
+  supportsLegacyBridge: boolean;
+}
+
+export interface IHyperEvmWithdrawDestinationConfig extends IUsdcWithdrawDestinationConfigBase {
+  id: 'hyperevm';
+  transferType: 'hyperEvm';
+}
+
+export type IUsdcWithdrawDestinationConfig =
+  | ICctpWithdrawDestinationConfig
+  | IHyperEvmWithdrawDestinationConfig;
+
+export type IUsdcWithdrawFeeComponent =
+  | {
+      kind: 'cctpForwarding' | 'legacyBridge';
+      amount: string;
+      token: 'USDC';
+      debitedFrom: 'withdrawAmount';
+      isEstimate: boolean;
+    }
+  | {
+      kind: 'hyperEvmGas';
+      amount: string;
+      token: 'USDC';
+      debitedFrom: 'spotHypeOrSourceUsdc';
+      isEstimate: true;
+      displayAsLessThan: true;
+    };
+
+export interface IUsdcWithdrawFeeQuote {
+  components: IUsdcWithdrawFeeComponent[];
+  quotedAt: number;
+}
+
 export const MAX_DECIMALS_PERP = 6;
 export const MAX_DECIMALS_SPOT = 8;
 export const MAX_SIGNIFICANT_FIGURES = 5;
@@ -22,31 +68,92 @@ export const WITHDRAW_FEE = 1;
 // withdrawal or a plain transfer to HyperEVM.
 export const HYPEREVM_SYSTEM_ADDRESS =
   '0x2000000000000000000000000000000000000000' as IHex;
+export const USDC_WITHDRAW_GAS_RESERVE = 0.01;
 
-// Circle CCTP domain ids (NOT EVM chain ids). Arbitrum is the only destination
-// we withdraw to today.
-export const CCTP_DOMAIN_ARBITRUM = 3;
+// Keep the allowlist here so the UI and BG signer cannot disagree on a route or
+// EIP-712 signing chain. External chains use Circle CCTP domain ids; HyperEVM is
+// a native HyperCore sendAsset transfer and does not have a CCTP destination.
+export const USDC_WITHDRAW_DESTINATIONS = [
+  {
+    id: 'ethereum',
+    name: 'Ethereum',
+    networkId: 'evm--1',
+    transferType: 'cctp',
+    domain: 0,
+    addressEncoding: 'hex',
+    signatureChainId: '0x1',
+    fallbackFee: 1.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'avalanche',
+    name: 'Avalanche',
+    networkId: 'evm--43114',
+    transferType: 'cctp',
+    domain: 1,
+    addressEncoding: 'hex',
+    signatureChainId: '0xa86a',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'optimism',
+    name: 'OP Mainnet',
+    networkId: 'evm--10',
+    transferType: 'cctp',
+    domain: 2,
+    addressEncoding: 'hex',
+    signatureChainId: '0xa',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'arbitrum',
+    name: 'Arbitrum',
+    networkId: 'evm--42161',
+    transferType: 'cctp',
+    domain: 3,
+    addressEncoding: 'hex',
+    signatureChainId: '0xa4b1',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: true,
+  },
+  {
+    id: 'base',
+    name: 'Base',
+    networkId: 'evm--8453',
+    transferType: 'cctp',
+    domain: 6,
+    addressEncoding: 'hex',
+    signatureChainId: '0x2105',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'hyperevm',
+    name: 'HyperEVM',
+    networkId: 'evm--999',
+    transferType: 'hyperEvm',
+    // HyperEVM sendAsset accepts any valid EVM chain id for replay protection.
+    signatureChainId: '0xa4b1',
+  },
+] as const satisfies readonly IUsdcWithdrawDestinationConfig[];
+
+export type IUsdcWithdrawDestinationId =
+  (typeof USDC_WITHDRAW_DESTINATIONS)[number]['id'];
+
+export function getUsdcWithdrawDestination(
+  id: string,
+): IUsdcWithdrawDestinationConfig | undefined {
+  return USDC_WITHDRAW_DESTINATIONS.find((item) => item.id === id);
+}
+
+export const DEFAULT_USDC_WITHDRAW_DESTINATION_ID: IUsdcWithdrawDestinationId =
+  'arbitrum';
 export const CCTP_WITHDRAW_GAS_LIMIT = 200_000;
 // Empty hook data makes CoreDepositWallet attach the default forwarding hook, so
 // Circle delivers to the recipient instead of leaving them to claim it.
 export const CCTP_WITHDRAW_HOOK_DATA = '0x';
-
-// Circle's forwarding fee, deducted from the withdrawn amount. Source of truth is
-// `calculateCrossChainWithdrawalFee(true, domain)` on CoreDepositWallet
-// (HyperEVM 0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24). Mirrored as constants
-// because we only withdraw to Arbitrum, where the value has held since launch;
-// read it live once multiple destinations are selectable.
-const CCTP_WITHDRAW_FEE_DEFAULT = 0.2;
-const CCTP_WITHDRAW_FEE_BY_DOMAIN: Record<number, number> = {
-  0: 1.2, // Ethereum
-  5: 0.5, // Solana
-};
-
-export function getCctpWithdrawFee(destinationDomain: number): number {
-  return (
-    CCTP_WITHDRAW_FEE_BY_DOMAIN[destinationDomain] ?? CCTP_WITHDRAW_FEE_DEFAULT
-  );
-}
 
 export const USDC_TOKEN_INFO = {
   address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as IHex,

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -63,9 +63,8 @@ export const MIN_DEPOSIT_AMOUNT = 5;
 // Legacy Arbitrum bridge (`withdraw3`) fee. Kept for the `bridge` route.
 export const WITHDRAW_FEE = 1;
 
-// HyperCore system address that receives Core -> HyperEVM sends. A `send` delta
-// with this destination is USDC leaving HyperCore, whether it is a CCTP
-// withdrawal or a plain transfer to HyperEVM.
+// Receives every Core -> HyperEVM send, so a `send` here is USDC leaving
+// HyperCore whether by CCTP withdrawal or a plain transfer.
 export const HYPEREVM_SYSTEM_ADDRESS =
   '0x2000000000000000000000000000000000000000' as IHex;
 export const USDC_WITHDRAW_GAS_RESERVE = 0.01;

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -14,7 +14,39 @@ export const HYPERLIQUID_DEPOSIT_ADDRESS =
   '0x2df1c51e09aecf9cacb7bc98cb1742757f163df7' as IHex;
 
 export const MIN_DEPOSIT_AMOUNT = 5;
+// Legacy Arbitrum bridge (`withdraw3`) fee. Kept for the `bridge` route.
 export const WITHDRAW_FEE = 1;
+
+// HyperCore system address that receives Core -> HyperEVM sends. A `send` delta
+// with this destination is USDC leaving HyperCore, whether it is a CCTP
+// withdrawal or a plain transfer to HyperEVM.
+export const HYPEREVM_SYSTEM_ADDRESS =
+  '0x2000000000000000000000000000000000000000' as IHex;
+
+// Circle CCTP domain ids (NOT EVM chain ids). Arbitrum is the only destination
+// we withdraw to today.
+export const CCTP_DOMAIN_ARBITRUM = 3;
+export const CCTP_WITHDRAW_GAS_LIMIT = 200_000;
+// Empty hook data makes CoreDepositWallet attach the default forwarding hook, so
+// Circle delivers to the recipient instead of leaving them to claim it.
+export const CCTP_WITHDRAW_HOOK_DATA = '0x';
+
+// Circle's forwarding fee, deducted from the withdrawn amount. Source of truth is
+// `calculateCrossChainWithdrawalFee(true, domain)` on CoreDepositWallet
+// (HyperEVM 0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24). Mirrored as constants
+// because we only withdraw to Arbitrum, where the value has held since launch;
+// read it live once multiple destinations are selectable.
+const CCTP_WITHDRAW_FEE_DEFAULT = 0.2;
+const CCTP_WITHDRAW_FEE_BY_DOMAIN: Record<number, number> = {
+  0: 1.2, // Ethereum
+  5: 0.5, // Solana
+};
+
+export function getCctpWithdrawFee(destinationDomain: number): number {
+  return (
+    CCTP_WITHDRAW_FEE_BY_DOMAIN[destinationDomain] ?? CCTP_WITHDRAW_FEE_DEFAULT
+  );
+}
 
 export const USDC_TOKEN_INFO = {
   address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as IHex,

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -1,4 +1,5 @@
-import type { IFill, IHex, ITIF, IWithdraw3Request } from './sdk';
+import type { IUsdcWithdrawDestinationId } from './perp.constants';
+import type { IFill, IHex, ITIF } from './sdk';
 import type { EHyperLiquidAgentName } from '../../src/consts/perp';
 
 export enum EPerpsSubscriptionCategory {
@@ -136,8 +137,12 @@ export interface IModifyOrderParams {
   allowZeroSize?: boolean;
 }
 
-export interface IWithdrawParams extends IWithdraw3Request {
+export interface IWithdrawParams {
   userAccountId: string;
+  amount: string;
+  destinationId: IUsdcWithdrawDestinationId;
+  expectedRoute?: 'bridge' | 'cctp';
+  expectedCctpFee?: string;
 }
 
 export interface ILeverageUpdateRequest {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61320](https://onekeyhq.atlassian.net/browse/OK-61320)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Perps USDC withdrawal follows the rail Hyperliquid serves from `info/usdcRouting` and sends `sendToEvmWithData` (Circle CCTP) instead of the deprecated `withdraw3` Arbitrum bridge, dropping the user-facing fee from **$1.00 to $0.20**.
- A CCTP withdrawal reaches the ledger as a `send` to the HyperEVM system address rather than a `withdraw`, so net deposits and the account history row are taught that shape.
- `sendToEvmWithData` requires an explicit source balance, so it mirrors `perpsComputedAccountValueAtom` — spot for unified / portfolio-margin accounts, perp clearinghouse otherwise.

## Intent & Context

Investigation started from a product question: our users pay $1 to withdraw while Hyperliquid's own app charges $0.20 — is the difference builder-vs-official, or something we need to change?

Neither. OneKey takes no cut (the `$1` in the modal was a hardcoded label; the amount is passed to Hyperliquid untouched). The $1 is the fee of Hyperliquid's **legacy Arbitrum bridge**, which their docs now mark deprecated: *"CCTP is the preferred method for minting USDC natively on the Hyperliquid L1… The legacy bridge is deprecated."* USDC moved to Circle CCTP, the legacy bridge holds under 10% of HyperCore's USDC supply, and the official app already switched. We had not.

`POST api.hyperliquid.xyz/info {"type":"usdcRouting"}` currently returns `{"depositRoute":"cctp","withdrawalRoute":"cctp"}`. That endpoint — rather than a constant in our bundle — is what this PR follows.

Circle's integration guide for this exact flow: https://developers.circle.com/cctp/howtos/withdraw-usdc-from-hypercore-to-evm

## Root Cause

Not a bug, but the same shape as one: the withdrawal rail was pinned in the bundle (`exchangeClient.withdraw3`) with no way to follow Hyperliquid's server-side migration, and no way to switch back without a release.

Three downstream assumptions were tied to the legacy rail and would have broken silently on the new one:

1. `usePerpPortfolioData` counted only `delta.type === 'withdraw'` for net deposits. CCTP withdrawals are `send`, so the "Net Deposits" stat would silently stop counting withdrawals the moment we switched rails. (Display only — PnL comes from Hyperliquid's own `portfolio` endpoint and never reads this value.)
2. `AccountRow` already had a `send` entry configured `isIncrease: true`. An outgoing withdrawal would have rendered as a green `+ $X` — money out shown as money in.
3. `withdraw3` let Hyperliquid pick the source balance; `sendToEvmWithData` does not. Unified-account users' withdrawable is the spot-side USDC balance, so a blind `sourceDex: ''` would have drawn from a balance the withdraw form never validated against.

## Design Decisions

**Follow `usdcRouting`, don't hardcode CCTP.** Hyperliquid kept a `bridge`/`cctp` switch, which implies they want the option to revert. Following it means their revert is our revert, with no release on our side. Rabby, the only other wallet found with a native Hyperliquid Perps module, hardcodes `withdraw3` and a literal `1` fee — it would break the day Hyperliquid pulls the bridge.

**Fall back to the confirmed rail, then to `bridge`.** A lookup failure teaches us nothing new, so it must not silently downgrade a user to a rail that is 5× more expensive. A rail already observed live wins; only with nothing observed does it fall back to `bridge`, which has worked in production all along.

**Constants over a live fee read.** The authoritative source is `calculateCrossChainWithdrawalFee(true, domain)` on CoreDepositWallet (HyperEVM `0x6B9E77…0A24`) — verified live: Ethereum 1.20, Solana 0.50, Arbitrum/Base/others 0.20. It is noted in the constants, but the value is display-only, only Arbitrum is reachable today, and 0.20 has held since launch. A network dependency inside a funds modal is not worth buying accuracy we do not yet need; it earns its place when multiple destinations make the per-chain values differ.

**Minimum withdrawal stays at 2 USDC.** The official app uses 2 × fee (0.40). Lowering it opens a failure class: if Circle raises the forwarding fee, a withdrawal under it reverts on the HyperEVM leg. 2 exceeds any plausible fee, and keeping it means zero change from today's behavior.

**`sourceDex` mirrors the atom the form validates against.** Deriving it independently would let the two drift; mirroring `perpsComputedAccountValueAtom` branch-for-branch makes "the balance we spend" and "the balance we validated" the same decision. Rabby reaches the same conclusion (`sourceDex: isUnified ? 'spot' : ''`).

**No optimistic pending-withdrawal row.** There is none today, so omitting it is not a regression. Adding one would need the SDK-internal nonce captured through a custom `nonceManager`, a new persisted store, and handling a write-after-ledger-event race — three new failure points for a new feature, inside a change that ships as a hot update.

## Changes Detail

| File | Purpose |
|---|---|
| `ServiceHyperLiquid/usdcWithdrawRoute.ts` (new) | Resolves the active rail from `info/usdcRouting`; 5-min cache, single in-flight request, prefers a confirmed rail over the fallback. Reports failures through `requestLoggedHyperLiquidTransport`, the same path as every other Hyperliquid request in this service. Uses the transport directly because `usdcRouting` is absent from the pinned SDK's info client — deliberately not bumping `@nktkas/hyperliquid` on a release branch. |
| `ServiceHyperLiquid/usdcWithdrawRoute.test.ts` (new) | 8 tests: following the served rail, both fallback paths, caching, in-flight sharing, failures not cached, confirmed rail retained across a failed lookup. |
| `ServiceHyperliquidExchange.ts` | `withdraw()` branches on the rail; adds `_resolveWithdrawSourceDex()`. Rail and address resolution sit inside the `try` so a failure there is logged like any other withdrawal failure. |
| `usePerpPortfolioData.ts` | The "Net Deposits" stat counts the outbound `send` to the HyperEVM system address, so withdrawals keep counting after the rail switch. Outbound only: inbound EVM → Core credits arrive as `spotTransfer`, and counting them would double up against the existing `accountClassTransfer` branch. |
| `AccountRow.tsx` | A `send` to another party renders as outgoing (`sendOut`); transfers between a user's own balances keep today's rendering, since neither direction describes them. |
| `DepositWithdrawModal.tsx` | Fee row reflects the active rail. Display only — amount validation still uses `MIN_WITHDRAW_AMOUNT`, which covers both rails, and the service re-resolves the rail at submit. |
| `perp.constants.ts` | CCTP domain / gas limit / hook data, the system address, and a per-domain fee map. |
| `logger/.../hyperliquid.ts` | The existing withdrawal analytics event carries `route` and `sourceDex` — the two new branch points, and the fields needed to diagnose a production failure. |

## Verified on mainnet

One real 4 USDC withdrawal from a unified account:

| | |
|---|---|
| Ledger delta | `{"type":"send","destination":"0x2000…0000","sourceDex":"spot","amount":"4.0","fee":"0.0","nativeTokenFee":"0.00002"}` |
| Arbitrum arrival | 3.80 USDC minted from `0x0` (CCTP burn-and-mint), block 500709023 |
| Fee | 4.00 − 3.80 = **$0.20**, exactly as quoted in the modal |
| Latency | ~10s (legacy bridge is 3–5 min) |
| `sourceDex` | Sent `spot`, echoed back `spot` — Hyperliquid honored it |

## Risk Assessment

- **Risk Level**: Medium — funds path, though the blast radius is confined to withdrawal plus two display surfaces.
- **Affected Platforms**: Extension / Mobile / Desktop / Web (JS only — no native code, no `LOCAL_DB_VERSION` bump, no DB schema change, nothing newly persisted; safe as a hot update and safe to roll back).
- **Risk Areas**:
  - `sourceDex` is the funds-critical field. Verified live for `unifiedAccount`; `disabled`, `dexAbstraction` and `portfolioMargin` still want a QA pass. A wrong value fails the withdrawal server-side rather than overspending — Hyperliquid enforces per-dex balances.
  - Net deposits is the widest surface: it changes the "Net Deposits" stat for anyone with `send` deltas to the system address, including HyperEVM users who never withdraw. Display-only — no funds impact, and PnL does not read it.
  - Two independent kill switches, neither needing a release: Hyperliquid flipping `usdcRouting` back to `bridge` returns every client to `withdraw3`, and a failed lookup cannot downgrade a user below a rail already confirmed live.

## Out of scope

- **Multi-chain destinations.** The rail supports Ethereum / Base / Solana; a destination selector plus Solana base58 address entry is a separate change. Fee constants are keyed by CCTP domain so it drops in later.
- **Sub-dex withdrawal.** Unchanged — main-dex USDC only, matching today's behavior and Rabby's.
- **Showing the $0.20 in account history.** The ledger records only the HyperCore-side gas (~$0.001, or 0 when paid in HYPE); the forwarding fee is charged after funds leave HyperCore. Hyperliquid's app papers over this with a hardcoded constant, but a CCTP withdrawal and a plain Core → HyperEVM transfer are indistinguishable in the ledger, so that override would stamp a fee on transfers that never paid one. The modal quotes $0.20 at the moment the user decides, which is the disclosure that matters.
- **Deposits.** `usdcRouting.depositRoute` is also `cctp` while our Arbitrum deposit still targets the legacy bridge address. Same sunset, tracked separately.

## Test plan

- [x] Real mainnet withdrawal, unified account: 4 USDC out, 3.80 USDC received on Arbitrum, $0.20 fee, ~10s
- [x] 8 rail-resolution tests; `ServiceHyperLiquid` + Perps atoms + portfolio utils suites (15 suites, 141 tests)
- [x] Full-repo `tsc`, eslint, prettier, cspell
- [ ] Withdraw from a `disabled` account — expect `sourceDex: ""`, funds leave the perp clearinghouse
- [ ] Withdraw from a `dexAbstraction` account — expect `sourceDex: ""`
- [ ] Withdraw from a `portfolioMargin` account — expect `sourceDex: "spot"`
- [ ] Account history shows the withdrawal as outgoing (red `−`), not incoming
- [ ] Portfolio net deposits / PnL show no phantom loss after withdrawing
- [ ] Fee row reads `$0.20` before submitting
- [ ] Withdrawal below 2 USDC is still rejected by the form

[OK-61320]: https://onekeyhq.atlassian.net/browse/OK-61320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ