### PR TITLE
fix: bound the All Networks header hold and split the 6.5.2 home refresh hotfix OK-61576

### DIFF
--- a/packages/kit/src/hooks/allNetworkRunResultUtils.test.ts
+++ b/packages/kit/src/hooks/allNetworkRunResultUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  isAllNetworkFanOutExhausted,
   resolveAllNetworkFailedRunRestore,
   resolveAllNetworkPublishedResult,
 } from './allNetworkRunResultUtils';
@@ -199,6 +200,61 @@ describe('resolveAllNetworkFailedRunRestore', () => {
     ).toEqual({
       nextLastPublished: previous,
       shouldRestoreResult: false,
+    });
+  });
+});
+
+describe('isAllNetworkFanOutExhausted', () => {
+  const signature = 'account-1|all--networks|wallet-1|0|0';
+
+  test('an owner with no accounts issues no requests and is not exhausted', () => {
+    expect(
+      isAllNetworkFanOutExhausted({ requestCount: 0, resultCount: 0 }),
+    ).toBe(false);
+  });
+
+  test('a fan-out whose every request failed is exhausted', () => {
+    // `continueOnError` maps each rejection to `null`; after filtering, the
+    // fan-out resolves with an empty array instead of throwing.
+    expect(
+      isAllNetworkFanOutExhausted({ requestCount: 3, resultCount: 0 }),
+    ).toBe(true);
+  });
+
+  test('a partially failed fan-out still publishes its results', () => {
+    expect(
+      isAllNetworkFanOutExhausted({ requestCount: 3, resultCount: 1 }),
+    ).toBe(false);
+  });
+
+  test('restores the superseded successful run when the queued refresh is exhausted', () => {
+    const firstRun = [{ networkId: 'evm--1' }];
+
+    // Refresh 1 succeeds but a second manual refresh queued behind it
+    // supersedes the result; the accepted run had cleared the retained
+    // snapshot, so the superseded result becomes the last-good snapshot.
+    const superseded = resolveAllNetworkPublishedResult({
+      completedResult: firstRun,
+      hasQueuedRerun: true,
+      lastPublished: undefined,
+      runSignature: signature,
+      retainSupersededResult: true,
+    });
+    expect(superseded.publishedResult).toBeUndefined();
+
+    // Refresh 2 issues requests but every one of them fails.
+    expect(
+      isAllNetworkFanOutExhausted({ requestCount: 2, resultCount: 0 }),
+    ).toBe(true);
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: superseded.nextLastPublished,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: { result: firstRun, runSignature: signature },
+      shouldRestoreResult: true,
     });
   });
 });

--- a/packages/kit/src/hooks/allNetworkRunResultUtils.test.ts
+++ b/packages/kit/src/hooks/allNetworkRunResultUtils.test.ts
@@ -1,4 +1,7 @@
-import { resolveAllNetworkPublishedResult } from './allNetworkRunResultUtils';
+import {
+  resolveAllNetworkFailedRunRestore,
+  resolveAllNetworkPublishedResult,
+} from './allNetworkRunResultUtils';
 
 describe('resolveAllNetworkPublishedResult', () => {
   const signature = 'account-1|all--networks|wallet-1|0|0';
@@ -83,6 +86,119 @@ describe('resolveAllNetworkPublishedResult', () => {
     ).toEqual({
       publishedResult: null,
       nextLastPublished: { result: null, runSignature: signature },
+    });
+  });
+
+  test('retains a superseded result as the last-good snapshot when the accepted run cleared it', () => {
+    const completed = [{ networkId: 'evm--1' }];
+
+    // The accepted run invalidated the retained result before its fan-out;
+    // a must-run queued meanwhile supersedes this completed result.
+    const resolved = resolveAllNetworkPublishedResult({
+      completedResult: completed,
+      hasQueuedRerun: true,
+      lastPublished: undefined,
+      runSignature: signature,
+      retainSupersededResult: true,
+    });
+
+    expect(resolved).toEqual({
+      publishedResult: undefined,
+      nextLastPublished: { result: completed, runSignature: signature },
+    });
+
+    // The queued run fails: the superseded snapshot must be restorable.
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: resolved.nextLastPublished,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: { result: completed, runSignature: signature },
+      shouldRestoreResult: true,
+    });
+  });
+
+  test('prefers the newer superseded result over a retained one when retaining', () => {
+    const previous = [{ networkId: 'btc--0' }];
+    const completed = [{ networkId: 'evm--1' }];
+
+    expect(
+      resolveAllNetworkPublishedResult({
+        completedResult: completed,
+        hasQueuedRerun: true,
+        lastPublished: { result: previous, runSignature: signature },
+        runSignature: signature,
+        retainSupersededResult: true,
+      }),
+    ).toEqual({
+      publishedResult: previous,
+      nextLastPublished: { result: completed, runSignature: signature },
+    });
+  });
+});
+
+describe('resolveAllNetworkFailedRunRestore', () => {
+  const signature = 'account-1|all--networks|wallet-1|0|0';
+  const previous = {
+    result: [{ networkId: 'evm--1' }],
+    runSignature: signature,
+  };
+
+  test('restores the last-good result when the owner is unchanged', () => {
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: previous,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: previous,
+      shouldRestoreResult: true,
+    });
+  });
+
+  test('keeps the ref but does not touch the visible result after an owner switch', () => {
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: previous,
+        ownerUnchanged: false,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: previous,
+      shouldRestoreResult: false,
+    });
+  });
+
+  test('has nothing to restore when no result was ever published', () => {
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: undefined,
+        ownerUnchanged: true,
+        currentRunSignature: signature,
+      }),
+    ).toEqual({
+      nextLastPublished: undefined,
+      shouldRestoreResult: false,
+    });
+  });
+
+  test('keeps the ref but does not publish a snapshot minted for another run signature', () => {
+    // The retained ref outlives an account switch: owner X's superseded
+    // result is still in the ref when owner Y's first run is accepted. If
+    // that run fails, `ownerUnchanged` is true for Y's own runner, yet the
+    // snapshot belongs to X and must not be published under Y.
+    expect(
+      resolveAllNetworkFailedRunRestore({
+        previousPublished: previous,
+        ownerUnchanged: true,
+        currentRunSignature: 'account-2|all--networks|wallet-1|0|0',
+      }),
+    ).toEqual({
+      nextLastPublished: previous,
+      shouldRestoreResult: false,
     });
   });
 });

--- a/packages/kit/src/hooks/allNetworkRunResultUtils.ts
+++ b/packages/kit/src/hooks/allNetworkRunResultUtils.ts
@@ -60,6 +60,23 @@ export function resolveAllNetworkPublishedResult<T>({
  * unconditional: the skip path and the publish path both re-check the run
  * signature before serving it.
  */
+/**
+ * Every per-network request of a fan-out failed. `continueOnError` turns each
+ * rejection into `null`, so such a fan-out resolves with no results instead of
+ * throwing — by the result alone it looks exactly like an owner with no
+ * accounts. The request count tells the two apart: "no accounts" issues no
+ * requests at all.
+ */
+export function isAllNetworkFanOutExhausted({
+  requestCount,
+  resultCount,
+}: {
+  requestCount: number;
+  resultCount: number;
+}): boolean {
+  return requestCount > 0 && resultCount === 0;
+}
+
 export function resolveAllNetworkFailedRunRestore<T>({
   previousPublished,
   ownerUnchanged,

--- a/packages/kit/src/hooks/allNetworkRunResultUtils.ts
+++ b/packages/kit/src/hooks/allNetworkRunResultUtils.ts
@@ -8,11 +8,19 @@ export function resolveAllNetworkPublishedResult<T>({
   hasQueuedRerun,
   lastPublished,
   runSignature,
+  retainSupersededResult = false,
 }: {
   completedResult: Array<T> | null;
   hasQueuedRerun: boolean;
   lastPublished: IAllNetworkLastPublishedResult<T> | undefined;
   runSignature: string;
+  /**
+   * Consumers that clear the retained result when a run is accepted have no
+   * last-good snapshot left by the time a superseded run completes. Record
+   * the superseded (unpublished) result as that snapshot so the queued run
+   * can restore it if its own fan-out fails.
+   */
+  retainSupersededResult?: boolean;
 }): {
   publishedResult: Array<T> | null | undefined;
   nextLastPublished: IAllNetworkLastPublishedResult<T> | undefined;
@@ -23,7 +31,9 @@ export function resolveAllNetworkPublishedResult<T>({
         lastPublished?.runSignature === runSignature
           ? lastPublished.result
           : undefined,
-      nextLastPublished: lastPublished,
+      nextLastPublished: retainSupersededResult
+        ? { result: completedResult, runSignature }
+        : lastPublished,
     };
   }
 
@@ -34,5 +44,39 @@ export function resolveAllNetworkPublishedResult<T>({
   return {
     publishedResult: completedResult,
     nextLastPublished,
+  };
+}
+
+/**
+ * An accepted run invalidates the retained result BEFORE its fan-out starts.
+ * When that fan-out then fails, the previously published result must be
+ * restored — otherwise the consumer stays pinned on `undefined` until the
+ * next successful must-run. The visible result is only restored while the
+ * owner is unchanged AND the retained snapshot carries the current run
+ * signature. `ownerUnchanged` only proves the failed runner still owns the
+ * hook; the retained ref outlives account/network switches, so without the
+ * signature check the first failed refresh after a switch would publish the
+ * previous owner's snapshot under the new owner. The ref restore itself is
+ * unconditional: the skip path and the publish path both re-check the run
+ * signature before serving it.
+ */
+export function resolveAllNetworkFailedRunRestore<T>({
+  previousPublished,
+  ownerUnchanged,
+  currentRunSignature,
+}: {
+  previousPublished: IAllNetworkLastPublishedResult<T> | undefined;
+  ownerUnchanged: boolean;
+  currentRunSignature: string;
+}): {
+  nextLastPublished: IAllNetworkLastPublishedResult<T> | undefined;
+  shouldRestoreResult: boolean;
+} {
+  return {
+    nextLastPublished: previousPublished,
+    shouldRestoreResult:
+      ownerUnchanged &&
+      previousPublished !== undefined &&
+      previousPublished.runSignature === currentRunSignature,
   };
 }

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -38,6 +38,7 @@ import { perfTokenListView } from '../components/TokenListView/perfTokenListView
 
 import {
   type IAllNetworkLastPublishedResult,
+  isAllNetworkFanOutExhausted,
   resolveAllNetworkFailedRunRestore,
   resolveAllNetworkPublishedResult,
 } from './allNetworkRunResultUtils';
@@ -744,6 +745,9 @@ function useAllNetworkRequests<T>(params: {
       let onStartedError: unknown;
       let onStartedTask: Promise<void> | undefined;
       let completedResult: Array<T> | null = null;
+      // Per-network requests actually issued by this run; distinguishes an
+      // owner with no accounts from a fan-out whose every request failed.
+      let fanOutRequestCount = 0;
       let hasQueuedRerun = false;
 
       try {
@@ -994,6 +998,7 @@ function useAllNetworkRequests<T>(params: {
               });
           });
 
+          fanOutRequestCount = requestFactories.length;
           try {
             // L4a: sliding-window executor (worker-pool) replaces the
             // batch-barrier so a slow network no longer idles the rest of its
@@ -1040,6 +1045,7 @@ function useAllNetworkRequests<T>(params: {
             const factories = Array.from(accountsInfoBackendIndexed).map(
               makeColdFactory,
             );
+            fanOutRequestCount += factories.length;
             const r = (
               await promiseAllSettledEnhanced(factories, {
                 continueOnError: true,
@@ -1058,6 +1064,7 @@ function useAllNetworkRequests<T>(params: {
             const factories = Array.from(accountsInfoBackendNotIndexed).map(
               makeColdFactory,
             );
+            fanOutRequestCount += factories.length;
             const r = (
               await promiseAllSettledEnhanced(factories, {
                 continueOnError: true,
@@ -1140,6 +1147,44 @@ function useAllNetworkRequests<T>(params: {
         // result can be classified as superseded before publication.
         isFetching.current = false;
         hasQueuedRerun = scheduleQueuedRerun();
+      }
+
+      if (
+        clearRetainedResultOnAcceptedRun &&
+        isAllNetworkFanOutExhausted({
+          requestCount: fanOutRequestCount,
+          resultCount: completedResult?.length ?? 0,
+        })
+      ) {
+        // Every per-network request failed. `continueOnError` turned each
+        // rejection into `null`, so the fan-out resolved with no results and
+        // never reached the catch above. Publishing that empty result would
+        // overwrite the retained last-good snapshot (e.g. a superseded
+        // successful run) with nothing, and the consumer skips its
+        // authoritative commit on an empty result — so it would never mark
+        // the snapshot complete. Treat it exactly like a failed fan-out:
+        // keep the retained snapshot and serve it again under the same
+        // owner/signature guard as the throw path.
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'all-network-fan-out-exhausted',
+          networkId: currentNetworkId,
+          isAllNetworks: true,
+          accountsCount: fanOutRequestCount,
+          resultCount: 0,
+          ownerPresent: !!currentAccountId,
+          reason: requestKind,
+        });
+        const { nextLastPublished, shouldRestoreResult } =
+          resolveAllNetworkFailedRunRestore({
+            previousPublished: previousPublishedResult,
+            ownerUnchanged: liveRunOwnerKeyRef.current === runnerOwnerKey,
+            currentRunSignature,
+          });
+        lastPublishedResultRef.current = nextLastPublished;
+        return shouldRestoreResult && previousPublishedResult
+          ? previousPublishedResult.result
+          : undefined;
       }
 
       const resolved = resolveAllNetworkPublishedResult({

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -45,6 +45,7 @@ import { makeColdRequestFactory } from './makeColdRequestFactory';
 import { reorderNetworksByCachePriority } from './reorderNetworksByCachePriority';
 import { shouldSkipRedundantAllNetworkRun } from './shouldSkipRedundantAllNetworkRun';
 import { usePromiseResult } from './usePromiseResult';
+import { useRouteIsFocused } from './useRouteIsFocused';
 
 // Native keeps a strict cap to avoid Hermes memory spikes.
 // Web keeps full fan-out to preserve Home startup latency.
@@ -410,6 +411,43 @@ function useAllNetworkRequests<T>(params: {
   const runGenerationRef = useRef(0);
   const [isEmptyAccount, setIsEmptyAccount] = useState(false);
   const [isLocked] = useAppIsLockedAtom();
+  const isRouteFocused = useRouteIsFocused();
+  let traceRequestKind = 'token';
+  if (isNFTRequests) {
+    traceRequestKind = 'nft';
+  } else if (isDeFiRequests) {
+    traceRequestKind = 'defi';
+  }
+  // Diagnostic: usePromiseResult drops deps-triggered runs while the route
+  // is unfocused or the app is locked, and that skip is invisible from this
+  // hook. Record the gate inputs whenever they change so a run that never
+  // starts can be explained from device logs.
+  useEffect(() => {
+    if (!isAllNetworks) {
+      return;
+    }
+    defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+      runtime: 'main',
+      phase: 'all-network-hook-gate',
+      networkId: currentNetworkId,
+      isAllNetworks: true,
+      reason: traceRequestKind,
+      disabled,
+      isRouteFocused,
+      isLocked,
+      shouldAlwaysFetch: !!shouldAlwaysFetch,
+      ownerPresent: !!currentAccountId,
+    });
+  }, [
+    currentAccountId,
+    currentNetworkId,
+    disabled,
+    isAllNetworks,
+    isLocked,
+    isRouteFocused,
+    shouldAlwaysFetch,
+    traceRequestKind,
+  ]);
   const [enabledNetworksChangedNonce, setEnabledNetworksChangedNonce] =
     useState(0);
   const rerunAfterCurrentRef = useRef(false);
@@ -594,20 +632,44 @@ function useAllNetworkRequests<T>(params: {
       // out before the redundant-run gate so the stale closure cannot clear
       // the new owner's published result via `applyResultRef` or corrupt
       // `lastRunSignatureRef` / `isFetching` with a full ghost fan-out.
+      let requestKind = 'token';
+      if (isNFTRequests) {
+        requestKind = 'nft';
+      } else if (isDeFiRequests) {
+        requestKind = 'defi';
+      }
+      const traceRunSkipped = (skipReason: string) => {
+        if (!isAllNetworks) {
+          return;
+        }
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'all-network-hook-run-skipped',
+          networkId: currentNetworkId,
+          isAllNetworks: true,
+          reason: requestKind,
+          skipReason,
+          ownerPresent: !!currentAccountId,
+        });
+      };
       if (liveRunOwnerKeyRef.current !== runnerOwnerKey) {
+        traceRunSkipped('stale-owner');
         if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
         return;
       }
 
       if (effectiveDisabled) {
+        traceRunSkipped('disabled');
         if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
         return;
       }
       if (isFetching.current) {
+        traceRunSkipped('queued-behind-active-run');
         rerunAfterCurrentRef.current = true;
         return;
       }
       if (!currentAccountId || !currentNetworkId || !currentWalletId) {
+        traceRunSkipped('missing-owner');
         if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
         return;
       }
@@ -630,12 +692,6 @@ function useAllNetworkRequests<T>(params: {
         alwaysSetStateForThisRun ||
         skipAccountsCacheRef.current ||
         ignoreDisabledForThisRun;
-      let requestKind = 'token';
-      if (isNFTRequests) {
-        requestKind = 'nft';
-      } else if (isDeFiRequests) {
-        requestKind = 'defi';
-      }
       if (
         shouldSkipRedundantAllNetworkRun({
           isMustRun,
@@ -644,6 +700,7 @@ function useAllNetworkRequests<T>(params: {
           lastSignature: lastRunSignatureRef.current,
         })
       ) {
+        traceRunSkipped('redundant-same-owner');
         if (clearRetainedResultOnAcceptedRun) {
           scheduleQueuedRerun();
           return lastPublishedResultRef.current?.runSignature ===

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -466,6 +466,10 @@ function useAllNetworkRequests<T>(params: {
   >(undefined);
   // Render-updated owner identity used to detect a stale runner closure.
   const liveRunOwnerKeyRef = useRef('');
+  // Invariant: only an accepted run writes this ref, and acceptance is
+  // serialized by `isFetching` (set at accept, released only in `finally`;
+  // a queued rerun starts from a later macrotask). A failed run's restore
+  // therefore never overwrites a snapshot published by a newer owner's run.
   const lastPublishedResultRef = useRef<
     IAllNetworkLastPublishedResult<T> | undefined
   >(undefined);

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -38,6 +38,7 @@ import { perfTokenListView } from '../components/TokenListView/perfTokenListView
 
 import {
   type IAllNetworkLastPublishedResult,
+  resolveAllNetworkFailedRunRestore,
   resolveAllNetworkPublishedResult,
 } from './allNetworkRunResultUtils';
 import { makeColdRequestFactory } from './makeColdRequestFactory';
@@ -214,6 +215,26 @@ function filterAllNetworkAccountsInfoResult({
   };
 }
 
+// Identity of the owner a runner closure was created for. A runner parked in
+// the debounce window can outlive an account/network/wallet switch; comparing
+// this key against a render-updated ref lets the stale runner bail out before
+// it mutates any shared ref or clears the new owner's published result.
+function buildAllNetworkRunOwnerKey({
+  accountId,
+  networkId,
+  walletId,
+  isAllNetworks,
+}: {
+  accountId?: string;
+  networkId?: string;
+  walletId?: string;
+  isAllNetworks?: boolean;
+}): string {
+  return `${accountId ?? ''}|${networkId ?? ''}|${walletId ?? ''}|${
+    isAllNetworks ? 1 : 0
+  }`;
+}
+
 type IEnabledNetworksCompatResult = {
   networkInfoMap: Record<string, INetworkDeriveInfo>;
   compatibleNetworks: IServerNetwork[];
@@ -341,6 +362,11 @@ function useAllNetworkRequests<T>(params: {
   // consumer's LWW materialized view reject a stale earlier run's settle.
   onRequestSettled?: (result: T, generation: number) => void;
   revalidateOnFocus?: boolean;
+  // Clear a retained result after the all-network redundant-run gate accepts a
+  // new fan-out. Deliberately NOT forwarded to usePromiseResult's
+  // `undefinedResultIfReRun` (which clears on EVERY runner start): a skipped
+  // duplicate must keep its stable result here.
+  clearRetainedResultOnAcceptedRun?: boolean;
 }) {
   type IAllNetworkRequestsRunConfig = {
     alwaysSetState?: boolean;
@@ -367,9 +393,15 @@ function useAllNetworkRequests<T>(params: {
     onCacheChecked,
     onRequestSettled,
     revalidateOnFocus = false,
+    clearRetainedResultOnAcceptedRun = false,
   } = params;
   const allNetworkDataInit = useRef(false);
   const isFetching = useRef(false);
+  // Reserve active debounce windows so a second manual refresh is queued by
+  // runWithQueue instead of starting another usePromiseResult runner and
+  // invalidating the first runner's nonce. A count handles overlapping
+  // dependency-triggered runners without releasing the reservation early.
+  const debouncePendingCountRef = useRef(0);
   const runCountRef = useRef(0);
   // Monotonic run generation for the consumer's LWW materialized view. Unlike
   // `runCountRef` (reset to 0 on owner/enabled-network change), this is NEVER
@@ -387,6 +419,14 @@ function useAllNetworkRequests<T>(params: {
   const runWithQueueRef = useRef<
     ((config?: IAllNetworkRequestsRunConfig) => Promise<void>) | undefined
   >(undefined);
+  // Applies a value to the hook result from inside the runner closure.
+  // `setResult` is declared after the runner (usePromiseResult return), so it
+  // must be reached through a render-updated ref.
+  const applyResultRef = useRef<
+    ((result: Array<T> | null | undefined) => void) | undefined
+  >(undefined);
+  // Render-updated owner identity used to detect a stale runner closure.
+  const liveRunOwnerKeyRef = useRef('');
   const lastPublishedResultRef = useRef<
     IAllNetworkLastPublishedResult<T> | undefined
   >(undefined);
@@ -479,8 +519,14 @@ function useAllNetworkRequests<T>(params: {
     enabledNetworksChangedNonce,
   ]);
 
-  const { run, result } = usePromiseResult(
+  const { run, result, setResult } = usePromiseResult(
     async () => {
+      const runnerOwnerKey = buildAllNetworkRunOwnerKey({
+        accountId: currentAccountId,
+        networkId: currentNetworkId,
+        walletId: currentWalletId,
+        isAllNetworks,
+      });
       const ignoreDisabledForThisRun = ignoreDisabledRef.current;
       ignoreDisabledRef.current = false;
       const effectiveDisabled = disabled && !ignoreDisabledForThisRun;
@@ -493,7 +539,16 @@ function useAllNetworkRequests<T>(params: {
         !!isAllNetworks &&
         runCountRef.current > 0;
       if (shouldDebounceWait) {
-        await timerUtils.wait(POLLING_DEBOUNCE_INTERVAL);
+        if (clearRetainedResultOnAcceptedRun) {
+          debouncePendingCountRef.current += 1;
+        }
+        try {
+          await timerUtils.wait(POLLING_DEBOUNCE_INTERVAL);
+        } finally {
+          if (clearRetainedResultOnAcceptedRun) {
+            debouncePendingCountRef.current -= 1;
+          }
+        }
       }
       perfTokenListView.markEnd(
         'useAllNetworkRequestsRun_debounceDelay',
@@ -506,13 +561,60 @@ function useAllNetworkRequests<T>(params: {
 
       perfTokenListView.markStart('useAllNetworkRequestsRun');
 
-      if (effectiveDisabled) return;
+      const scheduleQueuedRerun = () => {
+        const hasQueuedRerun = rerunAfterCurrentRef.current;
+        if (!hasQueuedRerun) {
+          return false;
+        }
+        rerunAfterCurrentRef.current = false;
+        // Preserve the explicit refresh flags from runWithQueue. A queue set
+        // by an internal dependency runner has no config and must still pass
+        // through the redundant-run gate; otherwise every render churn could
+        // be promoted to another forced fan-out.
+        const rerunConfig = rerunConfigRef.current;
+        const hasQueuedMustRun =
+          !!rerunConfig?.alwaysSetState ||
+          !!rerunConfig?.skipAccountsCache ||
+          !!rerunConfig?.ignoreDisabled;
+        rerunConfigRef.current = undefined;
+        setTimeout(() => {
+          void runWithQueueRef.current?.(rerunConfig);
+        }, 0);
+        // Only an explicit must-run refresh supersedes the result that just
+        // completed. A dependency-triggered duplicate is still drained, but
+        // its preceding result remains publishable while the gate skips it.
+        return clearRetainedResultOnAcceptedRun
+          ? hasQueuedMustRun
+          : hasQueuedRerun;
+      };
+
+      // A runner resumed from the debounce window may belong to a previous
+      // owner: the dep change that swapped the owner already spawned a fresh
+      // runner, and this one's return value is nonce-invalidated anyway. Bail
+      // out before the redundant-run gate so the stale closure cannot clear
+      // the new owner's published result via `applyResultRef` or corrupt
+      // `lastRunSignatureRef` / `isFetching` with a full ghost fan-out.
+      if (liveRunOwnerKeyRef.current !== runnerOwnerKey) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
+
+      if (effectiveDisabled) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
       if (isFetching.current) {
         rerunAfterCurrentRef.current = true;
         return;
       }
-      if (!currentAccountId || !currentNetworkId || !currentWalletId) return;
-      if (!isAllNetworks) return;
+      if (!currentAccountId || !currentNetworkId || !currentWalletId) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
+      if (!isAllNetworks) {
+        if (clearRetainedResultOnAcceptedRun) scheduleQueuedRerun();
+        return;
+      }
 
       // L5: drop redundant same-owner re-fires (usePromiseResult dep-identity
       // churn during/after a switch). Read+reset the relayed alwaysSetState
@@ -542,9 +644,26 @@ function useAllNetworkRequests<T>(params: {
           lastSignature: lastRunSignatureRef.current,
         })
       ) {
+        if (clearRetainedResultOnAcceptedRun) {
+          scheduleQueuedRerun();
+          return lastPublishedResultRef.current?.runSignature ===
+            currentRunSignature
+            ? lastPublishedResultRef.current.result
+            : undefined;
+        }
         return;
       }
       lastRunSignatureRef.current = currentRunSignature;
+
+      // Captured for the failure path: an accepted run invalidates the
+      // retained result below, and a failed fan-out must restore it.
+      const previousPublishedResult = lastPublishedResultRef.current;
+      if (clearRetainedResultOnAcceptedRun) {
+        // Keep a queued refresh from restoring the prior published result
+        // after the new run has already invalidated it.
+        applyResultRef.current?.(undefined);
+        lastPublishedResultRef.current = undefined;
+      }
 
       runCountRef.current += 1;
       runGenerationRef.current += 1;
@@ -912,6 +1031,29 @@ function useAllNetworkRequests<T>(params: {
           ownerPresent: !!currentAccountId,
           reason: requestKind,
         });
+      } catch (error) {
+        if (clearRetainedResultOnAcceptedRun) {
+          // The accepted run cleared the retained result before fetching.
+          // Restore the last-good snapshot so a failed fan-out does not pin
+          // the consumer on `undefined` until the next successful must-run.
+          // The visible result is only restored while the owner is unchanged
+          // AND the retained snapshot carries this run's signature: the ref
+          // outlives owner switches, so `ownerUnchanged` alone cannot prove
+          // the snapshot belongs to the current owner. The ref restore alone
+          // is safe because the skip path re-checks the run signature before
+          // serving it.
+          const { nextLastPublished, shouldRestoreResult } =
+            resolveAllNetworkFailedRunRestore({
+              previousPublished: previousPublishedResult,
+              ownerUnchanged: liveRunOwnerKeyRef.current === runnerOwnerKey,
+              currentRunSignature,
+            });
+          lastPublishedResultRef.current = nextLastPublished;
+          if (shouldRestoreResult && previousPublishedResult) {
+            applyResultRef.current?.(previousPublishedResult.result);
+          }
+        }
+        throw error;
       } finally {
         // Wait for onStarted to settle before firing onFinished, so
         // the started/finished events for this run land in monotonic
@@ -940,15 +1082,7 @@ function useAllNetworkRequests<T>(params: {
         // during async cleanup must queue behind this run so its completed
         // result can be classified as superseded before publication.
         isFetching.current = false;
-        hasQueuedRerun = rerunAfterCurrentRef.current;
-        if (hasQueuedRerun) {
-          rerunAfterCurrentRef.current = false;
-          const rerunConfig = rerunConfigRef.current;
-          rerunConfigRef.current = undefined;
-          setTimeout(() => {
-            void runWithQueueRef.current?.(rerunConfig);
-          }, 0);
-        }
+        hasQueuedRerun = scheduleQueuedRerun();
       }
 
       const resolved = resolveAllNetworkPublishedResult({
@@ -956,6 +1090,10 @@ function useAllNetworkRequests<T>(params: {
         hasQueuedRerun,
         lastPublished: lastPublishedResultRef.current,
         runSignature: currentRunSignature,
+        // The accepted run cleared the retained result above; a superseded
+        // completed result is then the only last-good snapshot the queued
+        // must-run can restore from if its fan-out fails.
+        retainSupersededResult: clearRetainedResultOnAcceptedRun,
       });
       lastPublishedResultRef.current = resolved.nextLastPublished;
       return resolved.publishedResult;
@@ -978,6 +1116,7 @@ function useAllNetworkRequests<T>(params: {
       allNetworkCacheData,
       allNetworkRequests,
       onRequestSettled,
+      clearRetainedResultOnAcceptedRun,
     ],
     {
       revalidateOnFocus,
@@ -989,7 +1128,11 @@ function useAllNetworkRequests<T>(params: {
 
   const runWithQueue = useCallback(
     async (config?: IAllNetworkRequestsRunConfig) => {
-      if (isFetching.current) {
+      if (
+        isFetching.current ||
+        (clearRetainedResultOnAcceptedRun &&
+          debouncePendingCountRef.current > 0)
+      ) {
         rerunAfterCurrentRef.current = true;
         rerunConfigRef.current = {
           ...rerunConfigRef.current,
@@ -1017,9 +1160,16 @@ function useAllNetworkRequests<T>(params: {
       }
       await run(config);
     },
-    [run],
+    [run, clearRetainedResultOnAcceptedRun],
   );
 
+  applyResultRef.current = (nextResult) => setResult(nextResult);
+  liveRunOwnerKeyRef.current = buildAllNetworkRunOwnerKey({
+    accountId: currentAccountId,
+    networkId: currentNetworkId,
+    walletId: currentWalletId,
+    isAllNetworks,
+  });
   runWithQueueRef.current = runWithQueue;
 
   return {

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -1416,7 +1416,10 @@ function TokenSelector() {
             valueAccountId = activeAccountId;
           }
         }
-        if (valueAccountId && activeNetworkId) {
+        // A filtered selector response is only a token subset (wallet-only or
+        // dApp-only). It must not be persisted as the canonical network total;
+        // otherwise opening the selector can overwrite Home with a partial sum.
+        if (valueAccountId && activeNetworkId && !showTokenSelectorFilter) {
           const valueKey = accountUtils.buildAccountValueKey({
             accountId: activeAccountId,
             networkId: activeNetworkId,
@@ -1461,6 +1464,7 @@ function TokenSelector() {
     networkId,
     showActiveAccountTokenList,
     showLpTokensOnly,
+    showTokenSelectorFilter,
     showFetchTokenListErrorToast,
     tokenSelectorFilterParams,
     useSelectorFilteredTokenList,

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.cacheOnlyGate.test.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.cacheOnlyGate.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/*
+yarn jest packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.cacheOnlyGate.test.ts
+*/
+
+describe('DeFiListBlock cache-only readiness producer', () => {
+  it('lets the cache-only all-network hook run regardless of route focus', () => {
+    // The cache-only instance is the only writer of the header's DeFi
+    // readiness. Device logs showed sessions where its hook never started,
+    // pinning the All Networks header to a stale persisted total.
+    const source = readFileSync(join(__dirname, 'DeFiListBlock.tsx'), 'utf8');
+    const hookStart = source.indexOf('} = useAllNetworkRequests<');
+    const hookEnd = source.indexOf('});', hookStart);
+    const hookConfig = source.slice(hookStart, hookEnd);
+
+    expect(hookStart).toBeGreaterThan(0);
+    expect(hookConfig).toContain('isDeFiRequests: true');
+    expect(hookConfig).toContain('shouldAlwaysFetch: refreshCacheOnly');
+  });
+});

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -958,6 +958,11 @@ function DeFiListBlock({
     clearAllNetworkData: handleClearAllNetworkData,
     isDeFiRequests: true,
     disabled: network?.isAllNetworks ? !isAllNetRequestsEnabled : false,
+    // The cache-only instance is the sole writer of the header's DeFi
+    // readiness and only reads local caches. usePromiseResult skips
+    // deps-triggered runs while the route is unfocused, which left readiness
+    // unset for entire sessions; let this instance run regardless of focus.
+    shouldAlwaysFetch: refreshCacheOnly,
   });
 
   const handleRefreshAllNetworkData = useCallback(() => {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -64,6 +64,7 @@ import {
   shouldShowDeFiEmptyState,
 } from './deFiListLoadingReducer';
 import { DeFiListSkeleton } from './DeFiListSkeleton';
+import { planDeFiOverviewInit } from './deFiOverviewInitPlan';
 import { getOverviewCollapsedProtocolLimit } from './DeFiOverviewPlanner';
 import { formatPortfolioTotal } from './formatPortfolioTotal';
 import { buildDeFiOverviewCells } from './hooks/useDeFiOverviewTopN';
@@ -281,6 +282,8 @@ function DeFiListBlock({
     cacheKey?: string;
     hasCache: boolean;
   }>({ hasCache: false });
+  // Owner the init effect last ran for; see planDeFiOverviewInit.
+  const initDeFiOwnerKeyRef = useRef<string | undefined>(undefined);
 
   const [isSliced, setIsSliced] = useDeFiListSlicedAtom();
   const overviewCols = useMemo(
@@ -1036,17 +1039,26 @@ function DeFiListBlock({
         cacheKey,
         hasCache: false,
       };
-      updateOverviewDeFiDataState({
+      const initPlan = planDeFiOverviewInit({
         accountId,
         networkId,
-        isReady: undefined,
+        accountAddress: account?.address,
+        lastInitOwnerKey: initDeFiOwnerKeyRef.current,
       });
+      initDeFiOwnerKeyRef.current = initPlan.ownerKey;
+      if (initPlan.shouldResetReadiness) {
+        updateOverviewDeFiDataState({
+          accountId,
+          networkId,
+          isReady: undefined,
+        });
+      }
       void backgroundApiProxy.serviceDeFi.updateCurrentAccount({
         networkId,
         accountId,
       });
 
-      if (networkUtils.isAllNetwork({ networkId })) {
+      if (!initPlan.shouldHydrateSingleNetworkCache) {
         return;
       }
 

--- a/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.test.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.test.ts
@@ -1,0 +1,60 @@
+import {
+  buildDeFiOverviewInitOwnerKey,
+  planDeFiOverviewInit,
+} from './deFiOverviewInitPlan';
+
+const owner = {
+  accountId: 'hd-1--m/44h/60h/0h/0/0',
+  networkId: 'onekeyall--0',
+  accountAddress: '0xabc',
+};
+
+describe('planDeFiOverviewInit', () => {
+  it('resets readiness on the first init for an owner', () => {
+    const plan = planDeFiOverviewInit({
+      ...owner,
+      lastInitOwnerKey: undefined,
+    });
+    expect(plan.isOwnerChanged).toBe(true);
+    expect(plan.shouldResetReadiness).toBe(true);
+    expect(plan.shouldHydrateSingleNetworkCache).toBe(false);
+  });
+
+  it('keeps all-network readiness when only the currency map changed', () => {
+    // A currency-map refresh re-fires the init effect for the SAME owner.
+    // The cache-only Portfolio instance only writes readiness during the
+    // cold cache probe, so clearing it here would leave the header pinned
+    // on the last confirmed balance until the DeFi tab is visited.
+    const plan = planDeFiOverviewInit({
+      ...owner,
+      lastInitOwnerKey: buildDeFiOverviewInitOwnerKey(owner),
+    });
+    expect(plan.isOwnerChanged).toBe(false);
+    expect(plan.shouldResetReadiness).toBe(false);
+    expect(plan.shouldHydrateSingleNetworkCache).toBe(false);
+  });
+
+  it('re-hydrates the single-network cache for a same-owner re-run', () => {
+    const singleNetworkOwner = { ...owner, networkId: 'evm--1' };
+    const plan = planDeFiOverviewInit({
+      ...singleNetworkOwner,
+      lastInitOwnerKey: buildDeFiOverviewInitOwnerKey(singleNetworkOwner),
+    });
+    expect(plan.shouldResetReadiness).toBe(false);
+    expect(plan.shouldHydrateSingleNetworkCache).toBe(true);
+  });
+
+  it.each([
+    ['accountId', { accountId: 'hd-2--m/44h/60h/0h/0/0' }],
+    ['networkId', { networkId: 'evm--1' }],
+    ['accountAddress', { accountAddress: '0xdef' }],
+  ])('resets readiness when %s changes', (_field, patch) => {
+    const plan = planDeFiOverviewInit({
+      ...owner,
+      ...patch,
+      lastInitOwnerKey: buildDeFiOverviewInitOwnerKey(owner),
+    });
+    expect(plan.isOwnerChanged).toBe(true);
+    expect(plan.shouldResetReadiness).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/deFiOverviewInitPlan.ts
@@ -1,0 +1,57 @@
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+
+export interface IDeFiOverviewInitOwner {
+  accountId: string;
+  networkId: string;
+  accountAddress?: string;
+}
+
+export interface IDeFiOverviewInitPlan {
+  ownerKey: string;
+  isOwnerChanged: boolean;
+  /**
+   * Clear `overviewDeFiDataState.isReady` before (re)initializing.
+   *
+   * Only an owner switch may clear it. The init effect also re-fires when
+   * the currency map or display currency changes, and in All Networks mode
+   * readiness is written solely by the all-network cold cache probe /
+   * fan-out — nothing re-runs those for a same-owner re-fire. Clearing
+   * readiness there would leave the always-visible header holding the last
+   * confirmed balance indefinitely (it gates on token AND DeFi readiness).
+   */
+  shouldResetReadiness: boolean;
+  /** Single-network owners re-hydrate the local overview on every run. */
+  shouldHydrateSingleNetworkCache: boolean;
+}
+
+export function buildDeFiOverviewInitOwnerKey({
+  accountId,
+  networkId,
+  accountAddress,
+}: IDeFiOverviewInitOwner): string {
+  return `${accountId}__${networkId}__${accountAddress ?? ''}`;
+}
+
+export function planDeFiOverviewInit({
+  accountId,
+  networkId,
+  accountAddress,
+  lastInitOwnerKey,
+}: IDeFiOverviewInitOwner & {
+  lastInitOwnerKey: string | undefined;
+}): IDeFiOverviewInitPlan {
+  const ownerKey = buildDeFiOverviewInitOwnerKey({
+    accountId,
+    networkId,
+    accountAddress,
+  });
+  const isOwnerChanged = ownerKey !== lastInitOwnerKey;
+  return {
+    ownerKey,
+    isOwnerChanged,
+    shouldResetReadiness: isOwnerChanged,
+    shouldHydrateSingleNetworkCache: !networkUtils.isAllNetwork({
+      networkId,
+    }),
+  };
+}

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.portfolioSync.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.portfolioSync.test.ts
@@ -30,6 +30,7 @@ describe('TokenListBlock portfolio sync producer', () => {
     );
     expect(source).toContain('assetStatusCurrency &&');
     expect(source).toContain('if (!snapshot || isStaleOwnerRequest())');
+    expect(source).toContain('clearRetainedResultOnAcceptedRun: true');
     expect(source).toContain('totalFiatCurrency: assetStatusCurrency');
     expect(gateIndex).toBeGreaterThan(0);
     expect(gateIndex).toBeLessThan(buildIndex);
@@ -41,5 +42,31 @@ describe('TokenListBlock portfolio sync producer', () => {
     expect(source).not.toContain(
       'appEventBus.emit(EAppEventBusNames.AllNetworksTokenListSettled',
     );
+  });
+
+  it('commits the authoritative snapshot before running asset status analytics', () => {
+    const source = readFileSync(join(__dirname, 'TokenListBlock.tsx'), 'utf8');
+    const producerStart = source.indexOf(
+      'const updateAllNetworksTokenList = useCallback',
+    );
+    const producerSource = source.slice(producerStart);
+    const worthIndex = producerSource.indexOf('updateAccountWorth({');
+    const commitIndex = producerSource.indexOf(
+      'commitAuthoritativeIngest(snapshot);',
+    );
+    const readyStateIndex = producerSource.indexOf(
+      'updateTokenListState({',
+      commitIndex,
+    );
+    const analyticsIndex = producerSource.indexOf(
+      'getWalletAssetStatusAnalytics',
+      commitIndex,
+    );
+
+    expect(producerStart).toBeGreaterThan(0);
+    expect(worthIndex).toBeGreaterThan(0);
+    expect(commitIndex).toBeGreaterThan(worthIndex);
+    expect(readyStateIndex).toBeGreaterThan(commitIndex);
+    expect(analyticsIndex).toBeGreaterThan(readyStateIndex);
   });
 });

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1641,6 +1641,7 @@ function TokenListBlock({
     onCacheChecked: handleAllNetworkCacheChecked,
     onRequestSettled: handleAllNetworkRequestSettled,
     shouldAlwaysFetch,
+    clearRetainedResultOnAcceptedRun: true,
   });
 
   const updateAllNetworksTokenList = useCallback(async () => {
@@ -1693,120 +1694,6 @@ function TokenListBlock({
         result: allNetworksResult,
       });
     const assetStatusCurrency = getWalletAssetStatusCurrency(allNetworksResult);
-    if (
-      assetStatusAggregationComplete &&
-      assetStatusCurrency?.toLowerCase() === USD_CURRENCY_ID
-    ) {
-      const reportNow = Date.now();
-      const assetStatusAnalytics =
-        await backgroundApiProxy.simpleDb.appStatus.getWalletAssetStatusAnalytics();
-      const { wallets: eligibleWallets } =
-        await backgroundApiProxy.serviceAccount.getAllHdHwQrWallets({
-          includingAccounts: true,
-        });
-      if (isStaleOwnerRequest()) {
-        return;
-      }
-      const eligibleAccountIds = Array.from(
-        new Set(
-          eligibleWallets.flatMap((eligibleWallet) =>
-            (eligibleWallet.dbIndexedAccounts ?? []).map(
-              (indexedAccountItem) => indexedAccountItem.id,
-            ),
-          ),
-        ),
-      );
-
-      if (eligibleAccountIds.length) {
-        const accountValues =
-          await backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountIdBatch(
-            {
-              accounts: eligibleAccountIds.map((accountId) => ({
-                accountId,
-              })),
-            },
-          );
-        if (isStaleOwnerRequest()) {
-          return;
-        }
-        const currentAccountValueId =
-          indexedAccount?.id ?? account?.indexedAccountId;
-        const currentAccountValue =
-          currentAccountValueId &&
-          eligibleAccountIds.includes(currentAccountValueId)
-            ? {
-                accountId: currentAccountValueId,
-                value: snapshot.accountsWorth,
-                currency: USD_CURRENCY_ID,
-              }
-            : undefined;
-        const assetStatusEvaluation = evaluateWalletAssetStatus({
-          accountValues,
-          currentAccountValue,
-          eligibleWalletCount: eligibleWallets.length,
-        });
-
-        if (
-          assetStatusEvaluation.assetStatus &&
-          assetStatusEvaluation.balanceBucket &&
-          assetStatusEvaluation.changeReason
-        ) {
-          const baseParams = {
-            source: WALLET_ASSET_STATUS_SOURCE,
-            scope: WALLET_ASSET_STATUS_SCOPE,
-            assetStatus: assetStatusEvaluation.assetStatus,
-            balanceBucket: assetStatusEvaluation.balanceBucket,
-            thresholdUsd: WALLET_ASSET_STATUS_THRESHOLD_USD,
-            thresholdCurrency: WALLET_ASSET_STATUS_THRESHOLD_CURRENCY,
-            assetBasis: WALLET_ASSET_STATUS_BASIS,
-            eligibleWalletTypes: WALLET_ASSET_STATUS_ELIGIBLE_WALLET_TYPES,
-            eligibleWalletCount: assetStatusEvaluation.eligibleWalletCount,
-            eligibleAccountCount: assetStatusEvaluation.eligibleAccountCount,
-            knownAccountCount: assetStatusEvaluation.knownAccountCount,
-            unknownAccountCount: assetStatusEvaluation.unknownAccountCount,
-          } as const;
-          const shouldReportSnapshot = shouldReportWalletAssetStatusSnapshot({
-            lastReportedAt: assetStatusAnalytics?.lastSnapshotReportedAt,
-            now: reportNow,
-          });
-          const shouldReportChange = shouldReportWalletAssetStatusChange({
-            previousStatus: assetStatusAnalytics?.assetStatus,
-            currentStatus: assetStatusEvaluation.assetStatus,
-          });
-
-          if (shouldReportSnapshot) {
-            defaultLogger.wallet.balance.walletAssetStatusEvaluated(baseParams);
-          }
-          if (shouldReportChange) {
-            defaultLogger.wallet.balance.walletAssetStatusChanged({
-              ...baseParams,
-              previousStatus: assetStatusAnalytics?.assetStatus ?? 'unknown',
-              currentStatus: assetStatusEvaluation.assetStatus,
-              changeReason: assetStatusEvaluation.changeReason,
-            });
-          }
-
-          if (
-            shouldReportSnapshot ||
-            shouldReportChange ||
-            assetStatusAnalytics?.assetStatus !==
-              assetStatusEvaluation.assetStatus
-          ) {
-            await backgroundApiProxy.simpleDb.appStatus.setWalletAssetStatusAnalytics(
-              {
-                assetStatus: assetStatusEvaluation.assetStatus,
-                lastSnapshotReportedAt: shouldReportSnapshot
-                  ? reportNow
-                  : assetStatusAnalytics?.lastSnapshotReportedAt,
-                lastStatusChangedAt: shouldReportChange
-                  ? reportNow
-                  : assetStatusAnalytics?.lastStatusChangedAt,
-              },
-            );
-          }
-        }
-      }
-    }
 
     if (isStaleOwnerRequest()) {
       return;
@@ -1924,6 +1811,124 @@ function TokenListBlock({
       initialized: true,
       isRefreshing: false,
     });
+
+    // Asset status analytics is non-critical for the Home refresh. Keep it
+    // after the authoritative snapshot has reached the UI so a slow background
+    // RPC cannot hold the refreshed balance/token list in a loading state.
+    if (
+      assetStatusAggregationComplete &&
+      assetStatusCurrency?.toLowerCase() === USD_CURRENCY_ID
+    ) {
+      const reportNow = Date.now();
+      const assetStatusAnalytics =
+        await backgroundApiProxy.simpleDb.appStatus.getWalletAssetStatusAnalytics();
+      const { wallets: eligibleWallets } =
+        await backgroundApiProxy.serviceAccount.getAllHdHwQrWallets({
+          includingAccounts: true,
+        });
+      if (isStaleOwnerRequest()) {
+        return;
+      }
+      const eligibleAccountIds = Array.from(
+        new Set(
+          eligibleWallets.flatMap((eligibleWallet) =>
+            (eligibleWallet.dbIndexedAccounts ?? []).map(
+              (indexedAccountItem) => indexedAccountItem.id,
+            ),
+          ),
+        ),
+      );
+
+      if (eligibleAccountIds.length) {
+        const accountValues =
+          await backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountIdBatch(
+            {
+              accounts: eligibleAccountIds.map((accountId) => ({
+                accountId,
+              })),
+            },
+          );
+        if (isStaleOwnerRequest()) {
+          return;
+        }
+        const currentAccountValueId =
+          indexedAccount?.id ?? account?.indexedAccountId;
+        const currentAccountValue =
+          currentAccountValueId &&
+          eligibleAccountIds.includes(currentAccountValueId)
+            ? {
+                accountId: currentAccountValueId,
+                value: snapshot.accountsWorth,
+                currency: USD_CURRENCY_ID,
+              }
+            : undefined;
+        const assetStatusEvaluation = evaluateWalletAssetStatus({
+          accountValues,
+          currentAccountValue,
+          eligibleWalletCount: eligibleWallets.length,
+        });
+
+        if (
+          assetStatusEvaluation.assetStatus &&
+          assetStatusEvaluation.balanceBucket &&
+          assetStatusEvaluation.changeReason
+        ) {
+          const baseParams = {
+            source: WALLET_ASSET_STATUS_SOURCE,
+            scope: WALLET_ASSET_STATUS_SCOPE,
+            assetStatus: assetStatusEvaluation.assetStatus,
+            balanceBucket: assetStatusEvaluation.balanceBucket,
+            thresholdUsd: WALLET_ASSET_STATUS_THRESHOLD_USD,
+            thresholdCurrency: WALLET_ASSET_STATUS_THRESHOLD_CURRENCY,
+            assetBasis: WALLET_ASSET_STATUS_BASIS,
+            eligibleWalletTypes: WALLET_ASSET_STATUS_ELIGIBLE_WALLET_TYPES,
+            eligibleWalletCount: assetStatusEvaluation.eligibleWalletCount,
+            eligibleAccountCount: assetStatusEvaluation.eligibleAccountCount,
+            knownAccountCount: assetStatusEvaluation.knownAccountCount,
+            unknownAccountCount: assetStatusEvaluation.unknownAccountCount,
+          } as const;
+          const shouldReportSnapshot = shouldReportWalletAssetStatusSnapshot({
+            lastReportedAt: assetStatusAnalytics?.lastSnapshotReportedAt,
+            now: reportNow,
+          });
+          const shouldReportChange = shouldReportWalletAssetStatusChange({
+            previousStatus: assetStatusAnalytics?.assetStatus,
+            currentStatus: assetStatusEvaluation.assetStatus,
+          });
+
+          if (shouldReportSnapshot) {
+            defaultLogger.wallet.balance.walletAssetStatusEvaluated(baseParams);
+          }
+          if (shouldReportChange) {
+            defaultLogger.wallet.balance.walletAssetStatusChanged({
+              ...baseParams,
+              previousStatus: assetStatusAnalytics?.assetStatus ?? 'unknown',
+              currentStatus: assetStatusEvaluation.assetStatus,
+              changeReason: assetStatusEvaluation.changeReason,
+            });
+          }
+
+          if (
+            shouldReportSnapshot ||
+            shouldReportChange ||
+            assetStatusAnalytics?.assetStatus !==
+              assetStatusEvaluation.assetStatus
+          ) {
+            await backgroundApiProxy.simpleDb.appStatus.setWalletAssetStatusAnalytics(
+              {
+                assetStatus: assetStatusEvaluation.assetStatus,
+                lastSnapshotReportedAt: shouldReportSnapshot
+                  ? reportNow
+                  : assetStatusAnalytics?.lastSnapshotReportedAt,
+                lastStatusChangedAt: shouldReportChange
+                  ? reportNow
+                  : assetStatusAnalytics?.lastStatusChangedAt,
+              },
+            );
+          }
+        }
+      }
+    }
   }, [
     account?.address,
     account?.id,
@@ -2463,7 +2468,11 @@ function TokenListBlock({
   useEffect(() => {
     const fn = () => {
       if (network?.isAllNetworks) {
-        void runAllNetworksRequests({ alwaysSetState: true });
+        // The all-network token refresh for this event is handled inside
+        // useAllNetworkRequests (its wallet-scoped listener also bypasses the
+        // accounts cache). Kicking it again here queued a second forced
+        // fan-out per hardware-account batch; only the LP token list still
+        // needs a dedicated trigger.
         if (showLpTokensOnly) {
           void runLpTokenList({ alwaysSetState: true });
         }
@@ -2473,12 +2482,7 @@ function TokenListBlock({
     return () => {
       appEventBus.off(EAppEventBusNames.AddDBAccountsToWallet, fn);
     };
-  }, [
-    network?.isAllNetworks,
-    runAllNetworksRequests,
-    runLpTokenList,
-    showLpTokensOnly,
-  ]);
+  }, [network?.isAllNetworks, runLpTokenList, showLpTokensOnly]);
 
   const handleRefreshAllNetworkDataByAccounts = useCallback(
     async (accounts: { accountId: string; networkId: string }[]) => {

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -459,19 +459,31 @@ function HomeOverviewContainer() {
         // accountValue SimpleDB.
         const accountWorthCurrency =
           accountWorth.currency ?? settings.currencyInfo.id;
+        const createAtNetworkValueKey = accountUtils.buildAccountValueKey({
+          accountId: account.id,
+          networkId: account.createAtNetwork ?? '',
+        });
         if (isOthers) {
           if (
             account.createAtNetwork &&
             (network.isAllNetworks || account.createAtNetwork === network.id)
           ) {
-            void backgroundApiProxy.serviceAccountProfile.updateAccountValue({
-              accountId: accountValueId,
-              networkAccountId: account.id,
-              networkId: account.createAtNetwork,
-              value: accountWorth.createAtNetworkWorth,
-              currency: accountWorthCurrency,
-              shouldUpdateActiveAccountValue: true,
-            });
+            const createAtNetworkValue =
+              accountWorth.worth[createAtNetworkValueKey];
+            if (createAtNetworkValue !== undefined) {
+              void backgroundApiProxy.serviceAccountProfile.updateAccountValue({
+                accountId: accountValueId,
+                networkAccountId: account.id,
+                networkId: account.createAtNetwork,
+                // The compound-key map stores the absolute value for this
+                // network. Prefer it over the legacy scalar, which can be
+                // transiently stale while independent network responses
+                // merge.
+                value: createAtNetworkValue,
+                currency: accountWorthCurrency,
+                shouldUpdateActiveAccountValue: true,
+              });
+            }
           }
         } else if (!network.isAllNetworks) {
           const singleNetworkValue =

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -840,10 +840,17 @@ function HomeOverviewContainer() {
       isTokenWorthReady: isCurrentAccountWorthReady,
       isTokenSnapshotCommitted: isCurrentTokenSnapshotCommitted,
       isDeFiReady: isCurrentAccountDeFiReady,
+      isDeFiRefreshing: isRefreshingDeFiList,
       deFiGraceExpired,
     });
+  // An expired grace stays expired until DeFi reports for this owner (or the
+  // owner changes). Clearing it whenever the grace disarms would flip the
+  // header from the live total back to the stale confirmed one for the length
+  // of every later refresh.
   useEffect(() => {
     setDeFiGraceExpired(false);
+  }, [currentOverviewOwnerKey, isCurrentAccountDeFiReady]);
+  useEffect(() => {
     if (!shouldArmDeFiGrace) {
       return undefined;
     }

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -60,9 +60,14 @@ import { showBalanceDetailsDialog } from '../components/BalanceDetailsDialog';
 import { useHomeWalletTabSupport } from '../hooks/useHomeWalletTabSupport';
 import { HomeTestIDs } from '../testIDs';
 
+import { resolveHomeOverviewBalanceHold } from './homeOverviewBalanceHold';
+
 // Grace period (ms) after an account switch during which the previous
 // balance is shown as a placeholder to avoid a skeleton flash.
 const BALANCE_REUSE_GRACE_MS = 180;
+// After the token side commits a complete All Networks snapshot, wait this
+// long for DeFi readiness before showing the live total without it.
+const ALL_NETWORKS_DEFI_GRACE_MS = 5000;
 
 const HOME_OVERVIEW_REFRESH_TABS = [
   EHomeTab.TOKENS,
@@ -723,6 +728,16 @@ function HomeOverviewContainer() {
   const isCurrentAllNetworksBalanceFullyReady =
     !network?.isAllNetworks ||
     (isCurrentAccountWorthReady && isCurrentAccountDeFiReady);
+  const isCurrentAccountWorthOwner =
+    !!accountWorth.accountId &&
+    (accountWorth.accountId === (account?.id ?? '') ||
+      accountWorth.accountId === (account?.indexedAccountId ?? ''));
+  // `updateAll` marks a complete snapshot for this owner (cache hydrate or an
+  // authoritative fan-out commit) as opposed to per-network progressive merges.
+  const isCurrentTokenSnapshotCommitted =
+    isCurrentAccountWorthOwner &&
+    accountWorth.initialized &&
+    accountWorth.updateAll === true;
 
   const [reuseLatestBalanceGraceExpired, setReuseLatestBalanceGraceExpired] =
     useState(false);
@@ -813,11 +828,32 @@ function HomeOverviewContainer() {
   ]);
 
   // During All Networks progressive loading, hold the previous confirmed
-  // balance until both token and DeFi data finish loading.
-  const shouldHoldCurrentConfirmedBalance =
-    !!network?.isAllNetworks &&
-    !!currentConfirmedBalance &&
-    !isCurrentAllNetworksBalanceFullyReady;
+  // balance until token and DeFi data finish loading. The hold is bounded:
+  // DeFi readiness only arrives through the cache-only DeFi hook, and when
+  // that hook does not run the header must not stay pinned to a stale
+  // persisted total for the whole session (see resolveHomeOverviewBalanceHold).
+  const [deFiGraceExpired, setDeFiGraceExpired] = useState(false);
+  const { shouldHold: shouldHoldCurrentConfirmedBalance, shouldArmDeFiGrace } =
+    resolveHomeOverviewBalanceHold({
+      isAllNetworks: !!network?.isAllNetworks,
+      hasConfirmedBalance: !!currentConfirmedBalance,
+      isTokenWorthReady: isCurrentAccountWorthReady,
+      isTokenSnapshotCommitted: isCurrentTokenSnapshotCommitted,
+      isDeFiReady: isCurrentAccountDeFiReady,
+      deFiGraceExpired,
+    });
+  useEffect(() => {
+    setDeFiGraceExpired(false);
+    if (!shouldArmDeFiGrace) {
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setDeFiGraceExpired(true);
+    }, ALL_NETWORKS_DEFI_GRACE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [currentOverviewOwnerKey, shouldArmDeFiGrace]);
 
   const lastConfirmedLatestUsd =
     canReuseLatestDisplayedBalance && lastConfirmedOverviewBalance.latest

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -60,7 +60,10 @@ import { showBalanceDetailsDialog } from '../components/BalanceDetailsDialog';
 import { useHomeWalletTabSupport } from '../hooks/useHomeWalletTabSupport';
 import { HomeTestIDs } from '../testIDs';
 
-import { resolveHomeOverviewBalanceHold } from './homeOverviewBalanceHold';
+import {
+  resolveHomeOverviewBalanceHold,
+  shouldIncludeKnownDeFiWorth,
+} from './homeOverviewBalanceHold';
 
 // Grace period (ms) after an account switch during which the previous
 // balance is shown as a placeholder to avoid a skeleton flash.
@@ -662,6 +665,15 @@ function HomeOverviewContainer() {
     overviewDeFiDataState.ownerKey,
   ]);
 
+  // Set by the bounded All Networks hold below (resolveHomeOverviewBalanceHold).
+  const [deFiGraceExpired, setDeFiGraceExpired] = useState(false);
+  const isDeFiOverviewOwnerMatched =
+    !!currentOverviewOwnerKey &&
+    buildOverviewOwnerKey(
+      accountDeFiOverview.accountId,
+      accountDeFiOverview.networkId,
+    ) === currentOverviewOwnerKey;
+
   // Returns a USD-basis string. DeFi data arrives in display currency from
   // DeFiListBlock, so it's converted back to USD here before summing.
   const resolvedBalanceString = useMemo(() => {
@@ -693,10 +705,14 @@ function HomeOverviewContainer() {
       currencyMap,
     });
 
-    const deFiWorthRaw =
-      !isAllNetworks || isCurrentAccountDeFiReady
-        ? (accountDeFiOverview.netWorth ?? 0)
-        : 0;
+    const deFiWorthRaw = shouldIncludeKnownDeFiWorth({
+      isAllNetworks,
+      isDeFiReady: isCurrentAccountDeFiReady,
+      deFiGraceExpired,
+      isDeFiOverviewOwnerMatched,
+    })
+      ? (accountDeFiOverview.netWorth ?? 0)
+      : 0;
     const deFiWorthUsd = convertFiat({
       value: deFiWorthRaw,
       sourceCurrency: accountDeFiOverview.currency || settings.currencyInfo.id,
@@ -716,8 +732,10 @@ function HomeOverviewContainer() {
     accountDeFiOverview.netWorth,
     accountDeFiOverview.currency,
     currencyMap,
+    deFiGraceExpired,
     isCurrentAccountDeFiReady,
     isCurrentAccountWorthReady,
+    isDeFiOverviewOwnerMatched,
     isPerpsEnabled,
     network?.isAllNetworks,
     perpsNetWorthUsd,
@@ -832,7 +850,6 @@ function HomeOverviewContainer() {
   // DeFi readiness only arrives through the cache-only DeFi hook, and when
   // that hook does not run the header must not stay pinned to a stale
   // persisted total for the whole session (see resolveHomeOverviewBalanceHold).
-  const [deFiGraceExpired, setDeFiGraceExpired] = useState(false);
   const { shouldHold: shouldHoldCurrentConfirmedBalance, shouldArmDeFiGrace } =
     resolveHomeOverviewBalanceHold({
       isAllNetworks: !!network?.isAllNetworks,

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
@@ -1,4 +1,7 @@
-import { resolveHomeOverviewBalanceHold } from './homeOverviewBalanceHold';
+import {
+  resolveHomeOverviewBalanceHold,
+  shouldIncludeKnownDeFiWorth,
+} from './homeOverviewBalanceHold';
 
 /*
 yarn jest packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
@@ -89,5 +92,48 @@ describe('resolveHomeOverviewBalanceHold', () => {
         deFiGraceExpired: true,
       }),
     ).toEqual({ shouldHold: false, shouldArmDeFiGrace: false });
+  });
+});
+
+describe('shouldIncludeKnownDeFiWorth', () => {
+  const worthBase = {
+    isAllNetworks: true,
+    isDeFiReady: false,
+    deFiGraceExpired: false,
+    isDeFiOverviewOwnerMatched: true,
+  };
+
+  it('always includes DeFi outside All Networks', () => {
+    expect(
+      shouldIncludeKnownDeFiWorth({ ...worthBase, isAllNetworks: false }),
+    ).toBe(true);
+  });
+
+  it('includes DeFi once it reported for this owner', () => {
+    expect(
+      shouldIncludeKnownDeFiWorth({ ...worthBase, isDeFiReady: true }),
+    ).toBe(true);
+  });
+
+  it('excludes DeFi while the hold is still waiting for it', () => {
+    expect(shouldIncludeKnownDeFiWorth(worthBase)).toBe(false);
+  });
+
+  it('keeps the last same-owner DeFi value after the grace released the hold', () => {
+    // A warm refresh never clears the overview atom; zeroing it here would
+    // drop the header by the whole DeFi position until DeFi reports again.
+    expect(
+      shouldIncludeKnownDeFiWorth({ ...worthBase, deFiGraceExpired: true }),
+    ).toBe(true);
+  });
+
+  it("never borrows another owner's DeFi value after the grace released", () => {
+    expect(
+      shouldIncludeKnownDeFiWorth({
+        ...worthBase,
+        deFiGraceExpired: true,
+        isDeFiOverviewOwnerMatched: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
@@ -1,0 +1,69 @@
+import { resolveHomeOverviewBalanceHold } from './homeOverviewBalanceHold';
+
+/*
+yarn jest packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
+*/
+
+const base = {
+  isAllNetworks: true,
+  hasConfirmedBalance: true,
+  isTokenWorthReady: true,
+  isTokenSnapshotCommitted: true,
+  isDeFiReady: false,
+  deFiGraceExpired: false,
+};
+
+describe('resolveHomeOverviewBalanceHold', () => {
+  it('never holds outside All Networks', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, isAllNetworks: false }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: false });
+  });
+
+  it('has nothing to hold without a confirmed balance', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, hasConfirmedBalance: false }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: true });
+  });
+
+  it('holds while the token fan-out is still progressive', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({
+        ...base,
+        isTokenSnapshotCommitted: false,
+      }),
+    ).toEqual({ shouldHold: true, shouldArmDeFiGrace: false });
+  });
+
+  it('releases as soon as both token and DeFi are ready', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, isDeFiReady: true }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: false });
+  });
+
+  it('keeps holding during the DeFi grace window after the token commit', () => {
+    expect(resolveHomeOverviewBalanceHold(base)).toEqual({
+      shouldHold: true,
+      shouldArmDeFiGrace: true,
+    });
+  });
+
+  it('releases the live total when DeFi never reports within the grace window', () => {
+    // Regression for the iOS log where the cache-only DeFi hook never ran:
+    // the header stayed on a persisted total for the whole session while the
+    // token list already showed live values.
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, deFiGraceExpired: true }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: true });
+  });
+
+  it('does not let an expired grace release a still-progressive token side', () => {
+    expect(
+      resolveHomeOverviewBalanceHold({
+        ...base,
+        isTokenSnapshotCommitted: false,
+        deFiGraceExpired: true,
+      }),
+    ).toEqual({ shouldHold: true, shouldArmDeFiGrace: false });
+  });
+});

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.test.ts
@@ -10,6 +10,7 @@ const base = {
   isTokenWorthReady: true,
   isTokenSnapshotCommitted: true,
   isDeFiReady: false,
+  isDeFiRefreshing: false,
   deFiGraceExpired: false,
 };
 
@@ -65,5 +66,28 @@ describe('resolveHomeOverviewBalanceHold', () => {
         deFiGraceExpired: true,
       }),
     ).toEqual({ shouldHold: true, shouldArmDeFiGrace: false });
+  });
+
+  it('does not start the grace from a stale token commit while DeFi is refreshing', () => {
+    // A warm refresh never resets `updateAll`, so the token side still looks
+    // committed while the DeFi run has reset its readiness. The run will
+    // write readiness back when it finishes; the header must keep holding
+    // instead of dropping DeFi after the window.
+    expect(
+      resolveHomeOverviewBalanceHold({ ...base, isDeFiRefreshing: true }),
+    ).toEqual({ shouldHold: true, shouldArmDeFiGrace: false });
+  });
+
+  it('keeps the released live total while DeFi refreshes after the grace expired', () => {
+    // DeFi never reported for this owner and the grace already released the
+    // header; a later DeFi run must not pin it back on the stale confirmed
+    // total for the length of the run.
+    expect(
+      resolveHomeOverviewBalanceHold({
+        ...base,
+        isDeFiRefreshing: true,
+        deFiGraceExpired: true,
+      }),
+    ).toEqual({ shouldHold: false, shouldArmDeFiGrace: false });
   });
 });

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
@@ -12,6 +12,12 @@ export interface IHomeOverviewBalanceHoldInput {
   isTokenSnapshotCommitted: boolean;
   /** `overviewDeFiDataState.isReady !== undefined` for this owner. */
   isDeFiReady: boolean;
+  /**
+   * The DeFi list run for this owner is in flight. Its start resets DeFi
+   * readiness and its finish always writes it back, so readiness is on its
+   * way; the grace must not start from a stale token commit meanwhile.
+   */
+  isDeFiRefreshing: boolean;
   /** The DeFi grace timer armed after the token commit has elapsed. */
   deFiGraceExpired: boolean;
 }
@@ -35,6 +41,14 @@ export interface IHomeOverviewBalanceHoldPlan {
  * showed live values. The hold is therefore bounded: once the token side has
  * committed a complete snapshot, DeFi gets a short grace window and then the
  * live total is shown with whatever DeFi value is currently known.
+ *
+ * `updateAll` is never reset by a warm refresh, so the token commit alone
+ * cannot tell a fresh snapshot from the previous one. While a DeFi run is in
+ * flight its readiness was reset by that run and will be written back when it
+ * finishes; starting the grace then would drop DeFi from the header after the
+ * window even though it is merely reloading. The grace therefore only arms
+ * when DeFi is neither ready nor refreshing, i.e. when nothing is going to
+ * report it.
  */
 export function resolveHomeOverviewBalanceHold({
   isAllNetworks,
@@ -42,12 +56,14 @@ export function resolveHomeOverviewBalanceHold({
   isTokenWorthReady,
   isTokenSnapshotCommitted,
   isDeFiReady,
+  isDeFiRefreshing,
   deFiGraceExpired,
 }: IHomeOverviewBalanceHoldInput): IHomeOverviewBalanceHoldPlan {
   if (!isAllNetworks) {
     return { shouldHold: false, shouldArmDeFiGrace: false };
   }
-  const shouldArmDeFiGrace = isTokenSnapshotCommitted && !isDeFiReady;
+  const shouldArmDeFiGrace =
+    isTokenSnapshotCommitted && !isDeFiReady && !isDeFiRefreshing;
   const isReleased =
     isTokenWorthReady &&
     (isDeFiReady || (isTokenSnapshotCommitted && deFiGraceExpired));

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
@@ -72,3 +72,29 @@ export function resolveHomeOverviewBalanceHold({
     shouldArmDeFiGrace,
   };
 }
+
+/**
+ * Whether the header total may include the DeFi value currently held in the
+ * overview atom. Readiness only says the DeFi hook reported for this owner
+ * this session. Once the grace has released the hold without it, the last
+ * value written for the SAME owner is still the best-known DeFi total — the
+ * warm token refresh never clears it — and zeroing it would make the header
+ * drop by the whole DeFi position until DeFi reports again.
+ */
+export function shouldIncludeKnownDeFiWorth({
+  isAllNetworks,
+  isDeFiReady,
+  deFiGraceExpired,
+  isDeFiOverviewOwnerMatched,
+}: {
+  isAllNetworks: boolean;
+  isDeFiReady: boolean;
+  deFiGraceExpired: boolean;
+  /** The overview atom is stamped with the current owner. */
+  isDeFiOverviewOwnerMatched: boolean;
+}): boolean {
+  if (!isAllNetworks || isDeFiReady) {
+    return true;
+  }
+  return deFiGraceExpired && isDeFiOverviewOwnerMatched;
+}

--- a/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
+++ b/packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts
@@ -1,0 +1,58 @@
+export interface IHomeOverviewBalanceHoldInput {
+  isAllNetworks: boolean;
+  /** A confirmed balance for this owner exists (persisted or from this session). */
+  hasConfirmedBalance: boolean;
+  /** Token worth for this owner has at least one network value. */
+  isTokenWorthReady: boolean;
+  /**
+   * The token side has committed a COMPLETE snapshot for this owner
+   * (`accountWorth.updateAll`): cache hydrate or an authoritative fan-out
+   * commit, as opposed to per-network progressive merges.
+   */
+  isTokenSnapshotCommitted: boolean;
+  /** `overviewDeFiDataState.isReady !== undefined` for this owner. */
+  isDeFiReady: boolean;
+  /** The DeFi grace timer armed after the token commit has elapsed. */
+  deFiGraceExpired: boolean;
+}
+
+export interface IHomeOverviewBalanceHoldPlan {
+  /** Keep showing the previously confirmed balance. */
+  shouldHold: boolean;
+  /** Arm (or keep) the DeFi grace timer for the current owner. */
+  shouldArmDeFiGrace: boolean;
+}
+
+/**
+ * Decide whether the All Networks header keeps the previously confirmed
+ * balance instead of the live, progressively merged total.
+ *
+ * The hold keeps the header from climbing network by network while a fan-out
+ * is in flight. It used to release only when BOTH token and DeFi readiness
+ * were true, and DeFi readiness is written solely inside the cache-only DeFi
+ * hook's run. When that run does not happen, the header stayed pinned to a
+ * stale persisted total for the whole session while the token list already
+ * showed live values. The hold is therefore bounded: once the token side has
+ * committed a complete snapshot, DeFi gets a short grace window and then the
+ * live total is shown with whatever DeFi value is currently known.
+ */
+export function resolveHomeOverviewBalanceHold({
+  isAllNetworks,
+  hasConfirmedBalance,
+  isTokenWorthReady,
+  isTokenSnapshotCommitted,
+  isDeFiReady,
+  deFiGraceExpired,
+}: IHomeOverviewBalanceHoldInput): IHomeOverviewBalanceHoldPlan {
+  if (!isAllNetworks) {
+    return { shouldHold: false, shouldArmDeFiGrace: false };
+  }
+  const shouldArmDeFiGrace = isTokenSnapshotCommitted && !isDeFiReady;
+  const isReleased =
+    isTokenWorthReady &&
+    (isDeFiReady || (isTokenSnapshotCommitted && deFiGraceExpired));
+  return {
+    shouldHold: hasConfirmedBalance && !isReleased,
+    shouldArmDeFiGrace,
+  };
+}

--- a/packages/shared/src/logger/scopes/account/scenes/allNetworkAccountPerf.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/allNetworkAccountPerf.ts
@@ -25,6 +25,11 @@ type IHomeTokenListRefreshTraceParams = {
   indexedAccountPresent?: boolean;
   source?: string;
   reason?: string;
+  skipReason?: string;
+  disabled?: boolean;
+  isRouteFocused?: boolean;
+  isLocked?: boolean;
+  shouldAlwaysFetch?: boolean;
 };
 
 export class AllNetworkAccountPerf extends BaseScene {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61576](https://onekeyhq.atlassian.net/browse/OK-61576)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Hotfix split of #13103 for `release/v6.5.2`, scoped to what the customer's iOS log (6.5.2, iPhone 15 Pro) actually shows, plus a fix for the gate that caused the reported symptom.

**What the log shows (device time):**
- The All Networks header is pinned by `shouldHoldCurrentConfirmedBalance` to a persisted total until BOTH token and DeFi readiness are true. Token readiness is trivially true after any network settles, so the gate is effectively "DeFi ready or freeze".
- DeFi readiness is written only inside the cache-only `DeFiListBlock` all-network hook run. Across 8 cold starts that day, that hook ran twice (18:43:49, 23:33:03). Those are exactly the two moments the header refreshed; the user's screenshot (header $21,880 vs one row $25,988) is the frozen state in between, while the token list already updated through progressive LWW merges.
- Two secondary defects made refreshes look dead: two manual refreshes inside the 1 s debounce (23:29:57/58 and 23:32:07/08) let the second runner's nonce discard the first fan-out and the rerun was skipped as redundant; and the authoritative commit waited on `getAllHdHwQrWallets` for 93 s while iOS suspended the app (23:30:33 to 23:32:07).

**Kept from #13103 (evidence-backed):**
- `useAllNetwork`: reserve the debounce window so a second manual refresh queues instead of spawning a runner; queued reruns keep their must-run config; stale-runner owner bail-out; retained result cleared on accepted runs and restored on failure (signature-checked).
- `TokenListBlock`: asset-status analytics moved after the authoritative commit; duplicate forced fan-out on `AddDBAccountsToWallet` removed; `clearRetainedResultOnAcceptedRun: true`.
- `DeFiListBlock` `deFiOverviewInitPlan`: same-owner init re-fires (currency map refresh) no longer reset readiness.
- `TokenSelector`: a filtered selector response is not persisted as the canonical network total. `HomeOverviewContainer`: Others accounts persist the compound-key value instead of the transient scalar.

**New in this PR:**
- `resolveHomeOverviewBalanceHold`: the hold is bounded. Once the token side has committed a complete snapshot (`accountWorth.updateAll`), DeFi gets a 5 s grace window; after that the live total is shown with the DeFi value currently known. The confirmed-balance persistence still requires full readiness, so a tokens-only total is never persisted as confirmed.
- The cache-only DeFi hook passes `shouldAlwaysFetch`, so `usePromiseResult`'s route-focus gate cannot skip the local cache probe that produces DeFi readiness.
- Diagnostics: `homeTokenListRefreshTrace` now records `all-network-hook-gate` (disabled / route focus / lock / shouldAlwaysFetch) and `all-network-hook-run-skipped` with a `skipReason`, so a hook that never starts can be explained from device logs next time.

**Deliberately excluded:** the `IAssetSnapshotMeta` freshness-marker system (ServiceToken minting, actions / ServiceAccountProfile / SimpleDb admission gates, LocalTokens admission). The log contains no observed out-of-order overwrite; the only theoretical window is the 93 s-delayed gen-4 commit landing after gen-5 progressive merges, which self-heals on the next commit and is largely removed by the two fixes above. It stays in #13103 to soak on `x`.

## Verification

- `yarn jest` for `allNetworkRunResultUtils`, `deFiOverviewInitPlan`, `homeOverviewBalanceHold`, `TokenListBlock.portfolioSync`, `DeFiListBlock.cacheOnlyGate`: 27 tests pass.
- `yarn agent:check --profile commit`: lint, tsc pass.
- Device QA still needed (iOS + desktop, All Networks, HW wallet):
  1. Cold start on the Tokens tab without visiting DeFi: header must leave the persisted value within ~5 s and match the list (look for `all-network-hook-gate` / `all-network-hook-run-skipped` with `reason:"defi"` in logs).
  2. Double-tap manual refresh inside 1 s: exactly one fan-out plus one queued must-run, and an `all-network-authoritative-commit` after the last run.
  3. Refresh, background the app for >30 s, foreground: header and list converge on the same snapshot.

Related: #13103 (full change set incl. freshness markers), OK-61576.

[OK-61576]: https://onekeyhq.atlassian.net/browse/OK-61576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ