### PR TITLE
feat: add destination selection for perps USDC withdrawals

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -7,6 +7,7 @@ import {
   backgroundClass,
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
   DISABLE_PERPS_WALLET_BIND,
   type EHyperLiquidAgentName,
@@ -48,10 +49,12 @@ import {
   parseSignatureToRSV,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import {
-  CCTP_DOMAIN_ARBITRUM,
-  CCTP_WITHDRAW_GAS_LIMIT,
-  CCTP_WITHDRAW_HOOK_DATA,
+  HYPEREVM_SYSTEM_ADDRESS,
   SPOT_ASSET_ID_OFFSET,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IUsdcWithdrawDestinationId,
+  IUsdcWithdrawFeeQuote,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IApiErrorResponse,
@@ -97,14 +100,24 @@ import {
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
-import { getUsdcWithdrawRoute } from './usdcWithdrawRoute';
-import type { IUsdcWithdrawRoute } from './usdcWithdrawRoute';
+import {
+  buildCctpWithdrawDestination,
+  getLiveUsdcWithdrawFee,
+  getUsdcWithdrawFee,
+  requireUsdcWithdrawDestination,
+} from './cctpWithdraw';
+import {
+  getLiveUsdcWithdrawRoute,
+  getUsdcWithdrawRoute,
+} from './usdcWithdrawRoute';
 import { createLoggedHyperLiquidClient } from './utils/logHyperLiquidApiFailure';
 
+import type { IHyperEvmRpcCall } from './cctpWithdraw';
 import type {
   WalletHyperliquidOnekey,
   WalletHyperliquidProxy,
 } from './ServiceHyperliquidWallet';
+import type { IUsdcWithdrawRoute } from './usdcWithdrawRoute';
 import type { IBackgroundApi } from '../../apis/IBackgroundApi';
 
 interface IOrderLogOptions {
@@ -1750,6 +1763,29 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     return getUsdcWithdrawRoute();
   }
 
+  private _callHyperEvmRpc: IHyperEvmRpcCall = async (method, params) => {
+    const [result] = await this.backgroundApi.serviceDApp.proxyRPCCall<unknown>(
+      {
+        networkId: getNetworkIdsMap().hyperevm,
+        request: {
+          jsonrpc: '2.0',
+          id: 0,
+          method,
+          params,
+        },
+        origin: 'onekey://perps',
+      },
+    );
+    return result;
+  };
+
+  @backgroundMethod()
+  async getUsdcWithdrawFee(params: {
+    destinationId: IUsdcWithdrawDestinationId;
+  }): Promise<IUsdcWithdrawFeeQuote> {
+    return getUsdcWithdrawFee(params.destinationId, this._callHyperEvmRpc);
+  }
+
   // `sendToEvmWithData` requires an explicit source balance, where `withdraw3`
   // let Hyperliquid pick one. Mirror perpsComputedAccountValueAtom: unified and
   // portfolio-margin accounts report the spot-side USDC balance as withdrawable,
@@ -1772,6 +1808,9 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
   @backgroundMethod()
   async withdraw(params: IWithdrawParams): Promise<void> {
     await this.checkAccountCanTrade();
+    const destinationConfig = requireUsdcWithdrawDestination(
+      params.destinationId,
+    );
     const wallet =
       await this.backgroundApi.serviceHyperliquidWallet.getOnekeyWallet({
         userAccountId: params.userAccountId,
@@ -1780,7 +1819,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       new ExchangeClient({
         transport: new HttpTransport(),
         wallet,
-        signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
+        signatureChainId: destinationConfig.signatureChainId,
       }),
     );
     const context = await this._buildLogContext();
@@ -1792,27 +1831,86 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     let sourceDex: '' | 'spot' | undefined;
     try {
       const [resolvedRoute, userAddress] = await Promise.all([
-        getUsdcWithdrawRoute(),
+        destinationConfig.transferType === 'cctp'
+          ? getLiveUsdcWithdrawRoute()
+          : Promise.resolve(undefined),
         wallet.getAddress(),
       ]);
       route = resolvedRoute;
+      if (
+        destinationConfig.transferType === 'cctp' &&
+        (!params.expectedRoute || route !== params.expectedRoute)
+      ) {
+        throw new OneKeyLocalError(
+          'Withdrawal route changed. Review the updated fee and try again.',
+        );
+      }
+      if (
+        destinationConfig.transferType === 'cctp' &&
+        route === 'bridge' &&
+        !destinationConfig.supportsLegacyBridge
+      ) {
+        throw new OneKeyLocalError(
+          `${destinationConfig.name} withdrawals require the CCTP route`,
+        );
+      }
+      if (destinationConfig.transferType === 'cctp' && route === 'cctp') {
+        const liveFeeQuote = await getLiveUsdcWithdrawFee(
+          params.destinationId,
+          this._callHyperEvmRpc,
+        );
+        const cctpFee = liveFeeQuote.components.find(
+          (component) => component.kind === 'cctpForwarding',
+        );
+        if (!cctpFee?.amount) {
+          throw new OneKeyLocalError('Unable to quote CCTP withdrawal fee');
+        }
+        if (
+          !params.expectedCctpFee ||
+          !new BigNumber(params.expectedCctpFee).eq(cctpFee.amount)
+        ) {
+          throw new OneKeyLocalError(
+            'Withdrawal fee changed. Review the updated fee and try again.',
+          );
+        }
+        if (new BigNumber(params.amount).lte(cctpFee.amount)) {
+          throw new OneKeyLocalError(
+            'Withdrawal amount must exceed the CCTP fee',
+          );
+        }
+      }
       await convertHyperLiquidResponse(async () => {
+        if (destinationConfig.transferType === 'hyperEvm') {
+          sourceDex = await this._resolveWithdrawSourceDex(userAddress);
+          return exchangeClient.sendAsset({
+            destination: HYPEREVM_SYSTEM_ADDRESS,
+            sourceDex,
+            destinationDex: 'spot',
+            token: 'USDC',
+            amount: params.amount,
+            fromSubAccount: '',
+          });
+        }
         if (route === 'cctp') {
           sourceDex = await this._resolveWithdrawSourceDex(userAddress);
+          const destination = buildCctpWithdrawDestination({
+            destinationId: params.destinationId,
+            ownerAddress: userAddress,
+          });
           return exchangeClient.sendToEvmWithData({
             token: 'USDC',
             amount: params.amount,
             sourceDex,
-            destinationRecipient: params.destination,
-            addressEncoding: 'hex',
-            destinationChainId: CCTP_DOMAIN_ARBITRUM,
-            gasLimit: CCTP_WITHDRAW_GAS_LIMIT,
-            data: CCTP_WITHDRAW_HOOK_DATA,
+            destinationRecipient: destination.destinationRecipient,
+            addressEncoding: destination.addressEncoding,
+            destinationChainId: destination.destinationChainId,
+            gasLimit: destination.gasLimit,
+            data: destination.data,
           });
         }
         return exchangeClient.withdraw3({
           amount: params.amount,
-          destination: params.destination,
+          destination: userAddress,
         });
       });
       defaultLogger.perp.hyperliquid.withdraw({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/cctpWithdraw.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/cctpWithdraw.ts
@@ -1,0 +1,242 @@
+import BigNumber from 'bignumber.js';
+
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  CCTP_WITHDRAW_GAS_LIMIT,
+  CCTP_WITHDRAW_HOOK_DATA,
+  USDC_WITHDRAW_GAS_RESERVE,
+  getUsdcWithdrawDestination,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  ICctpWithdrawDestinationConfig,
+  IUsdcWithdrawDestinationConfig,
+  IUsdcWithdrawDestinationId,
+  IUsdcWithdrawFeeComponent,
+  IUsdcWithdrawFeeQuote,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+const CORE_DEPOSIT_WALLET_ADDRESS =
+  '0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24';
+const CCTP_WITHDRAW_FEE_SELECTOR = 'e26f7d23';
+const CCTP_WITHDRAW_FEE_CACHE_TTL_MS = 5 * 60 * 1000;
+const USDC_DECIMALS = 6;
+
+export type IHyperEvmRpcCall = (
+  method: string,
+  params: unknown[],
+) => Promise<unknown>;
+
+interface ICctpWithdrawFeeCacheEntry {
+  fee: number;
+  fetchedAt: number;
+}
+
+export interface ICctpWithdrawDestinationActionFields {
+  config: ICctpWithdrawDestinationConfig;
+  destinationRecipient: string;
+  addressEncoding: 'hex';
+  destinationChainId: number;
+  gasLimit: number;
+  data: IHex;
+}
+
+const cachedFees = new Map<
+  IUsdcWithdrawDestinationId,
+  ICctpWithdrawFeeCacheEntry
+>();
+const inFlightFeeRequests = new Map<
+  IUsdcWithdrawDestinationId,
+  Promise<IUsdcWithdrawFeeComponent>
+>();
+
+export function requireUsdcWithdrawDestination(
+  destinationId: string,
+): IUsdcWithdrawDestinationConfig {
+  const config = getUsdcWithdrawDestination(destinationId);
+  if (!config) {
+    throw new OneKeyLocalError(
+      `Unsupported USDC withdrawal destination: ${destinationId}`,
+    );
+  }
+  return config;
+}
+
+function encodeWithdrawFeeCall(destinationDomain: number): IHex {
+  const useForwarding = '1'.padStart(64, '0');
+  const domain = destinationDomain.toString(16).padStart(64, '0');
+  return `0x${CCTP_WITHDRAW_FEE_SELECTOR}${useForwarding}${domain}` as IHex;
+}
+
+function parseWithdrawFee(result: unknown): number {
+  if (typeof result !== 'string' || !/^0x[0-9a-fA-F]+$/.test(result)) {
+    throw new OneKeyLocalError('Invalid CCTP withdrawal fee response');
+  }
+  const fee = new BigNumber(result.slice(2), 16)
+    .shiftedBy(-USDC_DECIMALS)
+    .toNumber();
+  if (!Number.isFinite(fee) || fee < 0) {
+    throw new OneKeyLocalError('Invalid CCTP withdrawal fee value');
+  }
+  return fee;
+}
+
+async function fetchCctpWithdrawFee(
+  config: ICctpWithdrawDestinationConfig,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<number> {
+  const result = await rpcCall('eth_call', [
+    {
+      to: CORE_DEPOSIT_WALLET_ADDRESS,
+      data: encodeWithdrawFeeCall(config.domain),
+    },
+    'latest',
+  ]);
+  return parseWithdrawFee(result);
+}
+
+async function getCctpWithdrawFee(
+  destinationId: IUsdcWithdrawDestinationId,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<IUsdcWithdrawFeeComponent> {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType !== 'cctp') {
+    throw new OneKeyLocalError(
+      `Destination does not have a CCTP fee: ${destinationId}`,
+    );
+  }
+  const cached = cachedFees.get(destinationId);
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < CCTP_WITHDRAW_FEE_CACHE_TTL_MS) {
+    return {
+      kind: 'cctpForwarding',
+      amount: cached.fee.toString(),
+      token: 'USDC',
+      debitedFrom: 'withdrawAmount',
+      isEstimate: false,
+    };
+  }
+
+  const inFlight = inFlightFeeRequests.get(destinationId);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = fetchCctpWithdrawFee(config, rpcCall)
+    .then((fee) => {
+      cachedFees.set(destinationId, { fee, fetchedAt: Date.now() });
+      return {
+        kind: 'cctpForwarding' as const,
+        amount: fee.toString(),
+        token: 'USDC' as const,
+        debitedFrom: 'withdrawAmount' as const,
+        isEstimate: false,
+      };
+    })
+    .catch(() => ({
+      kind: 'cctpForwarding' as const,
+      amount: config.fallbackFee.toString(),
+      token: 'USDC' as const,
+      debitedFrom: 'withdrawAmount' as const,
+      isEstimate: true,
+    }))
+    .finally(() => {
+      inFlightFeeRequests.delete(destinationId);
+    });
+  inFlightFeeRequests.set(destinationId, request);
+  return request;
+}
+
+export async function getUsdcWithdrawFee(
+  destinationId: IUsdcWithdrawDestinationId,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<IUsdcWithdrawFeeQuote> {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType === 'hyperEvm') {
+    return {
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: Date.now(),
+    };
+  }
+  const cctpFee = await getCctpWithdrawFee(destinationId, rpcCall);
+  return {
+    components: [cctpFee],
+    quotedAt: Date.now(),
+  };
+}
+
+// Submission must not rely on a cached or static CCTP fallback fee. The contract
+// can update per-domain USDC fees, while direct HyperEVM sends have no CCTP fee.
+export async function getLiveUsdcWithdrawFee(
+  destinationId: IUsdcWithdrawDestinationId,
+  rpcCall: IHyperEvmRpcCall,
+): Promise<IUsdcWithdrawFeeQuote> {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType === 'hyperEvm') {
+    return {
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: Date.now(),
+    };
+  }
+  const cctpFee = await fetchCctpWithdrawFee(config, rpcCall);
+  cachedFees.set(destinationId, { fee: cctpFee, fetchedAt: Date.now() });
+  return {
+    components: [
+      {
+        kind: 'cctpForwarding',
+        amount: cctpFee.toString(),
+        token: 'USDC',
+        debitedFrom: 'withdrawAmount',
+        isEstimate: false,
+      },
+    ],
+    quotedAt: Date.now(),
+  };
+}
+
+export function buildCctpWithdrawDestination({
+  destinationId,
+  ownerAddress,
+}: {
+  destinationId: IUsdcWithdrawDestinationId;
+  ownerAddress: string;
+}): ICctpWithdrawDestinationActionFields {
+  const config = requireUsdcWithdrawDestination(destinationId);
+  if (config.transferType !== 'cctp') {
+    throw new OneKeyLocalError(
+      `Destination does not use CCTP: ${destinationId}`,
+    );
+  }
+
+  return {
+    config,
+    destinationRecipient: ownerAddress,
+    addressEncoding: config.addressEncoding,
+    destinationChainId: config.domain,
+    gasLimit: CCTP_WITHDRAW_GAS_LIMIT,
+    data: CCTP_WITHDRAW_HOOK_DATA,
+  };
+}
+
+export function clearUsdcWithdrawFeeCacheForTest() {
+  cachedFees.clear();
+  inFlightFeeRequests.clear();
+}

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
@@ -1,9 +1,23 @@
 import {
+  USDC_WITHDRAW_DESTINATIONS,
+  USDC_WITHDRAW_GAS_RESERVE,
+  getUsdcWithdrawDestination,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+
+import {
+  buildCctpWithdrawDestination,
+  clearUsdcWithdrawFeeCacheForTest,
+  getLiveUsdcWithdrawFee,
+  getUsdcWithdrawFee,
+} from './cctpWithdraw';
+import {
   clearUsdcWithdrawRouteCacheForTest,
+  getLiveUsdcWithdrawRoute,
   getUsdcWithdrawRoute,
 } from './usdcWithdrawRoute';
 
 const requestMock = jest.fn<Promise<unknown>, unknown[]>();
+const rpcCallMock = jest.fn<Promise<unknown>, [string, unknown[]]>();
 
 jest.mock('@nktkas/hyperliquid', () => ({
   HttpTransport: jest.fn().mockImplementation(() => ({
@@ -79,5 +93,146 @@ describe('usdc withdraw route resolution', () => {
     ]);
     expect([first, second]).toEqual(['cctp', 'cctp']);
     expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the live rail before submission instead of using the UI cache', async () => {
+    requestMock.mockResolvedValueOnce({ withdrawalRoute: 'cctp' });
+    await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+
+    requestMock.mockResolvedValueOnce({ withdrawalRoute: 'bridge' });
+    await expect(getLiveUsdcWithdrawRoute()).resolves.toBe('bridge');
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an unknown live rail instead of silently falling back', async () => {
+    requestMock.mockResolvedValue({ withdrawalRoute: 'something-new' });
+    await expect(getLiveUsdcWithdrawRoute()).rejects.toThrow(
+      'Unsupported Hyperliquid withdrawal route',
+    );
+  });
+});
+
+describe('usdc withdraw destinations and fees', () => {
+  beforeEach(() => {
+    clearUsdcWithdrawFeeCacheForTest();
+    rpcCallMock.mockReset();
+  });
+
+  it('supports HyperEVM instead of Solana', () => {
+    expect(USDC_WITHDRAW_DESTINATIONS.map((item) => item.id)).toEqual([
+      'ethereum',
+      'avalanche',
+      'optimism',
+      'arbitrum',
+      'base',
+      'hyperevm',
+    ]);
+    expect(getUsdcWithdrawDestination('solana')).toBeUndefined();
+    expect(getUsdcWithdrawDestination('hyperevm')).toEqual({
+      id: 'hyperevm',
+      name: 'HyperEVM',
+      networkId: 'evm--999',
+      transferType: 'hyperEvm',
+      signatureChainId: '0xa4b1',
+    });
+    expect(
+      USDC_WITHDRAW_DESTINATIONS.filter(
+        (item) => item.transferType === 'cctp',
+      ).map((item) => [item.id, item.domain, item.fallbackFee]),
+    ).toEqual([
+      ['ethereum', 0, 1.2],
+      ['avalanche', 1, 0.2],
+      ['optimism', 2, 0.2],
+      ['arbitrum', 3, 0.2],
+      ['base', 6, 0.2],
+    ]);
+  });
+
+  it('builds the selected external CCTP destination', () => {
+    expect(
+      buildCctpWithdrawDestination({
+        destinationId: 'arbitrum',
+        ownerAddress: '0x0000000000000000000000000000000000000001',
+      }),
+    ).toMatchObject({
+      destinationRecipient: '0x0000000000000000000000000000000000000001',
+      addressEncoding: 'hex',
+      destinationChainId: 3,
+      gasLimit: 200_000,
+      data: '0x',
+    });
+    expect(() =>
+      buildCctpWithdrawDestination({
+        destinationId: 'hyperevm',
+        ownerAddress: '0x0000000000000000000000000000000000000001',
+      }),
+    ).toThrow('Destination does not use CCTP: hyperevm');
+  });
+
+  it('quotes only the CCTP forwarding fee through RPC', async () => {
+    rpcCallMock.mockResolvedValue('0x30d40');
+
+    await expect(getUsdcWithdrawFee('arbitrum', rpcCallMock)).resolves.toEqual({
+      components: [
+        {
+          kind: 'cctpForwarding',
+          amount: '0.2',
+          token: 'USDC',
+          debitedFrom: 'withdrawAmount',
+          isEstimate: false,
+        },
+      ],
+      quotedAt: expect.any(Number),
+    });
+    expect(rpcCallMock).toHaveBeenCalledTimes(1);
+    expect(rpcCallMock.mock.calls.map(([method]) => method)).toEqual([
+      'eth_call',
+    ]);
+    const cctpRequest = rpcCallMock.mock.calls.find(
+      ([method]) => method === 'eth_call',
+    );
+    expect((cctpRequest?.[1][0] as { data: string }).data).toBe(
+      `0xe26f7d23${'1'.padStart(64, '0')}${'3'.padStart(64, '0')}`,
+    );
+  });
+
+  it('marks the CCTP fallback as estimated', async () => {
+    rpcCallMock.mockRejectedValue(new Error('network down'));
+    await expect(getUsdcWithdrawFee('ethereum', rpcCallMock)).resolves.toEqual({
+      components: [
+        {
+          kind: 'cctpForwarding',
+          amount: '1.2',
+          token: 'USDC',
+          debitedFrom: 'withdrawAmount',
+          isEstimate: true,
+        },
+      ],
+      quotedAt: expect.any(Number),
+    });
+  });
+
+  it('shows a sub-cent HyperEVM fee without making an RPC call', async () => {
+    await expect(getUsdcWithdrawFee('hyperevm', rpcCallMock)).resolves.toEqual({
+      components: [
+        {
+          kind: 'hyperEvmGas',
+          amount: USDC_WITHDRAW_GAS_RESERVE.toString(),
+          token: 'USDC',
+          debitedFrom: 'spotHypeOrSourceUsdc',
+          isEstimate: true,
+          displayAsLessThan: true,
+        },
+      ],
+      quotedAt: expect.any(Number),
+    });
+    expect(rpcCallMock).not.toHaveBeenCalled();
+  });
+
+  it('does not use an estimated fallback for the submission fee check', async () => {
+    rpcCallMock.mockRejectedValue(new Error('network down'));
+    await expect(
+      getLiveUsdcWithdrawFee('arbitrum', rpcCallMock),
+    ).rejects.toThrow('network down');
   });
 });

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts
@@ -63,6 +63,26 @@ describe('usdc withdraw route resolution', () => {
     expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses the resolved rail for five minutes', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    try {
+      requestMock
+        .mockResolvedValueOnce({ withdrawalRoute: 'cctp' })
+        .mockResolvedValueOnce({ withdrawalRoute: 'bridge' });
+
+      await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+      nowSpy.mockReturnValue(1000 + 5 * 60 * 1000 - 1);
+      await expect(getUsdcWithdrawRoute()).resolves.toBe('cctp');
+      expect(requestMock).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockReturnValue(1000 + 5 * 60 * 1000);
+      await expect(getUsdcWithdrawRoute()).resolves.toBe('bridge');
+      expect(requestMock).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   // A failure must not be cached, or one flaky response would pin every later
   // withdrawal to the more expensive rail for the whole cache window.
   it('retries after a failed lookup', async () => {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
@@ -17,7 +17,7 @@ interface IUsdcRoutingResponse {
   withdrawalRoute?: string;
 }
 
-const ROUTE_CACHE_TTL_MS = 30 * 1000;
+const ROUTE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 // An unreachable or unparsable response tells us nothing new, so fall back to the
 // rail that has been working in production all along. It costs the legacy $1 fee

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.ts
@@ -1,5 +1,7 @@
 import { HttpTransport } from '@nktkas/hyperliquid';
 
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 import { requestLoggedHyperLiquidTransport } from './utils/logHyperLiquidApiFailure';
 
 // Hyperliquid moved USDC to Circle CCTP and marked the legacy Arbitrum bridge
@@ -15,7 +17,7 @@ interface IUsdcRoutingResponse {
   withdrawalRoute?: string;
 }
 
-const ROUTE_CACHE_TTL_MS = 5 * 60 * 1000;
+const ROUTE_CACHE_TTL_MS = 30 * 1000;
 
 // An unreachable or unparsable response tells us nothing new, so fall back to the
 // rail that has been working in production all along. It costs the legacy $1 fee
@@ -33,7 +35,11 @@ function parseRoute(value: unknown): IUsdcWithdrawRoute | undefined {
   return value === 'cctp' || value === 'bridge' ? value : undefined;
 }
 
-async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+async function fetchWithdrawRoute({
+  allowFallback,
+}: {
+  allowFallback: boolean;
+}): Promise<IUsdcWithdrawRoute> {
   const response =
     await requestLoggedHyperLiquidTransport<IUsdcRoutingResponse>(
       new HttpTransport(),
@@ -41,7 +47,11 @@ async function fetchWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
       { type: 'usdcRouting' },
       { action: 'usdcRouting' },
     );
-  return parseRoute(response?.withdrawalRoute) ?? FALLBACK_ROUTE;
+  const route = parseRoute(response?.withdrawalRoute);
+  if (!route && !allowFallback) {
+    throw new OneKeyLocalError('Unsupported Hyperliquid withdrawal route');
+  }
+  return route ?? FALLBACK_ROUTE;
 }
 
 export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
@@ -50,7 +60,7 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
     return cachedRoute.route;
   }
   if (!inFlightRequest) {
-    inFlightRequest = fetchWithdrawRoute()
+    inFlightRequest = fetchWithdrawRoute({ allowFallback: true })
       .then((route) => {
         cachedRoute = { route, fetchedAt: Date.now() };
         lastResolvedRoute = route;
@@ -66,6 +76,15 @@ export async function getUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
       });
   }
   return inFlightRequest;
+}
+
+// A submission must be bound to the route that Hyperliquid is serving now.
+// Falling back here could silently change both the rail and the charged fee.
+export async function getLiveUsdcWithdrawRoute(): Promise<IUsdcWithdrawRoute> {
+  const route = await fetchWithdrawRoute({ allowFallback: false });
+  cachedRoute = { route, fetchedAt: Date.now() };
+  lastResolvedRoute = route;
+  return route;
 }
 
 export function clearUsdcWithdrawRouteCacheForTest() {

--- a/packages/kit-bg/src/states/jotai/atoms/perps.test.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.test.ts
@@ -17,6 +17,7 @@ import {
   perpsActiveAccountStatusInfoAtom,
   perpsActiveAccountSummaryAtom,
   perpsComputedAccountValueAtom,
+  perpsCustomSettingsAtom,
   perpsShouldShowEnableTradingButtonAtom,
   perpsSpotBalancesAtom,
   tradingModeAtom,
@@ -43,6 +44,17 @@ describe('tradingModeAtom', () => {
     expect(atomsConfig[EAtomNames.tradingModeAtom]?.mergeInitialValue).toBe(
       false,
     );
+  });
+});
+
+describe('perpsCustomSettingsAtom', () => {
+  it('persists Arbitrum as the initial USDC withdrawal destination', () => {
+    const atom = perpsCustomSettingsAtom.atom() as unknown as IJotaiAtomPro<{
+      lastUsdcWithdrawDestinationId: string;
+    }>;
+
+    expect(atom.persist).toBe(true);
+    expect(atom.initialValue.lastUsdcWithdrawDestinationId).toBe('arbitrum');
   });
 });
 

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -20,7 +20,11 @@ import {
   EPerpUserType,
   ETriggerOrderType,
 } from '@onekeyhq/shared/types/hyperliquid';
-import { DEFAULT_PERP_TOKEN_ACTIVE_TAB } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import {
+  DEFAULT_PERP_TOKEN_ACTIVE_TAB,
+  DEFAULT_USDC_WITHDRAW_DESTINATION_ID,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IUsdcWithdrawDestinationId } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 import { EAtomNames } from '../atomNames';
@@ -979,6 +983,7 @@ export interface IPerpsCustomSettings {
   showChartLines: boolean;
   lastTriggerOrderType: ETriggerOrderType;
   lastAdvancedOrderType?: IPerpsLastAdvancedOrderType;
+  lastUsdcWithdrawDestinationId: IUsdcWithdrawDestinationId;
 }
 export const {
   target: perpsCustomSettingsAtom,
@@ -992,6 +997,7 @@ export const {
     showChartLines: true,
     lastTriggerOrderType: ETriggerOrderType.TRIGGER_MARKET,
     lastAdvancedOrderType: ETriggerOrderType.TRIGGER_MARKET,
+    lastUsdcWithdrawDestinationId: DEFAULT_USDC_WITHDRAW_DESTINATION_ID,
   },
 });
 

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -82,6 +82,7 @@ import type {
   ISpotUniverse,
 } from '@onekeyhq/shared/types/hyperliquid';
 import { SUB_DEX_LIST } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IUsdcWithdrawDestinationId } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type * as HL from '@onekeyhq/shared/types/hyperliquid/sdk';
 import {
   EPerpsSizeInputMode,
@@ -3469,7 +3470,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       params: {
         userAccountId: string;
         amount: string;
-        destination: `0x${string}`;
+        destinationId: IUsdcWithdrawDestinationId;
+        expectedRoute?: 'bridge' | 'cctp';
+        expectedCctpFee?: string;
       },
     ) => {
       return withToast({
@@ -3477,7 +3480,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           await backgroundApiProxy.serviceHyperliquidExchange.withdraw({
             userAccountId: params.userAccountId,
             amount: params.amount,
-            destination: params.destination,
+            destinationId: params.destinationId,
+            expectedRoute: params.expectedRoute,
+            expectedCctpFee: params.expectedCctpFee,
           });
         },
         actionType: EActionType.WITHDRAW,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -2103,42 +2103,31 @@ function DepositWithdrawContent({
     [setPerpsCustomSettings],
   );
 
-  // HyperEVM is a native sendAsset transfer. Only external CCTP destinations
-  // need the server-selected bridge/CCTP rail.
+  // The selector always needs the active external withdrawal rail, including
+  // when HyperEVM is selected. The background service serves its cached value.
   useEffect(() => {
-    if (
-      selectedAction !== 'withdraw' ||
-      selectedWithdrawDestination.transferType === 'hyperEvm'
-    ) {
+    if (selectedAction !== 'withdraw') {
       return;
     }
     let cancelled = false;
     setWithdrawRoute(undefined);
-    const loadWithdrawRoute = () => {
-      void backgroundApiProxy.serviceHyperliquidExchange
-        .getUsdcWithdrawRoute()
-        .then((route) => {
-          if (!cancelled) {
-            setWithdrawRoute(route);
-          }
-        })
-        .catch((error) => {
-          console.error(
-            '[DepositWithdrawModal] Failed to resolve withdraw route:',
-            error,
-          );
-        });
-    };
-    loadWithdrawRoute();
-    const refreshInterval = setInterval(
-      loadWithdrawRoute,
-      WITHDRAW_QUOTE_REFRESH_INTERVAL_MS,
-    );
+    void backgroundApiProxy.serviceHyperliquidExchange
+      .getUsdcWithdrawRoute()
+      .then((route) => {
+        if (!cancelled) {
+          setWithdrawRoute(route);
+        }
+      })
+      .catch((error) => {
+        console.error(
+          '[DepositWithdrawModal] Failed to resolve withdraw route:',
+          error,
+        );
+      });
     return () => {
       cancelled = true;
-      clearInterval(refreshInterval);
     };
-  }, [selectedAction, selectedWithdrawDestination.transferType]);
+  }, [selectedAction]);
 
   useEffect(() => {
     if (selectedAction !== 'withdraw') {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -6,7 +6,11 @@ import { BigNumber } from 'bignumber.js';
 import { useIntl } from 'react-intl';
 import { InputAccessoryView } from 'react-native';
 
-import type { IPageNavigationProp, useInTabDialog } from '@onekeyhq/components';
+import type {
+  IPageNavigationProp,
+  ISelectItem,
+  useInTabDialog,
+} from '@onekeyhq/components';
 import {
   Button,
   DashText,
@@ -17,6 +21,7 @@ import {
   NavBackButton,
   Page,
   Popover,
+  Select,
   SizableText,
   Skeleton,
   Stack,
@@ -52,6 +57,7 @@ import {
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountAtom,
   usePerpsComputedAccountValueAtom,
+  usePerpsCustomSettingsAtom,
   usePerpsDepositTokensAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
@@ -69,13 +75,19 @@ import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import {
-  CCTP_DOMAIN_ARBITRUM,
+  DEFAULT_USDC_WITHDRAW_DESTINATION_ID,
   HYPERLIQUID_DEPOSIT_ADDRESS,
   MIN_DEPOSIT_AMOUNT,
   MIN_WITHDRAW_AMOUNT,
   USDC_TOKEN_INFO,
+  USDC_WITHDRAW_DESTINATIONS,
+  USDC_WITHDRAW_GAS_RESERVE,
   WITHDRAW_FEE,
-  getCctpWithdrawFee,
+  getUsdcWithdrawDestination,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IUsdcWithdrawDestinationId,
+  IUsdcWithdrawFeeQuote,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import { swapDefaultSetTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type { ISwapNativeTokenConfig } from '@onekeyhq/shared/types/swap/types';
@@ -115,6 +127,7 @@ const PERP_DESKTOP_DEPOSIT_AMOUNT_INPUT_BLOCK_HEIGHT = 220;
 const PERP_ANDROID_DEPOSIT_AMOUNT_INPUT_BLOCK_HEIGHT = 176;
 const PERP_DESKTOP_DEPOSIT_SELECT_TOKEN_LIST_HEIGHT = 430;
 const PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT = 300;
+const WITHDRAW_QUOTE_REFRESH_INTERVAL_MS = 30_000;
 const LIFI_FALLBACK_LOGO = require('@onekeyhq/kit/assets/perps/lifi-logo.png');
 
 function hasPositivePerpsDepositTokenAmount(tokenAmount?: string) {
@@ -308,8 +321,22 @@ function DepositWithdrawContent({
   const selectedAction = params.actionType;
   const [computedValue] = usePerpsComputedAccountValueAtom();
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
+  const [perpsCustomSettings, setPerpsCustomSettings] =
+    usePerpsCustomSettingsAtom();
   const withdrawable = computedValue?.withdrawable ?? '';
   const [amount, setAmount] = useState('');
+  const withdrawDestinationId = getUsdcWithdrawDestination(
+    perpsCustomSettings.lastUsdcWithdrawDestinationId,
+  )
+    ? perpsCustomSettings.lastUsdcWithdrawDestinationId
+    : DEFAULT_USDC_WITHDRAW_DESTINATION_ID;
+  const [withdrawRoute, setWithdrawRoute] = useState<
+    'bridge' | 'cctp' | undefined
+  >(undefined);
+  const [withdrawFeeState, setWithdrawFeeState] = useState<{
+    key: string;
+    quote: IUsdcWithdrawFeeQuote;
+  }>();
   const [depositInputUnit, setDepositInputUnit] = useState<'token' | 'usd'>(
     'usd',
   );
@@ -319,6 +346,41 @@ function DepositWithdrawContent({
     'form' | 'selectToken'
   >('form');
   const amountInputRef = useRef<ISendAmountAutoSizeInputRef>(null);
+  const selectedWithdrawDestination = useMemo(
+    () =>
+      getUsdcWithdrawDestination(withdrawDestinationId) ??
+      USDC_WITHDRAW_DESTINATIONS[3],
+    [withdrawDestinationId],
+  );
+  let withdrawFeeKey: string | undefined;
+  if (selectedWithdrawDestination.transferType === 'hyperEvm') {
+    withdrawFeeKey = selectedWithdrawDestination.id;
+  } else if (withdrawRoute) {
+    withdrawFeeKey = `${selectedWithdrawDestination.id}:${withdrawRoute}`;
+  }
+  const withdrawFeeQuote =
+    withdrawFeeState && withdrawFeeState.key === withdrawFeeKey
+      ? withdrawFeeState.quote
+      : undefined;
+  const cctpFeeComponent = withdrawFeeQuote?.components.find(
+    (component) => component.kind === 'cctpForwarding',
+  );
+  const shouldReserveWithdrawGas =
+    selectedWithdrawDestination.transferType === 'hyperEvm' ||
+    withdrawRoute === 'cctp';
+  const isWithdrawFeeQuoteComplete =
+    Boolean(withdrawFeeQuote) &&
+    withdrawFeeQuote?.components.every((component) =>
+      Boolean(component.amount),
+    );
+  const isWithdrawDestinationReady =
+    selectedAction !== 'withdraw' ||
+    (isWithdrawFeeQuoteComplete &&
+      (selectedWithdrawDestination.transferType === 'hyperEvm' ||
+        withdrawRoute === 'cctp' ||
+        (withdrawRoute === 'bridge' &&
+          selectedWithdrawDestination.transferType === 'cctp' &&
+          selectedWithdrawDestination.supportsLegacyBridge)));
   const [
     {
       tokens,
@@ -870,6 +932,18 @@ function DepositWithdrawContent({
     [availableBalance.balance],
   );
 
+  // Hyperliquid may charge the sub-cent Core -> EVM gas outside the requested
+  // amount. Reserve one cent so a full-balance withdrawal does not fail.
+  const maximumWithdrawAmountBN = useMemo(() => {
+    const maximum = shouldReserveWithdrawGas
+      ? availableBalanceBN.minus(USDC_WITHDRAW_GAS_RESERVE)
+      : availableBalanceBN;
+    return BigNumber.maximum(maximum, 0).decimalPlaces(
+      USDC_TOKEN_INFO.decimals,
+      BigNumber.ROUND_DOWN,
+    );
+  }, [availableBalanceBN, shouldReserveWithdrawGas]);
+
   const checkFromTokenFiatValue = useMemo(() => {
     return getPerpsDepositMinimumCheck({
       inputAmount: amount,
@@ -884,6 +958,18 @@ function DepositWithdrawContent({
     currentPerpsDepositSelectedToken?.price,
   ]);
 
+  const minimumWithdrawAmountBN = useMemo(() => {
+    const configuredMinimum = new BigNumber(MIN_WITHDRAW_AMOUNT);
+    if (!cctpFeeComponent?.amount) {
+      return configuredMinimum;
+    }
+    const amountAboveFee = new BigNumber(cctpFeeComponent.amount).plus(
+      '0.000001',
+    );
+    return BigNumber.maximum(configuredMinimum, amountAboveFee);
+  }, [cctpFeeComponent?.amount]);
+  const minimumWithdrawAmountText = minimumWithdrawAmountBN.toFixed();
+
   const isValidAmount = useMemo(() => {
     if (amountBN.isNaN() || amountBN.lte(0)) return false;
 
@@ -895,14 +981,14 @@ function DepositWithdrawContent({
     const isBelowWithdrawMin =
       selectedAction === 'withdraw' &&
       hasActiveAmount &&
-      amountBN.lt(MIN_WITHDRAW_AMOUNT);
+      amountBN.lt(minimumWithdrawAmountBN);
 
     if (selectedAction === 'deposit') {
       return tokenAmountBN.lte(availableBalanceBN) && !isBelowDepositMin;
     }
 
     if (selectedAction === 'withdraw') {
-      return amountBN.lte(availableBalanceBN) && !isBelowWithdrawMin;
+      return amountBN.lte(maximumWithdrawAmountBN) && !isBelowWithdrawMin;
     }
 
     return true;
@@ -913,6 +999,8 @@ function DepositWithdrawContent({
     availableBalanceBN,
     selectedAction,
     checkFromTokenFiatValue.value,
+    maximumWithdrawAmountBN,
+    minimumWithdrawAmountBN,
   ]);
 
   const errorMessage = useMemo(() => {
@@ -935,10 +1023,10 @@ function DepositWithdrawContent({
     }
 
     if (selectedAction === 'withdraw') {
-      if (showMinAmountError && amountBN.lt(MIN_WITHDRAW_AMOUNT)) {
+      if (showMinAmountError && amountBN.lt(minimumWithdrawAmountBN)) {
         return intl.formatMessage(
           { id: ETranslations.perp_mini_withdraw },
-          { num: MIN_WITHDRAW_AMOUNT, token: 'USDC' },
+          { num: minimumWithdrawAmountText, token: 'USDC' },
         );
       }
     }
@@ -953,6 +1041,8 @@ function DepositWithdrawContent({
     checkFromTokenFiatValue.minFromTokenAmount,
     intl,
     currentPerpsDepositSelectedToken?.symbol,
+    minimumWithdrawAmountBN,
+    minimumWithdrawAmountText,
   ]);
 
   const depositQuoteAmountDebounced = useDebounce(tokenAmount, 800);
@@ -1082,12 +1172,18 @@ function DepositWithdrawContent({
         setShowMinAmountError(true);
       } else if (
         selectedAction === 'withdraw' &&
-        amountBN.lt(MIN_WITHDRAW_AMOUNT)
+        amountBN.lt(minimumWithdrawAmountBN)
       ) {
         setShowMinAmountError(true);
       }
     }
-  }, [amount, amountBN, selectedAction, checkFromTokenFiatValue.value]);
+  }, [
+    amount,
+    amountBN,
+    checkFromTokenFiatValue.value,
+    minimumWithdrawAmountBN,
+    selectedAction,
+  ]);
 
   const checkNativeTokenGasToast = useCallback(
     (
@@ -1197,7 +1293,10 @@ function DepositWithdrawContent({
         return;
       }
       if (availableBalance) {
-        const nextAmount = availableBalance.balance || '0';
+        const nextAmount =
+          selectedAction === 'withdraw'
+            ? maximumWithdrawAmountBN.toFixed()
+            : availableBalance.balance || '0';
         setAmount(nextAmount);
       }
     },
@@ -1206,6 +1305,7 @@ function DepositWithdrawContent({
       checkNativeTokenGasToast,
       selectedAction,
       depositInputUnit,
+      maximumWithdrawAmountBN,
       tokenPriceBN,
     ],
   );
@@ -1222,12 +1322,18 @@ function DepositWithdrawContent({
     }
 
     if (selectedAction === 'withdraw') {
-      setShowMinAmountError(amountBN.lt(MIN_WITHDRAW_AMOUNT));
+      setShowMinAmountError(amountBN.lt(minimumWithdrawAmountBN));
       return;
     }
 
     setShowMinAmountError(false);
-  }, [amount, amountBN, checkFromTokenFiatValue.value, selectedAction]);
+  }, [
+    amount,
+    amountBN,
+    checkFromTokenFiatValue.value,
+    minimumWithdrawAmountBN,
+    selectedAction,
+  ]);
 
   const validateAmountBeforeSubmit = useCallback(() => {
     if (amountBN.isNaN() || amountBN.lte(0)) {
@@ -1239,7 +1345,11 @@ function DepositWithdrawContent({
 
     const balanceCheckBN =
       selectedAction === 'deposit' ? tokenAmountBN : amountBN;
-    if (balanceCheckBN.gt(availableBalanceBN)) {
+    const maximumAmountBN =
+      selectedAction === 'deposit'
+        ? availableBalanceBN
+        : maximumWithdrawAmountBN;
+    if (balanceCheckBN.gt(maximumAmountBN)) {
       Toast.error({
         title: intl.formatMessage({
           id: ETranslations.earn_insufficient_balance,
@@ -1261,11 +1371,11 @@ function DepositWithdrawContent({
       return false;
     }
 
-    if (selectedAction === 'withdraw' && amountBN.lt(MIN_WITHDRAW_AMOUNT)) {
+    if (selectedAction === 'withdraw' && amountBN.lt(minimumWithdrawAmountBN)) {
       setShowMinAmountError(true);
       const message = intl.formatMessage(
         { id: ETranslations.perp_mini_withdraw },
-        { num: MIN_WITHDRAW_AMOUNT, token: 'USDC' },
+        { num: minimumWithdrawAmountText, token: 'USDC' },
       );
       Toast.error({ title: message });
       return false;
@@ -1284,6 +1394,9 @@ function DepositWithdrawContent({
     checkFromTokenFiatValue.value,
     currentPerpsDepositSelectedToken?.symbol,
     intl,
+    maximumWithdrawAmountBN,
+    minimumWithdrawAmountBN,
+    minimumWithdrawAmountText,
     selectedAction,
     showMinAmountError,
   ]);
@@ -1306,17 +1419,18 @@ function DepositWithdrawContent({
       >
         {intl.formatMessage(
           { id: ETranslations.perp_size_least },
-          { amount: `${MIN_WITHDRAW_AMOUNT} USDC` },
+          { amount: `${minimumWithdrawAmountText} USDC` },
         )}
       </SizableText>
     );
-  }, [intl, selectedAction]);
+  }, [intl, minimumWithdrawAmountText, selectedAction]);
 
   const handleConfirm = useCallback(async () => {
     if (
       !isValidAmount ||
       !selectedAccount.accountAddress ||
-      !checkAccountSupport
+      !checkAccountSupport ||
+      !isWithdrawDestinationReady
     )
       return;
 
@@ -1401,7 +1515,13 @@ function DepositWithdrawContent({
         await withdraw({
           userAccountId: selectedAccount.accountId || '',
           amount,
-          destination: selectedAccount.accountAddress,
+          destinationId: withdrawDestinationId,
+          expectedRoute:
+            selectedWithdrawDestination.transferType === 'cctp'
+              ? withdrawRoute
+              : undefined,
+          expectedCctpFee:
+            withdrawRoute === 'cctp' ? cctpFeeComponent?.amount : undefined,
         });
         void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
         onClose?.();
@@ -1414,6 +1534,7 @@ function DepositWithdrawContent({
     }
   }, [
     isValidAmount,
+    isWithdrawDestinationReady,
     checkAccountSupport,
     selectedAccount.accountAddress,
     selectedAccount.accountId,
@@ -1424,6 +1545,10 @@ function DepositWithdrawContent({
     isArbitrumUsdcToken,
     normalizeTxConfirm,
     amount,
+    cctpFeeComponent?.amount,
+    selectedWithdrawDestination.transferType,
+    withdrawDestinationId,
+    withdrawRoute,
     tokenAmount,
     handlePerpDepositTxSuccess,
     onClose,
@@ -1448,7 +1573,6 @@ function DepositWithdrawContent({
         id: ETranslations.earn_insufficient_balance,
       });
     }
-
     return errorMessage;
   }, [errorMessage, intl, isInsufficientBalance]);
 
@@ -1592,11 +1716,6 @@ function DepositWithdrawContent({
       resolvedCurrentPerpsDepositSelectedToken.networkId,
     );
   }, [resolvedCurrentPerpsDepositSelectedToken?.networkId]);
-
-  const perpsNetworkInfo = useMemo(
-    () => networkUtils.getLocalNetworkInfo(PERPS_NETWORK_ID),
-    [],
-  );
 
   const openTokenSelectorPage = useCallback(() => {
     if (!checkAccountSupport || balanceLoading) return;
@@ -1959,45 +2078,157 @@ function DepositWithdrawContent({
     return buttonText;
   }, [buttonText, intl, shouldShowBuyButton]);
 
-  // Hyperliquid serves the active withdrawal rail, and the two rails charge very
-  // different fees, so resolve it before quoting one. Display only: the amount
-  // validation uses MIN_WITHDRAW_AMOUNT, which covers both rails.
-  const [withdrawRoute, setWithdrawRoute] = useState<
-    'bridge' | 'cctp' | undefined
-  >(undefined);
+  const withdrawDestinationItems = useMemo<ISelectItem[]>(
+    () =>
+      USDC_WITHDRAW_DESTINATIONS.map((destination) => ({
+        label: destination.name,
+        value: destination.id,
+        disabled:
+          destination.transferType === 'cctp' &&
+          withdrawRoute !== 'cctp' &&
+          !destination.supportsLegacyBridge,
+      })),
+    [withdrawRoute],
+  );
+
+  const handleWithdrawDestinationChange = useCallback(
+    (value: IUsdcWithdrawDestinationId | undefined) => {
+      if (value && getUsdcWithdrawDestination(value)) {
+        setPerpsCustomSettings((previous) => ({
+          ...previous,
+          lastUsdcWithdrawDestinationId: value,
+        }));
+      }
+    },
+    [setPerpsCustomSettings],
+  );
+
+  // HyperEVM is a native sendAsset transfer. Only external CCTP destinations
+  // need the server-selected bridge/CCTP rail.
+  useEffect(() => {
+    if (
+      selectedAction !== 'withdraw' ||
+      selectedWithdrawDestination.transferType === 'hyperEvm'
+    ) {
+      return;
+    }
+    let cancelled = false;
+    setWithdrawRoute(undefined);
+    const loadWithdrawRoute = () => {
+      void backgroundApiProxy.serviceHyperliquidExchange
+        .getUsdcWithdrawRoute()
+        .then((route) => {
+          if (!cancelled) {
+            setWithdrawRoute(route);
+          }
+        })
+        .catch((error) => {
+          console.error(
+            '[DepositWithdrawModal] Failed to resolve withdraw route:',
+            error,
+          );
+        });
+    };
+    loadWithdrawRoute();
+    const refreshInterval = setInterval(
+      loadWithdrawRoute,
+      WITHDRAW_QUOTE_REFRESH_INTERVAL_MS,
+    );
+    return () => {
+      cancelled = true;
+      clearInterval(refreshInterval);
+    };
+  }, [selectedAction, selectedWithdrawDestination.transferType]);
+
   useEffect(() => {
     if (selectedAction !== 'withdraw') {
       return;
     }
+    if (!withdrawFeeKey) {
+      return;
+    }
     let cancelled = false;
-    void backgroundApiProxy.serviceHyperliquidExchange
-      .getUsdcWithdrawRoute()
-      .then((route) => {
-        if (!cancelled) {
-          setWithdrawRoute(route);
+    const loadWithdrawFee = () => {
+      if (
+        selectedWithdrawDestination.transferType === 'cctp' &&
+        withdrawRoute === 'bridge'
+      ) {
+        if (selectedWithdrawDestination.supportsLegacyBridge) {
+          setWithdrawFeeState({
+            key: withdrawFeeKey,
+            quote: {
+              components: [
+                {
+                  kind: 'legacyBridge',
+                  amount: WITHDRAW_FEE.toString(),
+                  token: 'USDC',
+                  debitedFrom: 'withdrawAmount',
+                  isEstimate: false,
+                },
+              ],
+              quotedAt: Date.now(),
+            },
+          });
         }
-      })
-      .catch((error) => {
-        console.error(
-          '[DepositWithdrawModal] Failed to resolve withdraw route:',
-          error,
-        );
-      });
+        return;
+      }
+      void backgroundApiProxy.serviceHyperliquidExchange
+        .getUsdcWithdrawFee({ destinationId: withdrawDestinationId })
+        .then((feeQuote) => {
+          if (!cancelled) {
+            setWithdrawFeeState({ key: withdrawFeeKey, quote: feeQuote });
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setWithdrawFeeState((current) =>
+              current?.key === withdrawFeeKey ? undefined : current,
+            );
+          }
+          console.error(
+            '[DepositWithdrawModal] Failed to resolve withdraw fee:',
+            error,
+          );
+        });
+    };
+    loadWithdrawFee();
+    const refreshInterval = setInterval(
+      loadWithdrawFee,
+      WITHDRAW_QUOTE_REFRESH_INTERVAL_MS,
+    );
     return () => {
       cancelled = true;
+      clearInterval(refreshInterval);
     };
-  }, [selectedAction]);
+  }, [
+    selectedAction,
+    selectedWithdrawDestination,
+    withdrawDestinationId,
+    withdrawFeeKey,
+    withdrawRoute,
+  ]);
 
   const withdrawFeeText = useMemo(() => {
-    if (!withdrawRoute) {
+    if (!withdrawFeeQuote) {
       return '--';
     }
-    const fee =
-      withdrawRoute === 'cctp'
-        ? getCctpWithdrawFee(CCTP_DOMAIN_ARBITRUM)
-        : WITHDRAW_FEE;
-    return `$${fee.toFixed(2)}`;
-  }, [withdrawRoute]);
+    return withdrawFeeQuote.components
+      .map((component) => {
+        if (component.kind === 'hyperEvmGas') {
+          return `< $${new BigNumber(component.amount).toFixed(2)}`;
+        }
+        return `${component.isEstimate ? '≈ ' : ''}$${new BigNumber(
+          component.amount,
+        ).toFixed(2)}`;
+      })
+      .join(' + ');
+  }, [withdrawFeeQuote]);
+
+  const withdrawSubmitDisabled =
+    !isValidAmount ||
+    isSubmitting ||
+    shouldShowWithdrawableSkeleton ||
+    !isWithdrawDestinationReady;
 
   const withdrawFeeHintTrigger = useMemo(
     () => (
@@ -2258,9 +2489,7 @@ function DepositWithdrawContent({
               testID="perp-btn"
               variant="primary"
               size={PERP_DIALOG_BUTTON_SIZE}
-              disabled={
-                !isValidAmount || isSubmitting || shouldShowWithdrawableSkeleton
-              }
+              disabled={withdrawSubmitDisabled}
               loading={isSubmitting}
               onPress={handleConfirm}
             >
@@ -2274,9 +2503,7 @@ function DepositWithdrawContent({
             onKeyPress={handleNativeAmountKeyPress}
             onBackspaceLongPress={handleNativeAmountBackspaceLongPress}
             ctaLabel={nativeAmountCtaLabel}
-            ctaDisabled={
-              !isValidAmount || isSubmitting || shouldShowWithdrawableSkeleton
-            }
+            ctaDisabled={withdrawSubmitDisabled}
             ctaLoading={isSubmitting}
             onCtaPress={handleConfirm}
           />
@@ -2472,10 +2699,47 @@ function DepositWithdrawContent({
                     alignItems="center"
                     gap="$1"
                   >
-                    <SizableText size="$bodySm" color="$textSubdued">
-                      {intl.formatMessage({ id: ETranslations.global_to })}{' '}
-                      {perpsNetworkInfo?.name ?? 'Arbitrum'}
-                    </SizableText>
+                    <Select
+                      key={`perp-withdraw-destination-${
+                        withdrawRoute ?? 'loading'
+                      }`}
+                      testID="perp-withdraw-destination-select"
+                      items={withdrawDestinationItems}
+                      value={withdrawDestinationId}
+                      onChange={handleWithdrawDestinationChange}
+                      disabled={isSubmitting || !checkAccountSupport}
+                      title={intl.formatMessage({
+                        id: ETranslations.global_select_network,
+                      })}
+                      renderTrigger={({
+                        onPress,
+                        label,
+                        disabled: disabledTrigger,
+                      }) => (
+                        <XStack
+                          alignItems="center"
+                          gap="$0.5"
+                          onPress={onPress}
+                          disabled={disabledTrigger}
+                          cursor={disabledTrigger ? 'default' : 'pointer'}
+                        >
+                          <SizableText size="$bodySm" color="$textSubdued">
+                            {intl.formatMessage({
+                              id: ETranslations.global_to,
+                            })}{' '}
+                            {label ?? selectedWithdrawDestination.name}
+                          </SizableText>
+                          <Icon
+                            name="ChevronTriangleDownSmallSolid"
+                            size="$4"
+                            color="$iconSubdued"
+                          />
+                        </XStack>
+                      )}
+                      placement="bottom"
+                      offset={16}
+                      floatingPanelProps={{ width: 200 }}
+                    />
                     {errorMessage ? (
                       <SizableText size="$bodySm" color="$textCritical">
                         {errorMessage}

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -1,5 +1,51 @@
 import type { IHex } from './sdk';
 
+interface IUsdcWithdrawDestinationConfigBase {
+  name: string;
+  networkId: string;
+  signatureChainId: IHex;
+}
+
+export interface ICctpWithdrawDestinationConfig extends IUsdcWithdrawDestinationConfigBase {
+  id: 'ethereum' | 'avalanche' | 'optimism' | 'arbitrum' | 'base';
+  transferType: 'cctp';
+  domain: 0 | 1 | 2 | 3 | 6;
+  addressEncoding: 'hex';
+  fallbackFee: number;
+  supportsLegacyBridge: boolean;
+}
+
+export interface IHyperEvmWithdrawDestinationConfig extends IUsdcWithdrawDestinationConfigBase {
+  id: 'hyperevm';
+  transferType: 'hyperEvm';
+}
+
+export type IUsdcWithdrawDestinationConfig =
+  | ICctpWithdrawDestinationConfig
+  | IHyperEvmWithdrawDestinationConfig;
+
+export type IUsdcWithdrawFeeComponent =
+  | {
+      kind: 'cctpForwarding' | 'legacyBridge';
+      amount: string;
+      token: 'USDC';
+      debitedFrom: 'withdrawAmount';
+      isEstimate: boolean;
+    }
+  | {
+      kind: 'hyperEvmGas';
+      amount: string;
+      token: 'USDC';
+      debitedFrom: 'spotHypeOrSourceUsdc';
+      isEstimate: true;
+      displayAsLessThan: true;
+    };
+
+export interface IUsdcWithdrawFeeQuote {
+  components: IUsdcWithdrawFeeComponent[];
+  quotedAt: number;
+}
+
 export const MAX_DECIMALS_PERP = 6;
 export const MAX_DECIMALS_SPOT = 8;
 export const MAX_SIGNIFICANT_FIGURES = 5;
@@ -22,31 +68,92 @@ export const WITHDRAW_FEE = 1;
 // withdrawal or a plain transfer to HyperEVM.
 export const HYPEREVM_SYSTEM_ADDRESS =
   '0x2000000000000000000000000000000000000000' as IHex;
+export const USDC_WITHDRAW_GAS_RESERVE = 0.01;
 
-// Circle CCTP domain ids (NOT EVM chain ids). Arbitrum is the only destination
-// we withdraw to today.
-export const CCTP_DOMAIN_ARBITRUM = 3;
+// Keep the allowlist here so the UI and BG signer cannot disagree on a route or
+// EIP-712 signing chain. External chains use Circle CCTP domain ids; HyperEVM is
+// a native HyperCore sendAsset transfer and does not have a CCTP destination.
+export const USDC_WITHDRAW_DESTINATIONS = [
+  {
+    id: 'ethereum',
+    name: 'Ethereum',
+    networkId: 'evm--1',
+    transferType: 'cctp',
+    domain: 0,
+    addressEncoding: 'hex',
+    signatureChainId: '0x1',
+    fallbackFee: 1.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'avalanche',
+    name: 'Avalanche',
+    networkId: 'evm--43114',
+    transferType: 'cctp',
+    domain: 1,
+    addressEncoding: 'hex',
+    signatureChainId: '0xa86a',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'optimism',
+    name: 'OP Mainnet',
+    networkId: 'evm--10',
+    transferType: 'cctp',
+    domain: 2,
+    addressEncoding: 'hex',
+    signatureChainId: '0xa',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'arbitrum',
+    name: 'Arbitrum',
+    networkId: 'evm--42161',
+    transferType: 'cctp',
+    domain: 3,
+    addressEncoding: 'hex',
+    signatureChainId: '0xa4b1',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: true,
+  },
+  {
+    id: 'base',
+    name: 'Base',
+    networkId: 'evm--8453',
+    transferType: 'cctp',
+    domain: 6,
+    addressEncoding: 'hex',
+    signatureChainId: '0x2105',
+    fallbackFee: 0.2,
+    supportsLegacyBridge: false,
+  },
+  {
+    id: 'hyperevm',
+    name: 'HyperEVM',
+    networkId: 'evm--999',
+    transferType: 'hyperEvm',
+    // HyperEVM sendAsset accepts any valid EVM chain id for replay protection.
+    signatureChainId: '0xa4b1',
+  },
+] as const satisfies readonly IUsdcWithdrawDestinationConfig[];
+
+export type IUsdcWithdrawDestinationId =
+  (typeof USDC_WITHDRAW_DESTINATIONS)[number]['id'];
+
+export function getUsdcWithdrawDestination(
+  id: string,
+): IUsdcWithdrawDestinationConfig | undefined {
+  return USDC_WITHDRAW_DESTINATIONS.find((item) => item.id === id);
+}
+
+export const DEFAULT_USDC_WITHDRAW_DESTINATION_ID: IUsdcWithdrawDestinationId =
+  'arbitrum';
 export const CCTP_WITHDRAW_GAS_LIMIT = 200_000;
 // Empty hook data makes CoreDepositWallet attach the default forwarding hook, so
 // Circle delivers to the recipient instead of leaving them to claim it.
 export const CCTP_WITHDRAW_HOOK_DATA = '0x';
-
-// Circle's forwarding fee, deducted from the withdrawn amount. Source of truth is
-// `calculateCrossChainWithdrawalFee(true, domain)` on CoreDepositWallet
-// (HyperEVM 0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24). Mirrored as constants
-// because we only withdraw to Arbitrum, where the value has held since launch;
-// read it live once multiple destinations are selectable.
-const CCTP_WITHDRAW_FEE_DEFAULT = 0.2;
-const CCTP_WITHDRAW_FEE_BY_DOMAIN: Record<number, number> = {
-  0: 1.2, // Ethereum
-  5: 0.5, // Solana
-};
-
-export function getCctpWithdrawFee(destinationDomain: number): number {
-  return (
-    CCTP_WITHDRAW_FEE_BY_DOMAIN[destinationDomain] ?? CCTP_WITHDRAW_FEE_DEFAULT
-  );
-}
 
 export const USDC_TOKEN_INFO = {
   address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as IHex,

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -1,4 +1,5 @@
-import type { IFill, IHex, ITIF, IWithdraw3Request } from './sdk';
+import type { IUsdcWithdrawDestinationId } from './perp.constants';
+import type { IFill, IHex, ITIF } from './sdk';
 import type { EHyperLiquidAgentName } from '../../src/consts/perp';
 
 export enum EPerpsSubscriptionCategory {
@@ -136,8 +137,12 @@ export interface IModifyOrderParams {
   allowZeroSize?: boolean;
 }
 
-export interface IWithdrawParams extends IWithdraw3Request {
+export interface IWithdrawParams {
   userAccountId: string;
+  amount: string;
+  destinationId: IUsdcWithdrawDestinationId;
+  expectedRoute?: 'bridge' | 'cctp';
+  expectedCctpFee?: string;
 }
 
 export interface ILeverageUpdateRequest {


### PR DESCRIPTION
## Summary
- Add a cross-platform withdrawal destination selector for Ethereum, Avalanche, OP Mainnet, Arbitrum, Base, and HyperEVM.
- Default to Arbitrum and persist the last selected destination across app restarts.
- Build and validate destination-specific CCTP or HyperEVM withdrawal actions, including live fee checks before submission.

## Intent & Context
The existing Perps USDC withdrawal flow was fixed to Arbitrum. This follow-up lets users choose the destination chain while keeping the route, signing chain, Circle domain, recipient, and displayed fee aligned with the selected destination.

## Design Decisions
- Keep the destination allowlist and signing metadata in shared constants so UI and background signing cannot disagree.
- Use Circle CCTP domains for external EVM destinations and Hyperliquid sendAsset for the native HyperCore to HyperEVM transfer.
- Query the CoreDepositWallet forwarding fee through the existing OneKey HyperEVM RPC path, cache display quotes for five minutes, and require a fresh exact fee before submission.
- Preserve the legacy bridge only for Arbitrum when Hyperliquid serves that route; other external destinations remain disabled until CCTP is available.
- Display the estimated HyperEVM gas cost as < $0.01 and reserve 0.01 USDC from the maximum withdrawal amount for Core to EVM gas safety.

## Changes Detail
- Added destination/domain/signing-chain configuration for Ethereum, Avalanche, OP Mainnet, Arbitrum, Base, and HyperEVM.
- Added CCTP fee encoding, parsing, caching, and destination payload construction.
- Extended the withdrawal service to revalidate route and fee immediately before signing and to select the correct source balance.
- Added responsive selector UI, solid triangle trigger styling, fee states, default selection, and persisted selection.
- Added focused coverage for destination routing, fee behavior, route changes, and persisted defaults.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Web, Desktop, Mobile
- **Risk Areas**: CCTP domain/signing metadata, live fee changes, Hyperliquid route changes, and source balance selection

## Test plan
- [x] Run `yarn jest packages/kit-bg/src/services/ServiceHyperLiquid/usdcWithdrawRoute.test.ts packages/kit-bg/src/states/jotai/atoms/perps.test.ts --runInBand --no-watchman` (44 tests passed)
- [x] Run `yarn agent:check --profile commit`
- [ ] Verify the destination selector layout and interaction on Web, Desktop, and Mobile.
- [ ] Verify Arbitrum is the first-run default and the last selection is restored after reopening.
- [ ] Verify CCTP fees refresh and submissions are blocked when the route or fee changes.
- [ ] Verify HyperEVM displays < $0.01 and submits through sendAsset.