### PR TITLE
fix: refresh DeFi network config cache(OK-61713)

### DIFF
--- a/packages/kit-bg/src/services/ServiceDeFi.enabledNetworks.test.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.enabledNetworks.test.ts
@@ -1,0 +1,232 @@
+/*
+yarn test packages/kit-bg/src/services/ServiceDeFi.enabledNetworks.test.ts
+*/
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => () => undefined,
+  backgroundMethod: () => (_t: unknown, _k: unknown, d: PropertyDescriptor) =>
+    d,
+  toastIfError: () => (_t: unknown, _k: unknown, d: PropertyDescriptor) => d,
+}));
+
+jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
+  EAppEventBusNames: {
+    DeFiEnabledNetworksChanged: 'DeFiEnabledNetworksChanged',
+    DeFiPositionRefreshed: 'DeFiPositionRefreshed',
+    LocalPendingTxConfirmed: 'LocalPendingTxConfirmed',
+  },
+  appEventBus: {
+    emit: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+jest.mock('../states/jotai/atoms/currency', () => ({
+  currencyPersistAtom: {
+    get: async () => ({ currencyMap: {} }),
+  },
+}));
+
+jest.mock('./ServiceBase', () => ({
+  __esModule: true,
+  default: class ServiceBase {
+    backgroundApi: unknown;
+
+    constructor({ backgroundApi }: { backgroundApi: unknown }) {
+      this.backgroundApi = backgroundApi;
+    }
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/accountUtils', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/networkUtils', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/timerUtils', () => ({
+  __esModule: true,
+  default: {
+    getTimeDurationMs: () => 10,
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
+
+// eslint-disable-next-line import/first
+import ServiceDeFi from './ServiceDeFi';
+
+const mockAppEventBus = appEventBus as unknown as {
+  emit: jest.Mock;
+  on: jest.Mock;
+};
+
+type IEnabledNetworksState = {
+  enabledNetworksMap: Record<string, boolean>;
+};
+
+function makeService(initialState: IEnabledNetworksState) {
+  let storedState = initialState;
+  let updateCount = 0;
+  const updateWaiters: Array<{
+    count: number;
+    resolve: () => void;
+  }> = [];
+  const deFiDb = {
+    getEnabledNetworksMap: jest.fn(async () => storedState.enabledNetworksMap),
+    updateEnabledNetworksMap: jest.fn(
+      async ({
+        enabledNetworksMap,
+      }: {
+        enabledNetworksMap: Record<string, boolean>;
+      }) => {
+        storedState = {
+          enabledNetworksMap,
+        };
+        updateCount += 1;
+        updateWaiters
+          .filter((waiter) => waiter.count <= updateCount)
+          .forEach((waiter) => waiter.resolve());
+      },
+    ),
+  };
+  const Ctor = ServiceDeFi as unknown as new (args: {
+    backgroundApi: unknown;
+  }) => ServiceDeFi;
+  const service = new Ctor({
+    backgroundApi: {
+      simpleDb: { deFi: deFiDb },
+    },
+  });
+
+  return {
+    deFiDb,
+    getStoredState: () => storedState,
+    service,
+    waitForUpdate: (count: number) => {
+      if (updateCount >= count) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        updateWaiters.push({ count, resolve });
+      });
+    },
+  };
+}
+
+async function flushAsyncWork() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe('DeFi enabled networks config cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('refreshes a persisted cache on first read and applies an added network', async () => {
+    const { getStoredState, service, waitForUpdate } = makeService({
+      enabledNetworksMap: { 'evm--1': true },
+    });
+    const fetchMock = jest
+      .spyOn(service, 'fetchDeFiEnabledNetworks')
+      .mockResolvedValue(['evm--1', 'evm--4663']);
+
+    const staleResult = await service.getDeFiEnabledNetworksMapState();
+    await waitForUpdate(1);
+    await flushAsyncWork();
+
+    expect(staleResult.enabledNetworksMap).toEqual({ 'evm--1': true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getStoredState().enabledNetworksMap).toEqual({
+      'evm--1': true,
+      'evm--4663': true,
+    });
+    expect(mockAppEventBus.emit).toHaveBeenCalledWith(
+      'DeFiEnabledNetworksChanged',
+      undefined,
+    );
+  });
+
+  test('reuses the cached refresh result within five minutes', async () => {
+    const { service, waitForUpdate } = makeService({
+      enabledNetworksMap: { 'evm--1': true },
+    });
+    const fetchMock = jest
+      .spyOn(service, 'fetchDeFiEnabledNetworks')
+      .mockResolvedValue(['evm--1']);
+
+    await service.getDeFiEnabledNetworksMapState();
+    await waitForUpdate(1);
+    await flushAsyncWork();
+    await service.getDeFiEnabledNetworksMapState();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockAppEventBus.emit).not.toHaveBeenCalledWith(
+      'DeFiEnabledNetworksChanged',
+      undefined,
+    );
+  });
+
+  test('refreshes on the next read after expiry and applies a removed network', async () => {
+    const { getStoredState, service, waitForUpdate } = makeService({
+      enabledNetworksMap: {
+        'evm--1': true,
+        'evm--4663': true,
+      },
+    });
+    const fetchMock = jest
+      .spyOn(service, 'fetchDeFiEnabledNetworks')
+      .mockResolvedValueOnce(['evm--1', 'evm--4663'])
+      .mockResolvedValue(['evm--1']);
+
+    await service.getDeFiEnabledNetworksMapState();
+    await waitForUpdate(1);
+    await flushAsyncWork();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await service.getDeFiEnabledNetworksMapState();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await waitForUpdate(2);
+    await flushAsyncWork();
+
+    expect(getStoredState().enabledNetworksMap).toEqual({ 'evm--1': true });
+    expect(mockAppEventBus.emit).toHaveBeenCalledWith(
+      'DeFiEnabledNetworksChanged',
+      undefined,
+    );
+  });
+
+  test('keeps stale config when refresh fails', async () => {
+    const { getStoredState, service } = makeService({
+      enabledNetworksMap: { 'evm--1': true },
+    });
+    let resolveErrorLogged: (() => void) | undefined;
+    const errorLogged = new Promise<void>((resolve) => {
+      resolveErrorLogged = resolve;
+    });
+    jest
+      .spyOn(service, 'fetchDeFiEnabledNetworks')
+      .mockRejectedValue(new Error('mock network failure'));
+    jest.spyOn(console, 'error').mockImplementation(() => {
+      resolveErrorLogged?.();
+    });
+
+    const result = await service.getDeFiEnabledNetworksMapState();
+    await errorLogged;
+
+    expect(result.enabledNetworksMap).toEqual({ 'evm--1': true });
+    expect(getStoredState().enabledNetworksMap).toEqual({ 'evm--1': true });
+    expect(mockAppEventBus.emit).not.toHaveBeenCalledWith(
+      'DeFiEnabledNetworksChanged',
+      undefined,
+    );
+  });
+});

--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { debounce, isEmpty, isUndefined } from 'lodash';
+import { debounce, isEmpty, isEqual, isUndefined } from 'lodash';
 
 import { settingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
@@ -14,8 +14,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
 import defiUtils from '@onekeyhq/shared/src/utils/defiUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { ICurrencyItem } from '@onekeyhq/shared/types/currency';
 import type {
   IDeFiBuildTransactionParams,
@@ -105,13 +107,6 @@ function normalizeDeFiBuildTransactionResp(
 
 @backgroundClass()
 class ServiceDeFi extends ServiceBase {
-  private enabledNetworksMapEmptyCacheExpiresAt = 0;
-
-  private ensureEnabledNetworksMapPromise:
-    | Promise<IDeFiEnabledNetworksMapState>
-    | undefined
-    | null = null;
-
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
 
@@ -647,15 +642,22 @@ class ServiceDeFi extends ServiceBase {
       return;
     }
 
+    const previousMap =
+      await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap();
+    const enabledNetworksMap = networkIds.reduce(
+      (acc, networkId) => {
+        acc[networkId] = true;
+        return acc;
+      },
+      {} as Record<string, boolean>,
+    );
     await this.backgroundApi.simpleDb.deFi.updateEnabledNetworksMap({
-      enabledNetworksMap: networkIds.reduce(
-        (acc, networkId) => {
-          acc[networkId] = true;
-          return acc;
-        },
-        {} as Record<string, boolean>,
-      ),
+      enabledNetworksMap,
     });
+
+    if (!isEqual(previousMap, enabledNetworksMap)) {
+      appEventBus.emit(EAppEventBusNames.DeFiEnabledNetworksChanged, undefined);
+    }
   }
 
   @backgroundMethod()
@@ -680,62 +682,55 @@ class ServiceDeFi extends ServiceBase {
   ): Promise<IDeFiEnabledNetworksMapState> {
     const existing =
       (await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap()) ?? {};
-    if (!isEmpty(existing)) {
-      this.enabledNetworksMapEmptyCacheExpiresAt = 0;
+    const isReady = !isEmpty(existing);
+
+    if (isReady) {
+      void this._syncDeFiEnabledNetworksMapStateWithCache().catch(
+        console.error,
+      );
       return {
         enabledNetworksMap: existing,
         isReady: true,
       };
     }
 
-    const now = Date.now();
-    if (this.enabledNetworksMapEmptyCacheExpiresAt > now) {
-      return {
-        enabledNetworksMap: existing,
-        isReady: false,
-      };
-    }
-
     if (options?.syncIfEmpty === false) {
-      void this._syncDeFiEnabledNetworksMapState();
+      void this._syncDeFiEnabledNetworksMapStateWithCache().catch(
+        console.error,
+      );
       return {
         enabledNetworksMap: existing,
         isReady: false,
       };
     }
 
-    return this._syncDeFiEnabledNetworksMapState();
+    try {
+      return await this._syncDeFiEnabledNetworksMapStateWithCache();
+    } catch (error) {
+      console.error(error);
+      return {
+        enabledNetworksMap: existing,
+        isReady: false,
+      };
+    }
   }
 
-  private _syncDeFiEnabledNetworksMapState(): Promise<IDeFiEnabledNetworksMapState> {
-    if (this.ensureEnabledNetworksMapPromise) {
-      return this.ensureEnabledNetworksMapPromise;
-    }
-    this.ensureEnabledNetworksMapPromise = (async () => {
-      try {
-        await this.syncDeFiEnabledNetworks();
-      } catch (error) {
-        console.error(error);
-      }
-      const refreshed =
-        await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap();
-      const enabledNetworksMap = refreshed ?? {};
+  private _syncDeFiEnabledNetworksMapStateWithCache = cacheUtils.memoizee(
+    async (): Promise<IDeFiEnabledNetworksMapState> => {
+      await this.syncDeFiEnabledNetworks();
+      const enabledNetworksMap =
+        (await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap()) ?? {};
       const isReady = !isEmpty(enabledNetworksMap);
-      if (!isReady) {
-        this.enabledNetworksMapEmptyCacheExpiresAt = Date.now() + 30_000;
-      } else {
-        this.enabledNetworksMapEmptyCacheExpiresAt = 0;
-      }
       return {
         enabledNetworksMap,
         isReady,
       };
-    })().finally(() => {
-      this.ensureEnabledNetworksMapPromise = null;
-    });
-
-    return this.ensureEnabledNetworksMapPromise;
-  }
+    },
+    {
+      maxAge: timerUtils.getTimeDurationMs({ minute: 5 }),
+      promise: true,
+    },
+  );
 
   @backgroundMethod()
   public async getAccountsLocalDeFiOverview({

--- a/packages/kit/src/views/Home/hooks/useHomeWalletTabSupport.ts
+++ b/packages/kit/src/views/Home/hooks/useHomeWalletTabSupport.ts
@@ -63,6 +63,24 @@ export function useHomeWalletTabSupport({
     };
   }, [isAllNetworks]);
 
+  useEffect(() => {
+    const onDeFiEnabledNetworksChanged = () => {
+      setEnabledNetworksChangedNonce((value) => value + 1);
+    };
+
+    appEventBus.on(
+      EAppEventBusNames.DeFiEnabledNetworksChanged,
+      onDeFiEnabledNetworksChanged,
+    );
+
+    return () => {
+      appEventBus.off(
+        EAppEventBusNames.DeFiEnabledNetworksChanged,
+        onDeFiEnabledNetworksChanged,
+      );
+    };
+  }, []);
+
   const scopeKey = useMemo(
     () =>
       [

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -311,6 +311,7 @@ export interface IAppEventBusPayload {
     protocols: IDeFiProtocol[];
     protocolMap: Record<string, IProtocolSummary>;
   };
+  [EAppEventBusNames.DeFiEnabledNetworksChanged]: undefined;
   [EAppEventBusNames.EstimateTxFeeRetry]: undefined;
   [EAppEventBusNames.GasAccountSubmitRetryScheduled]: {
     attempt: number;

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -60,6 +60,7 @@ export enum EAppEventBusNames {
   HistoryTxStatusChanged = 'HistoryTxStatusChanged',
   LocalPendingTxConfirmed = 'LocalPendingTxConfirmed',
   DeFiPositionRefreshed = 'DeFiPositionRefreshed',
+  DeFiEnabledNetworksChanged = 'DeFiEnabledNetworksChanged',
   EstimateTxFeeRetry = 'estimateTxFeeRetry',
   GasAccountSubmitRetryScheduled = 'gasAccountSubmitRetryScheduled',
   GasAccountSubmitRetryCleared = 'gasAccountSubmitRetryCleared',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61713](https://onekeyhq.atlassian.net/browse/OK-61713)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Refresh the persisted DeFi enabled-network configuration through a passive five-minute cache.
- Notify the Home wallet tab owner only when the server configuration actually changes.
- Preserve the last valid configuration for empty responses and request failures.

## Intent & Context
OK-61713 reports that server-side additions or removals to the DeFi enabled-network configuration are not reflected on the wallet Home page after the configuration has already been cached.

## Root Cause
Once the persisted enabled-network map became non-empty, the previous read path returned it forever and stopped reaching the server sync path. Additions could never enter the local map and removals remained stale.

## Design Decisions
- Reuse the shared memoizee cache helper for passive five-minute freshness and in-flight deduplication.
- Keep persisted SimpleDB data as the last-valid value and avoid active polling.
- Refresh only on the next read after expiration.
- Emit a typed DeFiEnabledNetworksChanged event only when the complete map changes so the existing Home tab support owner recomputes in place.

## Changes Detail
- Update ServiceDeFi cache refresh and change-notification behavior.
- Subscribe the Home wallet tab support hook to DeFi configuration changes.
- Add the typed shared event bus contract.
- Add regression coverage for additions, cache hits, removals, unchanged data, and request failures.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Risk Areas**: Shared background-service cache timing and Home tab visibility.

## Test plan
- [x] Run targeted DeFi cache, Home tab support, and DeFi net-worth tests: 20 tests passed.
- [x] Run yarn agent:check --profile commit.
- [x] Verify Desktop with controlled server configurations for addition, removal, unchanged, empty, failure, recovery, and All Networks cases.
- [x] Verify expiration alone does not poll and the next read synchronizes the current page.

[OK-61713]: https://onekeyhq.atlassian.net/browse/OK-61713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ