### PR TITLE
fix: correct market token badges and sharing | OK-61638 & OK-61616

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.networkLogo.test.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.networkLogo.test.tsx
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+
+import { useMarketBannerDetail } from '.';
+
+import { render } from '@testing-library/react';
+
+const mockNetworkList = [
+  {
+    networkId: 'evm--143',
+    index: 1,
+    name: 'Monad',
+    logoUrl: 'https://example.com/monad.png',
+    explorerUrl: 'https://example.com',
+    chainId: '143',
+  },
+];
+const mockTickerResult = [
+  {
+    address: '0xmonad',
+    name: 'Monad Token',
+    symbol: 'MON',
+    decimals: 18,
+    networkId: 'evm--143',
+  },
+];
+const mockBannerSort = {
+  sortBy: undefined,
+  sortType: undefined,
+};
+const mockSetBannerSort = jest.fn();
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: { serviceMarketV2: {} },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: () => ({
+    result: mockTickerResult,
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Market/hooks', () => ({
+  useMarketBasicConfig: () => ({ networkList: mockNetworkList }),
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useMarketBannerListSortAtom: () => [mockBannerSort, mockSetBannerSort],
+}));
+
+describe('useMarketBannerDetail network logos', () => {
+  it('uses dynamic Market config logos for banner rows', () => {
+    let latestNetworkLogoUri: string | undefined;
+
+    function Probe() {
+      latestNetworkLogoUri = useMarketBannerDetail({
+        tokenListId: 'dynamic-network-list',
+        isPerps: false,
+      }).mobileData[0]?.networkLogoUri;
+      return null;
+    }
+
+    render(<Probe />);
+
+    expect(latestNetworkLogoUri).toBe('https://example.com/monad.png');
+  });
+});

--- a/packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.ts
+++ b/packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.ts
@@ -2,9 +2,11 @@ import { useCallback, useMemo, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useMarketBasicConfig } from '@onekeyhq/kit/src/views/Market/hooks';
 import { useMarketBannerListSortAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import {
+  buildMarketNetworkLogoUriMap,
   getNetworkLogoUri,
   transformApiItemToToken,
 } from '../../MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers';
@@ -29,6 +31,11 @@ export function useMarketBannerDetail({
   tokenListId,
   isPerps,
 }: IUseMarketBannerDetailParams) {
+  const { networkList } = useMarketBasicConfig();
+  const networkLogoUriMap = useMemo(
+    () => buildMarketNetworkLogoUriMap(networkList),
+    [networkList],
+  );
   const [bannerSort, setBannerSort] = useMarketBannerListSortAtom();
   const sortRef = useRef(bannerSort);
   sortRef.current = bannerSort;
@@ -52,14 +59,16 @@ export function useMarketBannerDetail({
     if (!tickerResult) return [];
     return tickerResult.map((item, index) => {
       const chainId = item.networkId || '';
-      const networkLogoUri = getNetworkLogoUri(chainId);
+      const networkLogoUri =
+        networkLogoUriMap.get(chainId) || getNetworkLogoUri(chainId);
       return transformApiItemToToken(item, {
         chainId,
+        networkLogoUriMap,
         networkLogoUri,
         sortIndex: index,
       });
     });
-  }, [tickerResult]);
+  }, [networkLogoUriMap, tickerResult]);
 
   const currentSortBy = isBannerDetailSortBy(bannerSort.sortBy)
     ? bannerSort.sortBy

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.test.tsx
@@ -1,0 +1,143 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { render } from '@testing-library/react';
+
+import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
+
+import { TokenDetailHeaderLeft } from './TokenDetailHeaderLeft';
+
+let mockMd = false;
+
+jest.mock('@onekeyhq/components', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const Container = ({ children }: { children?: ReactNode }) =>
+    React.createElement('div', null, children);
+
+  return {
+    Divider: Container,
+    InteractiveIcon: ({ testID }: { testID?: string }) =>
+      React.createElement('button', { 'data-testid': testID }),
+    SizableText: Container,
+    XStack: Container,
+    YStack: Container,
+    useMedia: () => ({ md: mockMd }),
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/components/Token', () => ({
+  Token: () => null,
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useNetworkLogoUri', () => ({
+  useNetworkLogoUri: () => '',
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/scopes/dex', () => ({
+  EWatchlistFrom: { Detail: 'Detail' },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/accountUtils', () => ({
+  __esModule: true,
+  default: { shortenAddress: () => '0x1234...5678' },
+}));
+
+jest.mock('../../../components/CommunityRecognizedBadge', () => ({
+  CommunityRecognizedBadge: () => null,
+}));
+
+jest.mock('../../../components/MarketStarV2', () => ({
+  MarketStarV2: () => null,
+}));
+
+jest.mock('../../../components/PerpsBadges', () => ({
+  StockMarketStatusBadge: () => null,
+  StockSourceLogo: () => null,
+  SubtitleBadge: () => null,
+}));
+
+jest.mock('../../../components/TokenTagsPopover', () => ({
+  TokenTagsPopover: () => null,
+}));
+
+jest.mock('../TokenSecurityAlert', () => ({
+  TokenSecurityAlert: () => null,
+}));
+
+jest.mock('../TokenSelector/MarketTokenSelector', () => ({
+  MarketTokenSelector: () => null,
+}));
+
+jest.mock('./hooks/useTokenDetailHeaderLeftActions', () => ({
+  useTokenDetailHeaderLeftActions: () => ({
+    handleCopyAddress: jest.fn(),
+    handleOpenWebsite: jest.fn(),
+    handleOpenTwitter: jest.fn(),
+    handleOpenXSearch: jest.fn(),
+  }),
+}));
+
+jest.mock('./ShareButton', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    ShareButton: ({ useIconButton }: { useIconButton?: boolean }) =>
+      React.createElement('button', {
+        'data-testid': useIconButton
+          ? 'market-url-icon-btn'
+          : 'market-url-icon',
+      }),
+  };
+});
+
+const tokenDetail = {
+  symbol: 'AI',
+  address: '0x1234567890abcdef',
+  extraData: {
+    website: 'https://example.com',
+    twitter: 'https://x.com/example',
+  },
+} as IMarketTokenDetail;
+
+describe('TokenDetailHeaderLeft share button layout', () => {
+  beforeEach(() => {
+    mockMd = false;
+  });
+
+  test('renders only the outer share button in the desktop redesign', () => {
+    const view = render(
+      <TokenDetailHeaderLeft
+        tokenDetail={tokenDetail}
+        networkId="evm--1"
+        desktopRedesign
+      />,
+    );
+
+    expect(view.queryAllByTestId('market-url-icon')).toHaveLength(0);
+    expect(view.queryAllByTestId('market-url-icon-btn')).toHaveLength(1);
+  });
+
+  test('keeps the inline share button in the legacy desktop layout', () => {
+    const view = render(
+      <TokenDetailHeaderLeft tokenDetail={tokenDetail} networkId="evm--1" />,
+    );
+
+    expect(view.queryAllByTestId('market-url-icon')).toHaveLength(1);
+    expect(view.queryAllByTestId('market-url-icon-btn')).toHaveLength(0);
+  });
+
+  test('renders one outer share button for redesigned top coins', () => {
+    const view = render(
+      <TokenDetailHeaderLeft
+        tokenDetail={tokenDetail}
+        networkId="evm--1"
+        desktopRedesign
+        desktopDetailVariant="topCoins"
+      />,
+    );
+
+    expect(view.queryAllByTestId('market-url-icon')).toHaveLength(0);
+    expect(view.queryAllByTestId('market-url-icon-btn')).toHaveLength(1);
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -226,7 +226,10 @@ export function TokenDetailHeaderLeft({
                         />
                       ) : null}
 
-                      {networkId && address && address !== SUI_TYPE_ARG ? (
+                      {!desktopRedesign &&
+                      networkId &&
+                      address &&
+                      address !== SUI_TYPE_ARG ? (
                         <ShareButton
                           networkId={networkId}
                           address={address}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -7,13 +7,19 @@ import {
   swrCacheUtils,
   swrKeys,
 } from '@onekeyhq/shared/src/utils/swrCacheUtils';
-import type { IMarketTokenListResponse } from '@onekeyhq/shared/types/marketV2';
+import type {
+  IMarketBasicConfigNetwork,
+  IMarketTokenListResponse,
+} from '@onekeyhq/shared/types/marketV2';
+
+import { transformApiItemToToken } from '../utils/tokenListHelpers';
 
 import { fetchMarketTokenListForPlatform } from './marketTokenListPlatformApi';
 import { useMarketTokenList } from './useMarketTokenList';
 
 const mockTrackNetworkLoading = jest.fn();
 let mockLocale = 'en-US';
+let mockNetworkList: IMarketBasicConfigNetwork[] = [];
 
 jest.mock('@onekeyhq/components', () => ({
   getCurrentVisibilityState: () => true,
@@ -35,7 +41,10 @@ jest.mock('@onekeyhq/kit/src/hooks/useLocaleVariant', () => ({
 }));
 
 jest.mock('@onekeyhq/kit/src/views/Market/hooks', () => ({
-  useMarketBasicConfig: () => ({ minLiquidity: 5000 }),
+  useMarketBasicConfig: () => ({
+    minLiquidity: 5000,
+    networkList: mockNetworkList,
+  }),
 }));
 
 jest.mock(
@@ -71,29 +80,27 @@ jest.mock('@onekeyhq/shared/src/utils/networkUtils', () => ({
 
 jest.mock('../utils/tokenListHelpers', () => ({
   getNetworkLogoUri: () => 'network-logo',
-  transformApiItemToToken: (item: {
-    address: string;
-    name: string;
-    symbol: string;
-  }) => ({
-    id: item.address,
-    name: item.name,
-    symbol: item.symbol,
-    address: item.address,
-    decimals: 18,
-    price: 1,
-    change24h: 0,
-    marketCap: 0,
-    liquidity: 0,
-    transactions: 0,
-    uniqueTraders: 0,
-    holders: 0,
-    turnover: 0,
-    tokenImageUri: '',
-    networkLogoUri: 'network-logo',
-    networkId: 'evm--1',
-    chainId: 'evm--1',
-  }),
+  transformApiItemToToken: jest.fn(
+    (item: { address: string; name: string; symbol: string }) => ({
+      id: item.address,
+      name: item.name,
+      symbol: item.symbol,
+      address: item.address,
+      decimals: 18,
+      price: 1,
+      change24h: 0,
+      marketCap: 0,
+      liquidity: 0,
+      transactions: 0,
+      uniqueTraders: 0,
+      holders: 0,
+      turnover: 0,
+      tokenImageUri: '',
+      networkLogoUri: 'network-logo',
+      networkId: 'evm--1',
+      chainId: 'evm--1',
+    }),
+  ),
 }));
 
 jest.mock('./marketTokenListPlatformApi', () => ({
@@ -134,6 +141,7 @@ describe('useMarketTokenList initial data', () => {
     type: 'trending',
   });
   const mockFetchMarketTokenList = jest.mocked(fetchMarketTokenListForPlatform);
+  const mockTransformApiItemToToken = jest.mocked(transformApiItemToToken);
 
   beforeEach(() => {
     Object.defineProperty(globalThis, 'cancelIdleCallback', {
@@ -143,9 +151,11 @@ describe('useMarketTokenList initial data', () => {
     mutablePlatformEnv.isNative = false;
     mutablePlatformEnv.isWeb = true;
     mockLocale = 'en-US';
+    mockNetworkList = [];
     swrCacheUtils.clearAll();
     swrCacheUtils.flushNow();
     mockFetchMarketTokenList.mockReset();
+    mockTransformApiItemToToken.mockClear();
     mockTrackNetworkLoading.mockReset();
   });
 
@@ -260,6 +270,54 @@ describe('useMarketTokenList initial data', () => {
 
     await waitFor(() => {
       expect(mockFetchMarketTokenList).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('passes dynamic Market network logos to token transformation', async () => {
+    mockNetworkList = [
+      {
+        networkId: 'evm--143',
+        index: 1,
+        name: 'Monad',
+        logoUrl: 'https://example.com/monad.png',
+        explorerUrl: 'https://example.com',
+        chainId: '143',
+      },
+    ];
+    mockFetchMarketTokenList.mockResolvedValue({
+      list: [
+        {
+          address: '0xmonad',
+          name: 'Monad Token',
+          symbol: 'MON',
+          decimals: 18,
+          networkId: 'evm--143',
+        },
+      ],
+      total: 1,
+    });
+
+    function Probe() {
+      useMarketTokenList({
+        networkId: 'evm--143',
+        pollingInterval: 0,
+        type: 'trending',
+      });
+      return null;
+    }
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      const transformOptions = mockTransformApiItemToToken.mock.calls.find(
+        ([item]) => item.address === '0xmonad',
+      )?.[1];
+      expect(transformOptions?.networkLogoUri).toBe(
+        'https://example.com/monad.png',
+      );
+      expect(transformOptions?.networkLogoUriMap?.get('evm--143')).toBe(
+        'https://example.com/monad.png',
+      );
     });
   });
 });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -78,30 +78,73 @@ jest.mock('@onekeyhq/shared/src/utils/networkUtils', () => ({
   default: { isAllNetwork: () => false },
 }));
 
-jest.mock('../utils/tokenListHelpers', () => ({
-  getNetworkLogoUri: () => 'network-logo',
-  transformApiItemToToken: jest.fn(
-    (item: { address: string; name: string; symbol: string }) => ({
-      id: item.address,
-      name: item.name,
-      symbol: item.symbol,
-      address: item.address,
-      decimals: 18,
-      price: 1,
-      change24h: 0,
-      marketCap: 0,
-      liquidity: 0,
-      transactions: 0,
-      uniqueTraders: 0,
-      holders: 0,
-      turnover: 0,
-      tokenImageUri: '',
-      networkLogoUri: 'network-logo',
-      networkId: 'evm--1',
-      chainId: 'evm--1',
-    }),
-  ),
-}));
+jest.mock('../utils/tokenListHelpers', () => {
+  type ITokenItem = {
+    address: string;
+    name: string;
+    symbol: string;
+    networkId?: string;
+  };
+  type ITransformOptions = {
+    chainId: string;
+    networkLogoUriMap?: ReadonlyMap<string, string>;
+    networkLogoUri: string;
+  };
+  const getMarketTokenNetworkLogoUri = ({
+    tokenNetworkId,
+    chainId,
+    networkLogoUriMap,
+    networkLogoUri,
+  }: ITransformOptions & { tokenNetworkId?: string }) => {
+    if (!tokenNetworkId) {
+      return networkLogoUri;
+    }
+    return (
+      networkLogoUriMap?.get(tokenNetworkId) ||
+      (tokenNetworkId === chainId ? networkLogoUri : '')
+    );
+  };
+
+  return {
+    buildMarketNetworkLogoUriMap: (networkList: IMarketBasicConfigNetwork[]) =>
+      new Map(
+        networkList.map(
+          (network) => [network.networkId, network.logoUrl] as const,
+        ),
+      ),
+    getMarketTokenNetworkLogoUri,
+    getNetworkLogoUri: (networkId: string) =>
+      networkId === 'evm--1' ? 'network-logo' : '',
+    transformApiItemToToken: jest.fn(
+      (item: ITokenItem, options: ITransformOptions) => {
+        const tokenNetworkId = item.networkId || options.chainId;
+        const networkLogoUri = getMarketTokenNetworkLogoUri({
+          tokenNetworkId: item.networkId,
+          ...options,
+        });
+        return {
+          id: item.address,
+          name: item.name,
+          symbol: item.symbol,
+          address: item.address,
+          decimals: 18,
+          price: 1,
+          change24h: 0,
+          marketCap: 0,
+          liquidity: 0,
+          transactions: 0,
+          uniqueTraders: 0,
+          holders: 0,
+          turnover: 0,
+          tokenImageUri: '',
+          networkLogoUri,
+          networkId: tokenNetworkId,
+          chainId: tokenNetworkId,
+        };
+      },
+    ),
+  };
+});
 
 jest.mock('./marketTokenListPlatformApi', () => ({
   fetchMarketTokenListForPlatform: jest.fn(),
@@ -318,6 +361,160 @@ describe('useMarketTokenList initial data', () => {
       expect(transformOptions?.networkLogoUriMap?.get('evm--143')).toBe(
         'https://example.com/monad.png',
       );
+    });
+  });
+
+  it('keeps loaded pages and uses the latest logos when config resolves before page 2', async () => {
+    const pageTwoRequest = createDeferred<IMarketTokenListResponse>();
+    let latestResult: ReturnType<typeof useMarketTokenList> | undefined;
+    let loadMorePromise: Promise<void> | undefined;
+
+    mockFetchMarketTokenList.mockResolvedValueOnce({
+      list: [
+        {
+          address: '0xpage1',
+          name: 'Page One',
+          symbol: 'ONE',
+          decimals: 18,
+          networkId: 'evm--143',
+        },
+      ],
+      total: 2,
+    });
+
+    function Probe() {
+      latestResult = useMarketTokenList({
+        networkId: 'evm--143',
+        pageSize: 1,
+        pollingInterval: 0,
+        type: 'trending',
+      });
+      return null;
+    }
+
+    const view = render(<Probe />);
+    await waitFor(() => expect(latestResult?.canLoadMore).toBe(true));
+
+    mockFetchMarketTokenList.mockReturnValueOnce(pageTwoRequest.promise);
+    await act(async () => {
+      loadMorePromise = latestResult?.loadMore();
+      await Promise.resolve();
+    });
+
+    mockNetworkList = [
+      {
+        networkId: 'evm--143',
+        index: 1,
+        name: 'Monad',
+        logoUrl: 'https://example.com/monad.png',
+        explorerUrl: 'https://example.com',
+        chainId: '143',
+      },
+    ];
+    view.rerender(<Probe />);
+    await waitFor(() => {
+      expect(latestResult?.data).toHaveLength(1);
+      expect(latestResult?.data[0]?.networkLogoUri).toBe(
+        'https://example.com/monad.png',
+      );
+    });
+
+    await act(async () => {
+      pageTwoRequest.resolve({
+        list: [
+          {
+            address: '0xpage2',
+            name: 'Page Two',
+            symbol: 'TWO',
+            decimals: 18,
+            networkId: 'evm--143',
+          },
+        ],
+        total: 2,
+      });
+      await loadMorePromise;
+    });
+
+    await waitFor(() => {
+      expect(latestResult?.data).toHaveLength(2);
+      expect(
+        latestResult?.data.every(
+          (item) => item.networkLogoUri === 'https://example.com/monad.png',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('refreshes every loaded page without resetting pagination when config resolves later', async () => {
+    let latestResult: ReturnType<typeof useMarketTokenList> | undefined;
+
+    mockFetchMarketTokenList
+      .mockResolvedValueOnce({
+        list: [
+          {
+            address: '0xpage1',
+            name: 'Page One',
+            symbol: 'ONE',
+            decimals: 18,
+            networkId: 'evm--143',
+          },
+        ],
+        total: 2,
+      })
+      .mockResolvedValueOnce({
+        list: [
+          {
+            address: '0xpage2',
+            name: 'Page Two',
+            symbol: 'TWO',
+            decimals: 18,
+            networkId: 'evm--143',
+          },
+        ],
+        total: 2,
+      });
+
+    function Probe() {
+      latestResult = useMarketTokenList({
+        networkId: 'evm--143',
+        pageSize: 1,
+        pollingInterval: 0,
+        type: 'trending',
+      });
+      return null;
+    }
+
+    const view = render(<Probe />);
+    await waitFor(() => expect(latestResult?.canLoadMore).toBe(true));
+
+    await act(async () => {
+      await latestResult?.loadMore();
+    });
+    await waitFor(() => {
+      expect(latestResult?.data).toHaveLength(2);
+      expect(latestResult?.currentPage).toBe(2);
+    });
+
+    mockNetworkList = [
+      {
+        networkId: 'evm--143',
+        index: 1,
+        name: 'Monad',
+        logoUrl: 'https://example.com/monad.png',
+        explorerUrl: 'https://example.com',
+        chainId: '143',
+      },
+    ];
+    view.rerender(<Probe />);
+
+    await waitFor(() => {
+      expect(latestResult?.data).toHaveLength(2);
+      expect(latestResult?.currentPage).toBe(2);
+      expect(
+        latestResult?.data.every(
+          (item) => item.networkLogoUri === 'https://example.com/monad.png',
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -180,17 +180,20 @@ function reuseStableMarketTokenRows({
 function transformMarketTokenListResponse({
   response,
   networkId,
+  networkLogoUriMap,
   networkLogoUri,
   timeRange,
 }: {
   response: IMarketTokenListResponseWithSource | undefined;
   networkId: string;
+  networkLogoUriMap: ReadonlyMap<string, string>;
   networkLogoUri: string;
   timeRange: IMarketTimeRangeValue | undefined;
 }) {
   return (response?.list ?? []).map((item) =>
     transformApiItemToToken(item, {
       chainId: networkId,
+      networkLogoUriMap,
       networkLogoUri,
       timeRange,
     }),
@@ -211,8 +214,7 @@ export function useMarketTokenList({
   const locale = useLocaleVariant();
   const timeRangeRef = useRef(timeRange);
   timeRangeRef.current = timeRange;
-  // Get minLiquidity from market config
-  const { minLiquidity } = useMarketBasicConfig();
+  const { minLiquidity, networkList } = useMarketBasicConfig();
   const { trackNetworkLoading } = useNetworkLoadingAnalytics();
   const [sortBy, setSortBy] = useState<string | undefined>(initialSortBy);
   const [sortType, setSortType] = useState<'asc' | 'desc' | undefined>(
@@ -226,10 +228,19 @@ export function useMarketTokenList({
   const [hasReachedEnd, setHasReachedEnd] = useState(false);
   const maxPages = 5;
 
-  // Optimize network logo URI calculation
+  const networkLogoUriMap = useMemo(
+    () =>
+      new Map(
+        (networkList ?? []).map((network) => [
+          network.networkId,
+          network.logoUrl,
+        ]),
+      ),
+    [networkList],
+  );
   const networkLogoUri = useMemo(
-    () => getNetworkLogoUri(networkId),
-    [networkId],
+    () => networkLogoUriMap.get(networkId) || getNetworkLogoUri(networkId),
+    [networkId, networkLogoUriMap],
   );
   const hasNetworkId = Boolean(networkId);
 
@@ -493,6 +504,7 @@ export function useMarketTokenList({
     data: transformMarketTokenListResponse({
       response: apiResult,
       networkId,
+      networkLogoUriMap,
       networkLogoUri,
       timeRange: timeRangeRef.current,
     }),
@@ -504,6 +516,7 @@ export function useMarketTokenList({
       : transformMarketTokenListResponse({
           response: cachedMarketTokenListEntry?.data,
           networkId,
+          networkLogoUriMap,
           networkLogoUri,
           timeRange: timeRangeRef.current,
         });
@@ -600,6 +613,7 @@ export function useMarketTokenList({
     const transformed = transformMarketTokenListResponse({
       response: apiResult,
       networkId,
+      networkLogoUriMap,
       networkLogoUri,
       timeRange: timeRangeRef.current,
     });
@@ -641,6 +655,7 @@ export function useMarketTokenList({
     currentQueryKey,
     hasNetworkId,
     networkId,
+    networkLogoUriMap,
     networkLogoUri,
     timeFrame,
     trackNetworkLoading,
@@ -731,6 +746,7 @@ export function useMarketTokenList({
         const newTransformed = response.list.map((item) =>
           transformApiItemToToken(item, {
             chainId: networkId,
+            networkLogoUriMap,
             networkLogoUri,
             timeRange: timeRangeRef.current,
           }),
@@ -781,6 +797,7 @@ export function useMarketTokenList({
     category,
     timeFrame,
     trackNetworkLoading,
+    networkLogoUriMap,
     networkLogoUri,
   ]);
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -19,6 +19,8 @@ import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { TIME_RANGE_TO_API_MAP } from '../../../types';
 import {
+  buildMarketNetworkLogoUriMap,
+  getMarketTokenNetworkLogoUri,
   getNetworkLogoUri,
   transformApiItemToToken,
 } from '../utils/tokenListHelpers';
@@ -200,6 +202,40 @@ function transformMarketTokenListResponse({
   );
 }
 
+function refreshMarketTokenNetworkLogos({
+  data,
+  networkId,
+  networkLogoUriMap,
+  networkLogoUri,
+}: {
+  data: IMarketToken[];
+  networkId: string;
+  networkLogoUriMap: ReadonlyMap<string, string>;
+  networkLogoUri: string;
+}) {
+  let changed = false;
+  const nextData = data.map((token) => {
+    const nextNetworkLogoUri = getMarketTokenNetworkLogoUri({
+      tokenNetworkId: token.networkId,
+      chainId: networkId,
+      networkLogoUriMap,
+      networkLogoUri,
+    });
+    if (token.networkLogoUri === nextNetworkLogoUri) {
+      return token;
+    }
+
+    changed = true;
+    return {
+      ...token,
+      id: `${token.address}${token.name}${nextNetworkLogoUri}${token.symbol}`,
+      networkLogoUri: nextNetworkLogoUri,
+    };
+  });
+
+  return changed ? nextData : data;
+}
+
 export function useMarketTokenList({
   networkId,
   initialSortBy = 'v24hUSD',
@@ -229,19 +265,17 @@ export function useMarketTokenList({
   const maxPages = 5;
 
   const networkLogoUriMap = useMemo(
-    () =>
-      new Map(
-        (networkList ?? []).map((network) => [
-          network.networkId,
-          network.logoUrl,
-        ]),
-      ),
+    () => buildMarketNetworkLogoUriMap(networkList),
     [networkList],
   );
   const networkLogoUri = useMemo(
     () => networkLogoUriMap.get(networkId) || getNetworkLogoUri(networkId),
     [networkId, networkLogoUriMap],
   );
+  const networkLogoUriMapRef = useRef(networkLogoUriMap);
+  networkLogoUriMapRef.current = networkLogoUriMap;
+  const networkLogoUriRef = useRef(networkLogoUri);
+  networkLogoUriRef.current = networkLogoUri;
   const hasNetworkId = Boolean(networkId);
 
   // Check if "All Networks" is selected
@@ -613,8 +647,8 @@ export function useMarketTokenList({
     const transformed = transformMarketTokenListResponse({
       response: apiResult,
       networkId,
-      networkLogoUriMap,
-      networkLogoUri,
+      networkLogoUriMap: networkLogoUriMapRef.current,
+      networkLogoUri: networkLogoUriRef.current,
       timeRange: timeRangeRef.current,
     });
     const transformDuration =
@@ -655,12 +689,35 @@ export function useMarketTokenList({
     currentQueryKey,
     hasNetworkId,
     networkId,
-    networkLogoUriMap,
-    networkLogoUri,
     timeFrame,
     trackNetworkLoading,
     type,
     category,
+  ]);
+
+  useEffect(() => {
+    if (!hasNetworkId) {
+      return;
+    }
+
+    setTransformedDataState((prev) => {
+      if (prev.queryKey !== currentQueryKey) {
+        return prev;
+      }
+      const nextData = refreshMarketTokenNetworkLogos({
+        data: prev.data,
+        networkId,
+        networkLogoUriMap,
+        networkLogoUri,
+      });
+      return nextData === prev.data ? prev : { ...prev, data: nextData };
+    });
+  }, [
+    currentQueryKey,
+    hasNetworkId,
+    networkId,
+    networkLogoUriMap,
+    networkLogoUri,
   ]);
 
   // Reset pagination when networkId, sortBy, or sortType changes
@@ -746,8 +803,8 @@ export function useMarketTokenList({
         const newTransformed = response.list.map((item) =>
           transformApiItemToToken(item, {
             chainId: networkId,
-            networkLogoUriMap,
-            networkLogoUri,
+            networkLogoUriMap: networkLogoUriMapRef.current,
+            networkLogoUri: networkLogoUriRef.current,
             timeRange: timeRangeRef.current,
           }),
         );
@@ -797,8 +854,6 @@ export function useMarketTokenList({
     category,
     timeFrame,
     trackNetworkLoading,
-    networkLogoUriMap,
-    networkLogoUri,
   ]);
 
   const canLoadMore =

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.networkLogo.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.networkLogo.test.tsx
@@ -1,0 +1,89 @@
+/** @jest-environment jsdom */
+
+import { render, waitFor } from '@testing-library/react';
+
+import { useMarketWatchlistTokenList } from './useMarketWatchlistTokenList';
+
+import type { IMarketToken } from '../MarketTokenData';
+
+const mockNetworkList = [
+  {
+    networkId: 'evm--143',
+    index: 1,
+    name: 'Monad',
+    logoUrl: 'https://example.com/monad.png',
+    explorerUrl: 'https://example.com',
+    chainId: '143',
+  },
+];
+const mockWatchlistApiResult = {
+  list: [
+    {
+      address: '0xmonad',
+      name: 'Monad Token',
+      symbol: 'MON',
+      decimals: 18,
+      networkId: 'evm--143',
+      isNative: false,
+    },
+  ],
+};
+const mockRun = jest.fn(async () => undefined);
+
+jest.mock('@onekeyhq/components', () => ({
+  useCarouselIndex: () => 0,
+}));
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceMarketV2: {},
+    serviceHyperliquid: {},
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: (
+    _method: unknown,
+    _deps: unknown[],
+    options?: { watchLoading?: boolean },
+  ) => ({
+    result: options?.watchLoading ? mockWatchlistApiResult : null,
+    isLoading: false,
+    run: mockRun,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Market/hooks', () => ({
+  useMarketBasicConfig: () => ({ networkList: mockNetworkList }),
+}));
+
+describe('useMarketWatchlistTokenList network logos', () => {
+  it('uses dynamic Market config logos for watchlist rows', async () => {
+    let latestData: IMarketToken[] = [];
+    const watchlist = [
+      {
+        chainId: 'evm--143',
+        contractAddress: '0xmonad',
+        isNative: false,
+      },
+    ];
+
+    function Probe() {
+      latestData = useMarketWatchlistTokenList({
+        watchlist,
+        pollingInterval: 0,
+      }).data;
+      return null;
+    }
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(latestData).toHaveLength(1);
+      expect(latestData[0]?.networkLogoUri).toBe(
+        'https://example.com/monad.png',
+      );
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.ts
@@ -9,12 +9,14 @@ import {
 import { useCarouselIndex } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useMarketBasicConfig } from '@onekeyhq/kit/src/views/Market/hooks';
 import { getTokenSubtitle } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { IMarketWatchListItemV2 } from '@onekeyhq/shared/types/market';
 
 import {
   SORT_MAP,
+  buildMarketNetworkLogoUriMap,
   getNativeTokenInfo,
   getNetworkLogoUri,
   transformApiItemToToken,
@@ -58,6 +60,11 @@ export function useMarketWatchlistTokenList({
   pageSize = 100,
   pollingInterval = timerUtils.getTimeDurationMs({ seconds: 30 }),
 }: IUseMarketWatchlistTokenListParams) {
+  const { networkList } = useMarketBasicConfig();
+  const networkLogoUriMap = useMemo(
+    () => buildMarketNetworkLogoUriMap(networkList),
+    [networkList],
+  );
   const [currentPage, setCurrentPage] = useState(1);
   const [transformedData, setTransformedData] = useState<IMarketToken[]>([]);
   const [sortBy, setSortBy] = useState<string | undefined>(initialSortBy);
@@ -207,12 +214,14 @@ export function useMarketWatchlistTokenList({
           const key = `${networkId}:${normalizedAddress}`;
           const tokenInfo = tokenMap[key];
           const chainId = tokenInfo?.chainId || networkId;
-          const networkLogoUri = getNetworkLogoUri(chainId);
+          const networkLogoUri =
+            networkLogoUriMap.get(chainId) || getNetworkLogoUri(chainId);
           const sortIndex = tokenInfo?.sortIndex;
 
           spotTransformed.push(
             transformApiItemToToken(item, {
               chainId,
+              networkLogoUriMap,
               networkLogoUri,
               sortIndex,
             }),
@@ -256,7 +265,14 @@ export function useMarketWatchlistTokenList({
     if (isInitialLoad) {
       setIsInitialLoad(false);
     }
-  }, [apiResult, watchlist, spotItems, perpsTokenMap, isInitialLoad]);
+  }, [
+    apiResult,
+    watchlist,
+    spotItems,
+    perpsTokenMap,
+    isInitialLoad,
+    networkLogoUriMap,
+  ]);
 
   // Sorting
   const sortedData = useMemo(() => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
@@ -313,6 +313,80 @@ describe('market home live price change', () => {
   });
 });
 
+describe('market token network logos', () => {
+  const tokenItem = {
+    address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+    name: 'Token',
+    symbol: 'TOKEN',
+    decimals: 18,
+  };
+
+  test('uses the selected dynamic Market network logo', () => {
+    const token = transformApiItemToToken(
+      {
+        ...tokenItem,
+        networkId: 'evm--143',
+      },
+      {
+        chainId: 'evm--143',
+        networkLogoUri: 'https://example.com/monad.png',
+      },
+    );
+
+    expect(token.networkLogoUri).toBe('https://example.com/monad.png');
+  });
+
+  test('resolves each dynamic network logo from Market config', () => {
+    const networkLogoUriMap = new Map([
+      ['evm--143', 'https://example.com/monad.png'],
+      ['evm--4663', 'https://example.com/network-4663.png'],
+    ]);
+
+    const monadToken = transformApiItemToToken(
+      {
+        ...tokenItem,
+        networkId: 'evm--143',
+      },
+      {
+        chainId: 'onekeyall--0',
+        networkLogoUri: '',
+        networkLogoUriMap,
+      },
+    );
+    const network4663Token = transformApiItemToToken(
+      {
+        ...tokenItem,
+        networkId: 'evm--4663',
+      },
+      {
+        chainId: 'onekeyall--0',
+        networkLogoUri: '',
+        networkLogoUriMap,
+      },
+    );
+
+    expect(monadToken.networkLogoUri).toBe('https://example.com/monad.png');
+    expect(network4663Token.networkLogoUri).toBe(
+      'https://example.com/network-4663.png',
+    );
+  });
+
+  test('does not reuse the selected network logo for another network', () => {
+    const token = transformApiItemToToken(
+      {
+        ...tokenItem,
+        networkId: 'evm--4663',
+      },
+      {
+        chainId: 'evm--143',
+        networkLogoUri: 'https://example.com/monad.png',
+      },
+    );
+
+    expect(token.networkLogoUri).toBe('');
+  });
+});
+
 describe('shouldShowStockSubtitleForTokens', () => {
   test('returns false for empty data', () => {
     expect(shouldShowStockSubtitleForTokens([])).toBe(false);

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -215,20 +215,24 @@ export function transformApiItemToToken(
   item: IMarketTokenListItem & { isNative?: boolean },
   {
     chainId,
+    networkLogoUriMap,
     networkLogoUri,
     sortIndex,
     timeRange,
   }: {
     chainId: string;
+    networkLogoUriMap?: ReadonlyMap<string, string>;
     networkLogoUri: string;
     sortIndex?: number;
     timeRange?: IMarketTimeRangeValue;
   },
 ): IMarketToken {
-  // Use token's own networkId to get network logo, fallback to passed chainId
   const tokenNetworkId = item.networkId || chainId;
   const tokenNetworkLogoUri = item.networkId
-    ? getNetworkLogoUri(item.networkId)
+    ? networkLogoUriMap?.get(item.networkId) ||
+      (item.networkId === chainId
+        ? networkLogoUri
+        : getNetworkLogoUri(item.networkId))
     : networkLogoUri;
 
   const priceChangeValue = item.stock

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -1,5 +1,8 @@
 import { getPresetNetworks } from '@onekeyhq/shared/src/config/presetNetworks';
-import type { IMarketTokenListItem } from '@onekeyhq/shared/types/marketV2';
+import type {
+  IMarketBasicConfigNetwork,
+  IMarketTokenListItem,
+} from '@onekeyhq/shared/types/marketV2';
 
 import type { IMarketTimeRangeValue } from '../../../types';
 import type { IMarketToken } from '../MarketTokenData';
@@ -129,6 +132,14 @@ export function getNetworkLogoUri(chainOrNetworkId: string): string {
   return network?.logoURI || '';
 }
 
+export function buildMarketNetworkLogoUriMap(
+  networkList: readonly IMarketBasicConfigNetwork[],
+) {
+  return new Map<string, string>(
+    networkList.map((network) => [network.networkId, network.logoUrl] as const),
+  );
+}
+
 function safeNumber(value: string | undefined, fallback = 0): number {
   if (!value) return fallback;
 
@@ -208,6 +219,29 @@ export function calculateMarketTokenLivePriceChange({
   return ((price - priceChangeBasePrice) / priceChangeBasePrice) * 100;
 }
 
+export function getMarketTokenNetworkLogoUri({
+  tokenNetworkId,
+  chainId,
+  networkLogoUriMap,
+  networkLogoUri,
+}: {
+  tokenNetworkId?: string;
+  chainId: string;
+  networkLogoUriMap?: ReadonlyMap<string, string>;
+  networkLogoUri: string;
+}) {
+  if (!tokenNetworkId) {
+    return networkLogoUri;
+  }
+
+  return (
+    networkLogoUriMap?.get(tokenNetworkId) ||
+    (tokenNetworkId === chainId
+      ? networkLogoUri
+      : getNetworkLogoUri(tokenNetworkId))
+  );
+}
+
 /**
  * Convert raw api item to component token shape
  */
@@ -228,12 +262,12 @@ export function transformApiItemToToken(
   },
 ): IMarketToken {
   const tokenNetworkId = item.networkId || chainId;
-  const tokenNetworkLogoUri = item.networkId
-    ? networkLogoUriMap?.get(item.networkId) ||
-      (item.networkId === chainId
-        ? networkLogoUri
-        : getNetworkLogoUri(item.networkId))
-    : networkLogoUri;
+  const tokenNetworkLogoUri = getMarketTokenNetworkLogoUri({
+    tokenNetworkId: item.networkId,
+    chainId,
+    networkLogoUriMap,
+    networkLogoUri,
+  });
 
   const priceChangeValue = item.stock
     ? item.priceChange24hPercent


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61638](https://onekeyhq.atlassian.net/browse/OK-61638) [OK-61616](https://onekeyhq.atlassian.net/browse/OK-61616)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Fix missing network badges in Market token lists for dynamically configured networks.
- Fix the duplicate share action in the redesigned desktop token detail header.

## Root Cause

- Token list transformation only resolved selected or statically configured network logos, so tokens from dynamic Market networks could lose their network badge.
- The redesigned desktop header rendered both the inline share action and the outer share button.

## Changes

- Build a network logo map from the Market configuration.
- Resolve each token's network logo independently across initial, cached, and paginated list data.
- Hide the legacy inline share action in the redesigned desktop layout.
- Preserve existing behavior for legacy and Top Coins layouts.
- Add regression tests for both issues.

## Verification

- `yarn agent:check --profile commit`
- Targeted Jest tests: 3 suites, 32 tests passed
- Desktop runtime verification:
  - DINO list row renders both the token icon and network badge.
  - DINO detail renders 0 inline share buttons and 1 outer share button.

## Issues

- [OK-61638](https://onekeyhq.atlassian.net/browse/OK-61638)
- [OK-61616](https://onekeyhq.atlassian.net/browse/OK-61616)

[OK-61638]: https://onekeyhq.atlassian.net/browse/OK-61638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OK-61616]: https://onekeyhq.atlassian.net/browse/OK-61616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ