### PR TITLE
fix: Perps close-position price readiness, cold-start banner shift, favorites order sync and TWAP tab shadow flash(OK-61259 OK-61504 OK-61486 OK-61520)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -159,6 +159,7 @@ import {
 } from './userAbstractionCache';
 import { shouldPreserveConfirmedUserAbstractionMode } from './userAbstractionMode';
 import { buildDepositConfigFromTokensByNetwork } from './utils/depositConfigUtils';
+import { resolveMarketOrderReferencePrice } from './utils/marketOrderReferencePrice';
 import {
   mergePerpDexSlots,
   selectPerpMetasByDex,
@@ -1080,6 +1081,20 @@ export default class ServiceHyperliquid extends ServiceBase {
     {
       max: 1,
       maxAge: timerUtils.getTimeDurationMs({ seconds: 30 }),
+      promise: true,
+    },
+  );
+
+  // Per-dex REST snapshot that must not feed the shared cache: a main-dex-only
+  // result would wipe the sub-dex prices the WebSocket stream delivers.
+  _getMarketOrderAllMidsMemo = cacheUtils.memoizee(
+    async (dex: string) =>
+      dex
+        ? hyperLiquidApiClients.infoClient.allMids({ dex })
+        : hyperLiquidApiClients.infoClient.allMids(),
+    {
+      max: 8,
+      maxAge: timerUtils.getTimeDurationMs({ seconds: 1 }),
       promise: true,
     },
   );
@@ -4009,6 +4024,26 @@ export default class ServiceHyperliquid extends ServiceBase {
     } catch (error) {
       console.error(
         '[ServiceHyperliquid] Failed to load tradingview mid price:',
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  @backgroundMethod()
+  async getMarketOrderReferencePrice(
+    coin: string,
+  ): Promise<string | undefined> {
+    try {
+      return await resolveMarketOrderReferencePrice({
+        coin,
+        cachedAllMids: hyperLiquidCache.allMids,
+        cachedAt: hyperLiquidCache.allMidsUpdatedAt,
+        loadAllMids: async (dex) => this._getMarketOrderAllMidsMemo(dex),
+      });
+    } catch (error) {
+      console.error(
+        '[ServiceHyperliquid] Failed to load market order reference price:',
         error,
       );
       return undefined;

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/marketOrderReferencePrice.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/marketOrderReferencePrice.test.ts
@@ -1,0 +1,96 @@
+import { resolveMarketOrderReferencePrice } from './marketOrderReferencePrice';
+
+const nowMs = 10_000;
+
+describe('resolveMarketOrderReferencePrice', () => {
+  it('uses a fresh cached price without loading another snapshot', async () => {
+    let loadCount = 0;
+    const result = await resolveMarketOrderReferencePrice({
+      coin: 'xyz:NVDA',
+      cachedAllMids: { mids: { 'xyz:NVDA': '213.63' } },
+      cachedAt: nowMs - 100,
+      nowMs,
+      loadAllMids: async () => {
+        loadCount += 1;
+        return { 'xyz:NVDA': '214.00' };
+      },
+    });
+
+    expect(result).toBe('213.63');
+    expect(loadCount).toBe(0);
+  });
+
+  it('loads a fresh snapshot when the cached price is stale', async () => {
+    let loadCount = 0;
+    const result = await resolveMarketOrderReferencePrice({
+      coin: 'xyz:NVDA',
+      cachedAllMids: { mids: { 'xyz:NVDA': '200.00' } },
+      cachedAt: nowMs - 5001,
+      nowMs,
+      loadAllMids: async () => {
+        loadCount += 1;
+        return { 'xyz:NVDA': '213.63' };
+      },
+    });
+
+    expect(result).toBe('213.63');
+    expect(loadCount).toBe(1);
+  });
+
+  it('loads a fresh snapshot when no background price is cached', async () => {
+    const result = await resolveMarketOrderReferencePrice({
+      coin: 'xyz:NVDA',
+      cachedAllMids: undefined,
+      cachedAt: 0,
+      nowMs,
+      loadAllMids: async () => ({ 'xyz:NVDA': '213.63' }),
+    });
+
+    expect(result).toBe('213.63');
+  });
+
+  it('queries the coin dex when a fresh cache lacks a sub-dex price', async () => {
+    const requestedDexes: string[] = [];
+    const result = await resolveMarketOrderReferencePrice({
+      coin: 'xyz:NVDA',
+      cachedAllMids: { mids: { BTC: '65000' } },
+      cachedAt: nowMs - 100,
+      nowMs,
+      loadAllMids: async (dex) => {
+        requestedDexes.push(dex);
+        return { 'xyz:NVDA': '213.63' };
+      },
+    });
+
+    expect(result).toBe('213.63');
+    expect(requestedDexes).toEqual(['xyz']);
+  });
+
+  it('queries the main dex with an empty dex name', async () => {
+    const requestedDexes: string[] = [];
+    await resolveMarketOrderReferencePrice({
+      coin: 'BTC',
+      cachedAllMids: undefined,
+      cachedAt: 0,
+      nowMs,
+      loadAllMids: async (dex) => {
+        requestedDexes.push(dex);
+        return { BTC: '65000' };
+      },
+    });
+
+    expect(requestedDexes).toEqual(['']);
+  });
+
+  it('rejects a missing or invalid coin price from a fresh snapshot', async () => {
+    await expect(
+      resolveMarketOrderReferencePrice({
+        coin: 'xyz:NVDA',
+        cachedAllMids: undefined,
+        cachedAt: 0,
+        nowMs,
+        loadAllMids: async () => ({ 'xyz:NVDA': '0' }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/marketOrderReferencePrice.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/marketOrderReferencePrice.ts
@@ -1,0 +1,42 @@
+import {
+  getValidPerpsPrice,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { IWsAllMids } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+export const PERPS_MARKET_ORDER_REFERENCE_PRICE_STALE_MS = 5000;
+
+// The cache is fed by the WebSocket allMids stream, which carries every dex;
+// the REST fallback returns a single dex, so it is queried by the coin's dex.
+export async function resolveMarketOrderReferencePrice({
+  coin,
+  cachedAllMids,
+  cachedAt,
+  nowMs = Date.now(),
+  loadAllMids,
+}: {
+  coin: string;
+  cachedAllMids: IWsAllMids | undefined;
+  cachedAt: number;
+  nowMs?: number;
+  loadAllMids: (dex: string) => Promise<Record<string, string>>;
+}): Promise<string | undefined> {
+  if (!coin) {
+    return undefined;
+  }
+
+  const cacheAgeMs = Math.max(0, nowMs - cachedAt);
+  if (
+    cachedAllMids &&
+    cachedAt > 0 &&
+    cacheAgeMs <= PERPS_MARKET_ORDER_REFERENCE_PRICE_STALE_MS
+  ) {
+    const cachedPrice = getValidPerpsPrice(cachedAllMids.mids?.[coin]);
+    if (cachedPrice) {
+      return cachedPrice;
+    }
+  }
+
+  const freshAllMids = await loadAllMids(parseDexCoin(coin).dexLabel ?? '');
+  return getValidPerpsPrice(freshAllMids[coin]);
+}

--- a/packages/kit/src/hooks/useFixedColumnShadow.ts
+++ b/packages/kit/src/hooks/useFixedColumnShadow.ts
@@ -25,6 +25,8 @@ export interface IUseFixedColumnShadowResult {
   handleNativeScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   /** Scroll handler for web platforms */
   handleWebScroll: () => void;
+  /** Web only: false until the first measured state has been painted */
+  shadowTransitionEnabled: boolean;
 }
 
 /**
@@ -79,6 +81,7 @@ export function useFixedColumnShadow({
   const forceVisible = (isNative || isMobileWeb) && enabled;
 
   const [showShadow, setShowShadow] = useState(initialVisible);
+  const [shadowTransitionEnabled, setShadowTransitionEnabled] = useState(false);
   const scrollViewRef = useRef<React.ElementRef<typeof ScrollView>>(null);
 
   const getScrollElement = useCallback((): HTMLElement | null => {
@@ -134,9 +137,10 @@ export function useFixedColumnShadow({
     [forceVisible, position],
   );
 
-  // Measure before the first paint: a freshly mounted table seeded with
-  // initialVisible would otherwise flash the shadow for one frame even when
-  // its content does not overflow.
+  // Measure before the first paint, and keep CSS transitions off until that
+  // measured state has been painted: reading scrollWidth here forces a style
+  // flush with the seeded initialVisible shadow, so a transition would animate
+  // the seeded → measured change even though the seeded frame never paints.
   useLayoutEffect(() => {
     if (!enabled || isNative || forceVisible) return;
     if (typeof ResizeObserver === 'undefined') return;
@@ -147,7 +151,13 @@ export function useFixedColumnShadow({
     handleWebScroll();
     const resizeObserver = new ResizeObserver(handleWebScroll);
     resizeObserver.observe(element);
-    return () => resizeObserver.disconnect();
+    let frame = requestAnimationFrame(() => {
+      frame = requestAnimationFrame(() => setShadowTransitionEnabled(true));
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+    };
   }, [enabled, handleWebScroll, getScrollElement, isNative, forceVisible]);
 
   return {
@@ -155,6 +165,7 @@ export function useFixedColumnShadow({
     scrollViewRef,
     handleNativeScroll,
     handleWebScroll,
+    shadowTransitionEnabled,
   };
 }
 

--- a/packages/kit/src/hooks/useFixedColumnShadow.ts
+++ b/packages/kit/src/hooks/useFixedColumnShadow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 import type { ScrollView } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -134,8 +134,10 @@ export function useFixedColumnShadow({
     [forceVisible, position],
   );
 
-  // Web ResizeObserver setup
-  useEffect(() => {
+  // Measure before the first paint: a freshly mounted table seeded with
+  // initialVisible would otherwise flash the shadow for one frame even when
+  // its content does not overflow.
+  useLayoutEffect(() => {
     if (!enabled || isNative || forceVisible) return;
     if (typeof ResizeObserver === 'undefined') return;
 

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -3608,6 +3608,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
             .map((p) => p.position.coin)
             .filter((coin) => !symbolsMetaMap[coin] || !midPriceMap[coin]);
           if (unpricedCoins.length > 0) {
+            // TODO(i18n): same pre-existing literal as ClosePositionModal.
             const message = 'Unable to get current market price';
             Toast.error({ title: message });
             throw new OneKeyLocalError(

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -3577,18 +3577,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
               coins: filteredPositions.map((p) => p.position.coin),
             });
 
-          // Mids the main runtime has not received yet (cold start) are
-          // resolved by the background price source the close dialog uses.
+          // The main-runtime atom carries no age marker, so every coin is
+          // priced by the background owner (fresh snapshot or per-dex REST),
+          // matching the single close submit path.
           const midPrices = await Promise.all(
             filteredPositions.map(async (p) => {
               const { coin } = p.position;
               try {
-                const midPriceInfo = await this.getMidPrice.call(set, {
-                  coin,
-                });
-                if (midPriceInfo.mid) {
-                  return { coin, midPrice: midPriceInfo.mid };
-                }
                 return {
                   coin,
                   midPrice:

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -3577,20 +3577,28 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
               coins: filteredPositions.map((p) => p.position.coin),
             });
 
-          // Get current mid prices for all positions
+          // Mids the main runtime has not received yet (cold start) are
+          // resolved by the background price source the close dialog uses.
           const midPrices = await Promise.all(
             filteredPositions.map(async (p) => {
+              const { coin } = p.position;
               try {
                 const midPriceInfo = await this.getMidPrice.call(set, {
-                  coin: p.position.coin,
+                  coin,
                 });
-                return { coin: p.position.coin, midPrice: midPriceInfo.mid };
+                if (midPriceInfo.mid) {
+                  return { coin, midPrice: midPriceInfo.mid };
+                }
+                return {
+                  coin,
+                  midPrice:
+                    await backgroundApiProxy.serviceHyperliquid.getMarketOrderReferencePrice(
+                      coin,
+                    ),
+                };
               } catch (error) {
-                console.warn(
-                  `Failed to get mid price for ${p.position.coin}:`,
-                  error,
-                );
-                return { coin: p.position.coin, midPrice: null };
+                console.warn(`Failed to get mid price for ${coin}:`, error);
+                return { coin, midPrice: null };
               }
             }),
           );
@@ -3598,6 +3606,19 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           const midPriceMap = Object.fromEntries(
             midPrices.map((item) => [item.coin, item.midPrice]),
           );
+
+          // Never close a subset silently: a position without a price would
+          // be dropped while the rest reports success.
+          const unpricedCoins = filteredPositions
+            .map((p) => p.position.coin)
+            .filter((coin) => !symbolsMetaMap[coin] || !midPriceMap[coin]);
+          if (unpricedCoins.length > 0) {
+            const message = 'Unable to get current market price';
+            Toast.error({ title: message });
+            throw new OneKeyLocalError(
+              `${message}: ${unpricedCoins.join(', ')}`,
+            );
+          }
 
           // Prepare close orders for all positions
           const positionsToClose = filteredPositions

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoritesBar.web.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoritesBar.web.tsx
@@ -21,7 +21,10 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { usePerpsFavorites } from '../../hooks/usePerpsFavorites';
-import { dedupeTokenSelectorFavoritesOrder } from '../../utils/tokenSelectorFavorites';
+import {
+  dedupeTokenSelectorFavoritesOrder,
+  sortTokenSelectorFavoritesBySequence,
+} from '../../utils/tokenSelectorFavorites';
 
 import { FavoriteTokenItem } from './FavoriteTokenItem';
 
@@ -166,30 +169,14 @@ function FavoritesBar() {
 
   // Membership entries missing from the persisted order are appended at the
   // end, covering legacy data and toggles done outside the FavoriteButton.
-  const favoriteItems = useMemo(() => {
-    const merged = [...perpItems, ...spotItems];
-    const lookup = new Map<string, (typeof merged)[number]>();
-    for (const item of merged) {
-      lookup.set(`${item.mode}:${item.coinName}`, item);
-    }
-    const ordered: typeof merged = [];
-    const seen = new Set<string>();
-    for (const entry of dedupeTokenSelectorFavoritesOrder(
-      favoritesOrder.sequence,
-    )) {
-      const key = `${entry.mode}:${entry.coinName}`;
-      const item = lookup.get(key);
-      if (item) {
-        ordered.push(item);
-        seen.add(key);
-      }
-    }
-    for (const item of merged) {
-      const key = `${item.mode}:${item.coinName}`;
-      if (!seen.has(key)) ordered.push(item);
-    }
-    return ordered;
-  }, [perpItems, spotItems, favoritesOrder]);
+  const favoriteItems = useMemo(
+    () =>
+      sortTokenSelectorFavoritesBySequence(
+        [...perpItems, ...spotItems],
+        favoritesOrder.sequence,
+      ),
+    [perpItems, spotItems, favoritesOrder.sequence],
+  );
 
   // Idempotent reconciliation — only writes when sequence drifts from
   // membership, so callers that toggle favorites without touching this atom

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -150,6 +150,8 @@ const ClosePositionForm = memo(
         !priceUnavailableToastShownRef.current
       ) {
         priceUnavailableToastShownRef.current = true;
+        // TODO(i18n): pre-existing English literal shared with the submit
+        // path below and closeAllPositions; needs a Lokalise key.
         Toast.error({
           title: 'Unable to get current market price',
         });

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -27,6 +27,7 @@ import {
   calculateProfitLoss,
   formatHlSize,
   formatPriceToSignificantDigits,
+  getValidPerpsPrice,
   parseDexCoin,
   validateSizeInput,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
@@ -81,7 +82,7 @@ const ClosePositionForm = memo(
     const assetId = tokenInfo?.assetId;
 
     const midPrice = useMemo(() => {
-      return allMids?.mids?.[position.coin] || '0';
+      return getValidPerpsPrice(allMids?.mids?.[position.coin]);
     }, [allMids?.mids, position.coin]);
 
     const tokenDisplayName = useMemo(() => {
@@ -219,7 +220,7 @@ const ClosePositionForm = memo(
 
     const handleUseMid = useCallback(() => {
       const latestMidPrice = midPrice;
-      if (latestMidPrice && latestMidPrice !== '0') {
+      if (latestMidPrice) {
         setFormData((prev) => ({
           ...prev,
           limitPrice: formatPriceToSignificantDigits(latestMidPrice),
@@ -263,8 +264,11 @@ const ClosePositionForm = memo(
         }
 
         if (formData.type === 'market') {
-          const latestMidPrice = midPrice;
-          if (!latestMidPrice || latestMidPrice === '0') {
+          const latestMidPrice =
+            await backgroundApiProxy.serviceHyperliquid.getMarketOrderReferencePrice(
+              position.coin,
+            );
+          if (!latestMidPrice) {
             Toast.error({
               title: 'Unable to get current market price',
             });
@@ -319,7 +323,7 @@ const ClosePositionForm = memo(
       formData.limitPrice,
       calculatedAmount,
       assetId,
-      midPrice,
+      position.coin,
       isLongPosition,
       hyperliquidActions,
       onClose,
@@ -532,7 +536,9 @@ const ClosePositionForm = memo(
             variant="primary"
             onPress={handleSubmit}
             disabled={!isFormValid || isSubmitting}
-            loading={isSubmitting}
+            loading={
+              isSubmitting || (formData.type === 'market' && !isPriceValid)
+            }
           >
             {intl.formatMessage({
               id: ETranslations.perp_confirm_order,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -243,6 +243,7 @@ const ClosePositionForm = memo(
         return;
       }
       submittingRef.current = true;
+      let submitted = false;
       try {
         if (isNil(assetId) || Number.isNaN(assetId)) {
           return;
@@ -298,13 +299,18 @@ const ClosePositionForm = memo(
         }
 
         hyperliquidActions.current.resetTradingForm();
+        // The dialog stays mounted through its exit animation, so the guard
+        // must stay armed after success or a tap there places a second order.
+        submitted = true;
         if (isMountedRef.current) {
           onClose();
         }
       } finally {
-        submittingRef.current = false;
-        if (isMountedRef.current) {
-          setIsSubmitting(false);
+        if (!submitted) {
+          submittingRef.current = false;
+          if (isMountedRef.current) {
+            setIsSubmitting(false);
+          }
         }
       }
     }, [

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -15,6 +15,7 @@ import {
   YStack,
   useMedia,
 } from '@onekeyhq/components';
+import type { IDialogInstance } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
@@ -135,6 +136,7 @@ const ClosePositionForm = memo(
     }, []);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const submittingRef = useRef(false);
 
     const calculatedAmount = useMemo(() => {
       const percentage = Number.isNaN(formData.percentage)
@@ -235,6 +237,12 @@ const ClosePositionForm = memo(
     }, []);
 
     const handleSubmit = useCallback(async () => {
+      // The disabled state lands one render late, so same-frame double taps
+      // would otherwise send a second reduce-only order for the full size.
+      if (submittingRef.current) {
+        return;
+      }
+      submittingRef.current = true;
       try {
         if (isNil(assetId) || Number.isNaN(assetId)) {
           return;
@@ -294,6 +302,7 @@ const ClosePositionForm = memo(
           onClose();
         }
       } finally {
+        submittingRef.current = false;
         if (isMountedRef.current) {
           setIsSubmitting(false);
         }
@@ -531,16 +540,36 @@ const ClosePositionForm = memo(
 
 ClosePositionForm.displayName = 'ClosePositionForm';
 
+// Dialog.show mounts its portal asynchronously, so isExist() reports false
+// during the first frames; the grace window covers same-frame double taps.
+const CLOSE_DIALOG_MOUNT_GRACE_MS = 1000;
+let activeCloseDialog: IDialogInstance | undefined;
+let activeCloseDialogShownAt = 0;
+
 export function showClosePositionDialog({
   position,
   type,
   intl,
 }: IClosePositionParams & { intl: IntlShape }) {
+  // Rapid taps would stack dialogs, each holding its own position snapshot,
+  // so only one close dialog is kept alive at a time.
+  if (
+    activeCloseDialog &&
+    (activeCloseDialog.isExist() ||
+      Date.now() - activeCloseDialogShownAt < CLOSE_DIALOG_MOUNT_GRACE_MS)
+  ) {
+    return activeCloseDialog;
+  }
   const dialogInstance = Dialog.show({
     title: intl.formatMessage({
       id: ETranslations.perp_close_position_title,
     }),
     disableDrag: true,
+    onClose: () => {
+      if (activeCloseDialog === dialogInstance) {
+        activeCloseDialog = undefined;
+      }
+    },
     renderContent: (
       <PerpsProviderMirror>
         <ClosePositionForm
@@ -553,6 +582,8 @@ export function showClosePositionDialog({
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,
   });
+  activeCloseDialog = dialogInstance;
+  activeCloseDialogShownAt = Date.now();
 
   return dialogInstance;
 }

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -81,7 +81,7 @@ const ClosePositionForm = memo(
     const szDecimals = tokenInfo?.universe?.szDecimals ?? 2;
     const assetId = tokenInfo?.assetId;
 
-    const midPrice = useMemo(() => {
+    const atomMidPrice = useMemo(() => {
       return getValidPerpsPrice(allMids?.mids?.[position.coin]);
     }, [allMids?.mids, position.coin]);
 
@@ -114,9 +114,47 @@ const ClosePositionForm = memo(
     const initPriceRef = useRef(false);
     const isMountedRef = useRef(true);
 
+    const [referencePriceResolved, setReferencePriceResolved] = useState(false);
+    // The main runtime only sees mids the WebSocket has already forwarded,
+    // which lags by seconds on cold start, so the gate polls the same
+    // background price source the submit uses instead of waiting on the atom.
+    const { result: referencePrice } = usePromiseResult(
+      async () => {
+        if (atomMidPrice) {
+          return atomMidPrice;
+        }
+        const price =
+          await backgroundApiProxy.serviceHyperliquid.getMarketOrderReferencePrice(
+            position.coin,
+          );
+        if (isMountedRef.current) {
+          setReferencePriceResolved(true);
+        }
+        return price;
+      },
+      [atomMidPrice, position.coin],
+      { pollingInterval: 2000, checkIsFocused: false },
+    );
+    const midPrice = atomMidPrice ?? getValidPerpsPrice(referencePrice);
+    const isMarketPriceUnavailable = !midPrice && referencePriceResolved;
+    const priceUnavailableToastShownRef = useRef(false);
+
     useEffect(() => {
       setSliderPercentage(formData.percentage);
     }, [formData.percentage, setSliderPercentage]);
+
+    useEffect(() => {
+      if (
+        formData.type === 'market' &&
+        isMarketPriceUnavailable &&
+        !priceUnavailableToastShownRef.current
+      ) {
+        priceUnavailableToastShownRef.current = true;
+        Toast.error({
+          title: 'Unable to get current market price',
+        });
+      }
+    }, [formData.type, isMarketPriceUnavailable]);
 
     useEffect(() => {
       if (!midPrice) return;
@@ -484,7 +522,7 @@ const ClosePositionForm = memo(
             value={formData.limitPrice}
             onChange={handleLimitPriceChange}
             onUseMidPrice={handleUseMid}
-            disabled={!midPrice}
+            midPriceDisabled={!midPrice}
             szDecimals={szDecimals}
             ifOnDialog
           />
@@ -537,7 +575,10 @@ const ClosePositionForm = memo(
             onPress={handleSubmit}
             disabled={!isFormValid || isSubmitting}
             loading={
-              isSubmitting || (formData.type === 'market' && !isPriceValid)
+              isSubmitting ||
+              (formData.type === 'market' &&
+                !isPriceValid &&
+                !isMarketPriceUnavailable)
             }
           >
             {intl.formatMessage({

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -486,6 +486,7 @@ export function CommonTableListView<T>({
     scrollViewRef,
     handleNativeScroll,
     handleWebScroll,
+    shadowTransitionEnabled,
   } = useFixedColumnShadow({
     position: 'right',
     enabled: hasFixedColumns,
@@ -936,7 +937,9 @@ export function CommonTableListView<T>({
               ? getWebShadowStyle('right', isDark)
               : 'none',
             clipPath: getWebClipPath('right'),
-            transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
+            transition: shadowTransitionEnabled
+              ? `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`
+              : 'none',
           }}
         >
           <FixedColumnShadowOverlay

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -116,6 +116,7 @@ import {
   getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorFavoritesTab,
+  isPerpTokenSelectorFavoritesTabUserSort,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSortFieldActive,
   isPerpTokenSelectorSpotTab,
@@ -958,6 +959,11 @@ function MobileTokenSelectorModal({
   const dynamicSortAssetCtxsByDex = activeDynamicTabUserSort
     ? assetCtxsByDex
     : undefined;
+  const activeFavoritesTabUserSort = isPerpTokenSelectorFavoritesTabUserSort({
+    activeTab: displayActiveTab,
+    sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
+  });
 
   // Layer 2: filter — cheap O(n) filter; only dynamic user sort sorts the
   // filtered dynamic-token subset against live values.
@@ -989,7 +995,7 @@ function MobileTokenSelectorModal({
           tokenSearchAliases,
         }),
       });
-      if (sortField) {
+      if (activeFavoritesTabUserSort && sortField) {
         result = sortTokenSelectorFavoriteItems({
           items: result,
           sortField,
@@ -1075,6 +1081,7 @@ function MobileTokenSelectorModal({
     displayActiveTab,
     displayPrimaryTab,
     activeDynamicTabUserSort,
+    activeFavoritesTabUserSort,
     assetsByDex,
     categoryTabs,
     favoritesOrder.sequence,

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -111,6 +111,7 @@ import {
   getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorFavoritesTab,
+  isPerpTokenSelectorFavoritesTabUserSort,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSpotTab,
 } from '../../utils/tokenSelectorTabs';
@@ -961,6 +962,11 @@ function BasePerpTokenSelectorContent({
   const dynamicSortAssetCtxsByDex = activeDynamicTabUserSort
     ? assetCtxsByDex
     : undefined;
+  const activeFavoritesTabUserSort = isPerpTokenSelectorFavoritesTabUserSort({
+    activeTab: displayActiveTab,
+    sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
+  });
 
   // Layer 2: filter — cheap O(n); only dynamic user sort sorts the filtered
   // dynamic-token subset against live values.
@@ -994,7 +1000,7 @@ function BasePerpTokenSelectorContent({
           tokenSearchAliases,
         }),
       });
-      if (sortField) {
+      if (activeFavoritesTabUserSort && sortField) {
         result = sortTokenSelectorFavoriteItems({
           items: result,
           sortField,
@@ -1080,6 +1086,7 @@ function BasePerpTokenSelectorContent({
     displayActiveTab,
     displayPrimaryTab,
     activeDynamicTabUserSort,
+    activeFavoritesTabUserSort,
     assetsByDex,
     categoryTabs,
     computeSortValues,

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/PriceInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/PriceInput.tsx
@@ -17,6 +17,7 @@ interface IPriceInputProps {
   error?: string;
   disabled?: boolean;
   onUseMidPrice?: () => void;
+  midPriceDisabled?: boolean;
   szDecimals?: number;
   label?: string;
   placeholder?: string;
@@ -32,6 +33,7 @@ export const PriceInput = memo(
     error,
     disabled = false,
     onUseMidPrice,
+    midPriceDisabled = false,
     szDecimals,
     label,
     placeholder,
@@ -66,11 +68,11 @@ export const PriceInput = memo(
                 label: 'Mid',
                 labelColor: '$green11',
                 onPress: onUseMidPrice,
-                disabled: false,
+                disabled: midPriceDisabled,
               },
             ]
           : undefined,
-      [onUseMidPrice],
+      [onUseMidPrice, midPriceDisabled],
     );
 
     return (

--- a/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
@@ -4,6 +4,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpTokenFavoritesPersistAtom,
+  usePerpsFavoritesOrderPersistAtom,
   useSpotTokenFavoritesPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { isPerpsUniverseCacheComplete } from '@onekeyhq/shared/src/utils/perpsDexUtils';
@@ -17,7 +18,10 @@ import type {
 } from '@onekeyhq/shared/types/hyperliquid';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
-import { dedupeTokenSelectorFavoriteCoins } from '../utils/tokenSelectorFavorites';
+import {
+  dedupeTokenSelectorFavoriteCoins,
+  sortTokenSelectorFavoritesBySequence,
+} from '../utils/tokenSelectorFavorites';
 
 export type IFavoriteItem = {
   mode: 'perp' | 'spot';
@@ -37,6 +41,7 @@ export function usePerpsFavorites(options?: {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [perpFavorites] = usePerpTokenFavoritesPersistAtom();
   const [spotFavorites] = useSpotTokenFavoritesPersistAtom();
+  const [favoritesOrder] = usePerpsFavoritesOrderPersistAtom();
   const favoritesMode =
     options?.mode === 'current'
       ? activeTradeInstrument.mode
@@ -97,7 +102,7 @@ export function usePerpsFavorites(options?: {
     { checkIsFocused: false },
   );
 
-  const favoriteItems = useMemo(() => {
+  const unorderedFavoriteItems = useMemo(() => {
     if (!uniqueFavorites.length || !taggedUniverse) {
       return [];
     }
@@ -157,6 +162,16 @@ export function usePerpsFavorites(options?: {
 
     return items;
   }, [uniqueFavorites, taggedUniverse]);
+
+  // Every consumer follows the drag order set in the favorites bar.
+  const favoriteItems = useMemo(
+    () =>
+      sortTokenSelectorFavoritesBySequence(
+        unorderedFavoriteItems,
+        favoritesOrder.sequence,
+      ),
+    [unorderedFavoriteItems, favoritesOrder.sequence],
+  );
 
   return { favoriteItems, isReady: taggedUniverse !== undefined };
 }

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -64,6 +64,7 @@ import type { LayoutChangeEvent } from 'react-native';
 const MobilePerpMarketInline = LazyLoadPage(() => import('./MobilePerpMarket'));
 const PERP_NATIVE_HEADER_ROW_HEIGHT = 44;
 const PERP_NATIVE_HEADER_TOP_OFFSET = 20;
+const PERP_NATIVE_IOS_HEADER_TOP_PADDING = 26;
 
 function PerpLayout() {
   const { gtMd } = useMedia();
@@ -115,7 +116,11 @@ function PerpContent() {
   }, []);
 
   const fallbackTabPageHeight = platformEnv.isNative
-    ? resolvedSafeAreaTop + PERP_NATIVE_HEADER_ROW_HEIGHT
+    ? resolvedSafeAreaTop +
+      PERP_NATIVE_HEADER_ROW_HEIGHT +
+      (platformEnv.isNativeIOS
+        ? PERP_NATIVE_IOS_HEADER_TOP_PADDING - PERP_NATIVE_HEADER_TOP_OFFSET
+        : 0)
     : 92;
   const [measuredTabPageHeight, setMeasuredTabPageHeight] = useState<
     number | undefined
@@ -196,7 +201,11 @@ function PerpContent() {
             // safe-area top+28, matching the Wallet header. The MDHeader non-home
             // row is h=44 → center top+22 with the -20/pt($5) cancel; pt=26
             // (=20 offset + 6) lands it at top+28. Other platforms keep $5.
-            pt={platformEnv.isNativeIOS ? 26 : '$5'}
+            pt={
+              platformEnv.isNativeIOS
+                ? PERP_NATIVE_IOS_HEADER_TOP_PADDING
+                : '$5'
+            }
             width="100%"
             onLayout={handleTabPageLayout}
             zIndex={FLOAT_NAV_BAR_Z_INDEX}

--- a/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.test.ts
@@ -7,6 +7,7 @@ import {
   getTokenSelectorFavoriteSortEntry,
   reconcileTokenSelectorFavoritesOrder,
   sortTokenSelectorFavoriteItems,
+  sortTokenSelectorFavoritesBySequence,
   toggleTokenSelectorFavoriteCoin,
   updateTokenSelectorFavoriteCoins,
 } from './tokenSelectorFavorites';
@@ -221,5 +222,29 @@ describe('tokenSelectorFavorites', () => {
     });
 
     expect(entry.volume24h).toBe(42);
+  });
+
+  it('orders favorites by the persisted drag sequence and appends the rest', () => {
+    expect(
+      sortTokenSelectorFavoritesBySequence(
+        [
+          { mode: 'perp', coinName: 'BTC' },
+          { mode: 'perp', coinName: 'ETH' },
+          { mode: 'spot', coinName: '@142' },
+          { mode: 'perp', coinName: 'SOL' },
+        ],
+        [
+          { mode: 'perp', coinName: 'SOL' },
+          { mode: 'spot', coinName: '@142' },
+          { mode: 'perp', coinName: 'DOGE' },
+          { mode: 'perp', coinName: 'SOL' },
+        ],
+      ),
+    ).toEqual([
+      { mode: 'perp', coinName: 'SOL' },
+      { mode: 'spot', coinName: '@142' },
+      { mode: 'perp', coinName: 'BTC' },
+      { mode: 'perp', coinName: 'ETH' },
+    ]);
   });
 });

--- a/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.ts
@@ -5,6 +5,7 @@ import {
   dedupeTokenSelectorFavoritesOrder,
   getTokenSelectorFavoriteOrderKey,
   reconcileTokenSelectorFavoritesOrder,
+  sortTokenSelectorFavoritesBySequence,
   toggleTokenSelectorFavoriteCoin,
   updateTokenSelectorFavoriteCoins,
 } from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
@@ -303,6 +304,7 @@ export {
   getTokenSelectorListItemKey,
   reconcileTokenSelectorFavoritesOrder,
   sortTokenSelectorFavoriteItems,
+  sortTokenSelectorFavoritesBySequence,
   toggleTokenSelectorFavoriteCoin,
   updateTokenSelectorFavoriteCoins,
 };

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
@@ -14,6 +14,7 @@ import {
   isPerpTokenSelectorAllTab,
   isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorFavoritesTab,
+  isPerpTokenSelectorFavoritesTabUserSort,
   isPerpTokenSelectorHotTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
@@ -344,6 +345,62 @@ describe('tokenSelectorTabs', () => {
         sortSource: 'default',
       }),
     ).toBe(true);
+  });
+
+  it('keeps the favorites drag order until a header sort is clicked on that tab', () => {
+    expect(
+      isPerpTokenSelectorFavoritesTabUserSort({
+        activeTab: 'favorites',
+        sortSource: 'default',
+      }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorFavoritesTabUserSort({
+        activeTab: 'favorites',
+        sortSource: 'user',
+        sortSourceTab: 'hot',
+      }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorFavoritesTabUserSort({
+        activeTab: 'favorites',
+        sortSource: 'user',
+        sortSourceTab: 'favorites',
+      }),
+    ).toBe(true);
+    expect(
+      isPerpTokenSelectorFavoritesTabUserSort({
+        activeTab: 'perps',
+        sortSource: 'user',
+        sortSourceTab: 'perps',
+      }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorSortFieldActive({
+        activeTab: 'favorites',
+        field: 'volume24h',
+        sortField: 'volume24h',
+        sortSource: 'default',
+      }),
+    ).toBe(false);
+    expect(
+      getNextPerpTokenSelectorSortConfig({
+        prev: {
+          field: 'volume24h',
+          direction: 'desc',
+          activeTab: 'favorites',
+          sortSource: 'default',
+          sortSourceTab: undefined,
+        },
+        field: 'volume24h',
+      }),
+    ).toEqual({
+      field: 'volume24h',
+      direction: 'desc',
+      activeTab: 'favorites',
+      sortSource: 'user',
+      sortSourceTab: 'favorites',
+    });
   });
 
   it('scopes dynamic tab user sorting to the clicked tab', () => {

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
@@ -183,24 +183,45 @@ function isPerpTokenSelectorPrimaryTab(tabId: string) {
   return PRIMARY_TAB_ID_SET.has(normalizeTabId(tabId));
 }
 
-function isPerpTokenSelectorDynamicTabUserSort({
-  activeTab,
-  sortSource,
-  sortSourceTab,
-}: {
+type IPerpTokenSelectorUserSortParams = {
   activeTab?: string;
   sortSource?: IPerpTokenSelectorConfig['sortSource'];
   sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
-}) {
+};
+
+function isPerpTokenSelectorTabUserSort({
+  activeTab,
+  sortSource,
+  sortSourceTab,
+}: IPerpTokenSelectorUserSortParams) {
   const currentActiveTab = activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
-  if (isPerpTokenSelectorPrimaryTab(currentActiveTab)) {
-    return false;
-  }
   return (
     sortSource === 'user' &&
     sortSourceTab !== undefined &&
     normalizeTabId(sortSourceTab) === normalizeTabId(currentActiveTab)
   );
+}
+
+function isPerpTokenSelectorDynamicTabUserSort(
+  params: IPerpTokenSelectorUserSortParams,
+) {
+  const currentActiveTab = params.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  if (isPerpTokenSelectorPrimaryTab(currentActiveTab)) {
+    return false;
+  }
+  return isPerpTokenSelectorTabUserSort(params);
+}
+
+// Favorites keep the drag order from the favorites bar unless a header sort
+// was clicked on that tab.
+function isPerpTokenSelectorFavoritesTabUserSort(
+  params: IPerpTokenSelectorUserSortParams,
+) {
+  const currentActiveTab = params.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  if (!isPerpTokenSelectorFavoritesTab(currentActiveTab)) {
+    return false;
+  }
+  return isPerpTokenSelectorTabUserSort(params);
 }
 
 function isMissingSortValue(value: ITokenSelectorSortValue) {
@@ -392,11 +413,13 @@ function isPerpTokenSelectorSortFieldActive({
   sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
 }) {
   const currentActiveTab = activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
-  const isDynamicTab = !isPerpTokenSelectorPrimaryTab(currentActiveTab);
+  const followsUserSortOnly =
+    !isPerpTokenSelectorPrimaryTab(currentActiveTab) ||
+    isPerpTokenSelectorFavoritesTab(currentActiveTab);
   return (
     sortField === field &&
-    (!isDynamicTab ||
-      isPerpTokenSelectorDynamicTabUserSort({
+    (!followsUserSortOnly ||
+      isPerpTokenSelectorTabUserSort({
         activeTab: currentActiveTab,
         sortSource,
         sortSourceTab,
@@ -512,6 +535,7 @@ export {
   isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorAllTab,
   isPerpTokenSelectorFavoritesTab,
+  isPerpTokenSelectorFavoritesTabUserSort,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
   isPerpTokenSelectorSortFieldActive,

--- a/packages/shared/src/utils/perpsTokenSelectorFavorites.ts
+++ b/packages/shared/src/utils/perpsTokenSelectorFavorites.ts
@@ -135,6 +135,38 @@ function reconcileTokenSelectorFavoritesOrder({
   return [...filtered, ...missing];
 }
 
+// Favorites missing from the persisted sequence keep their membership order
+// at the end, covering legacy data and toggles done outside the favorites bar.
+function sortTokenSelectorFavoritesBySequence<
+  T extends ITokenSelectorFavoriteOrderEntry,
+>(items: T[], sequence: ITokenSelectorFavoriteOrderEntry[]): T[] {
+  const itemsByKey = new Map<string, T>();
+  for (const item of items) {
+    const key = getTokenSelectorFavoriteOrderKey(item);
+    if (!itemsByKey.has(key)) {
+      itemsByKey.set(key, item);
+    }
+  }
+  const ordered: T[] = [];
+  const seenKeys = new Set<string>();
+  for (const entry of dedupeTokenSelectorFavoritesOrder(sequence)) {
+    const key = getTokenSelectorFavoriteOrderKey(entry);
+    const item = itemsByKey.get(key);
+    if (item && !seenKeys.has(key)) {
+      ordered.push(item);
+      seenKeys.add(key);
+    }
+  }
+  for (const item of items) {
+    const key = getTokenSelectorFavoriteOrderKey(item);
+    if (!seenKeys.has(key)) {
+      ordered.push(item);
+      seenKeys.add(key);
+    }
+  }
+  return ordered;
+}
+
 export {
   dedupeTokenSelectorFavoriteCoins,
   dedupeTokenSelectorFavoritesOrder,
@@ -142,6 +174,7 @@ export {
   isSameFavoritesOrderSequence,
   isSameStringArray,
   reconcileTokenSelectorFavoritesOrder,
+  sortTokenSelectorFavoritesBySequence,
   toggleTokenSelectorFavoriteCoin,
   updateTokenSelectorFavoriteCoins,
 };

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -32,6 +32,7 @@ import {
   getOrderBookSizeDisplaySymbol,
   getSpotMarketCapValue,
   getSpotTokenDisplayName,
+  getValidPerpsPrice,
   getValidPriceDecimals,
   isHyperLiquidAbstractionModeEnabled,
   isPredictionMarketInstrument,
@@ -530,6 +531,19 @@ describe('HyperLiquid wire-safe formatters', () => {
   test('formatSpotPriceToValid truncates instead of rounding up', () => {
     expect(formatSpotPriceToValid('60.123456789', 2)).toBe('60.123');
     expect(formatSpotPriceToValid('0.00123456789', 2)).toBe('0.001234');
+  });
+});
+
+describe('getValidPerpsPrice', () => {
+  test.each([undefined, null, '', '0', '0.0', '-1', 'NaN', 'Infinity'])(
+    'rejects a non-positive or invalid trading price: %s',
+    (price) => {
+      expect(getValidPerpsPrice(price)).toBeUndefined();
+    },
+  );
+
+  test('preserves a valid positive trading price', () => {
+    expect(getValidPerpsPrice('213.63')).toBe('213.63');
   });
 });
 

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -524,6 +524,15 @@ function formatHlSize(size: BigNumber.Value, szDecimals: number): string {
   return out === '0' ? '' : out;
 }
 
+function getValidPerpsPrice(price?: string | null): string | undefined {
+  if (!price) {
+    return undefined;
+  }
+
+  const priceBN = new BigNumber(price);
+  return priceBN.isFinite() && priceBN.gt(0) ? price : undefined;
+}
+
 /**
  * Format a price value into a HyperLiquid wire-safe string.
  *
@@ -2225,6 +2234,7 @@ export {
   SPOT_SELECTOR_MIN_VOLUME,
   formatHlSize,
   formatHlPrice,
+  getValidPerpsPrice,
 };
 export default {
   formatAssetCtx,
@@ -2291,4 +2301,5 @@ export default {
   formatSpotPriceToValid,
   formatHlSize,
   formatHlPrice,
+  getValidPerpsPrice,
 };


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61259](https://onekeyhq.atlassian.net/browse/OK-61259) [OK-61504](https://onekeyhq.atlassian.net/browse/OK-61504) [OK-61486](https://onekeyhq.atlassian.net/browse/OK-61486) [OK-61520](https://onekeyhq.atlassian.net/browse/OK-61520)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Four Perps fixes for the 6.5.2 bundle. All four code paths are byte-identical on `x`, so this lands once here and follows the regular `release/v6.5.2 → x` sync.

- **OK-61259** (online, High): on iOS cold start the close-position dialog let the user confirm a market close before any mid price had reached the main runtime, and the tap failed with "Unable to get current market price". Confirm now stays disabled with a spinner until a valid price exists, and the submit re-resolves a fresh, dex-scoped price in the background. The dialog is also single-instance and guarded against double taps.
- **OK-61504** (High): ports #13097 from `x` so the iOS header spacer matches the measured header and the Perps body no longer drops 6pt after first paint on cold start.
- **OK-61486**: the footer ticker and the token selector's Favorites tab follow the drag order set in the favorites bar.
- **OK-61520**: switching TWAP sub-tabs no longer flashes the fixed-column shadow on a full-width table.

The two remaining tickets from the same batch (limit BBO toggle, iOS native chart) only exist on 6.6.0 code and are handled against `x` separately.

## Intent & Context

Working through the Perps Jira "doing" list for this sprint. Four of the six tickets were reported by QA on 6.6.0 test builds, but code inspection showed the affected paths are unchanged on the 6.5.2 hot-update line, and OK-61259 is an open High bug reported against production 6.5.0, so the batch is split by release line: these four land here and flow to `x` through the regular sync; the two 6.6-only tickets are handled against `x` separately.

OK-61259 was diagnosed from the reporter's log and screenshot (OneKey 6.6.0 build 2026082600, bundle 20484813, iOS 26.6).

## Root Cause

### OK-61259 — "Unable to get current market price" when closing right after cold start

`main` and `bg` are separate JS runtimes with separate heaps. On cold start the main runtime restores positions, the order book and the trading buttons from its cold-start cache, but `perpsAllMidsAtom` has no cache and only fills once the background WebSocket delivers the first `allMids` and forwards it over the event bus. In the log the user opened the close dialog and tapped Confirm at 17:35:42, the first `allMids` reached `bg` at 17:35:44 (4.2s after launch), no `ordersClose` RPC followed, and the same action had succeeded in 885ms one launch earlier once prices were present.

The dialog made this reachable: `midPrice` collapsed a missing price to the string `'0'`, `isPriceValid` used `Boolean(midPrice)` (true for `'0'`), so Confirm was enabled, and only the submit path rejected `'0'` with the toast in the screenshot.

The same path also allowed double submits: `handleClosePosition` opened a new dialog on every tap (stacked dialogs with stale snapshots), and `handleSubmit` relied on a `disabled` state that lands one render late and was released before the dialog's 300ms exit animation finished.

### OK-61504 — trading area jumps after cold start (iOS)

Same defect #13097 fixed on `x`: on iOS the initial native header spacer used `safeAreaTop + 44` while the floating header measured `safeAreaTop + 50` (26pt top padding minus the 20pt offset), so the first `onLayout` moved the whole Perps body down by 6pt. `Perp.tsx` is identical on this line, so the commit is cherry-picked as-is; the later sync to `x` sees the same change on both sides.

### OK-61486 — favorites order not synced

`FavoritesBar.web.tsx` persists the drag result to `perpsFavoritesOrderPersistAtom` and reorders its own rows locally. `usePerpsFavorites` never read that atom, so the footer ticker rendered membership (add-time) order. The token selector did read it, but then re-sorted the Favorites tab whenever `sortField` was truthy, and the selector config ships `volume24h` as its default, so the drag order was always overwritten.

### OK-61520 — shadow divider flashes on TWAP sub-tab switch

`PerpTwapList.tsx` renders the three sub-tabs as separate unkeyed `CommonTableListView` instances, so a switch remounts the table, and `useFixedColumnShadow` seeds `showShadow` from `initialVisible: true`. The flash is the CSS transition rather than a wrong state: the fixed column is inserted with the seeded `box-shadow`, reading `scrollWidth` in the measurement effect forces a style flush that records that as the before-change style, and the switch to `none` is then animated over the 0.2s `transition` even when the measurement runs before paint.

## Design Decisions

**One price source for the gate, the submit and Close All.** `getValidPerpsPrice` turns missing, zero, negative or non-finite mids into `undefined`. The dialog prefers the main-runtime atom and otherwise polls `serviceHyperliquid.getMarketOrderReferencePrice(coin)` every 2s, which uses the background `allMids` cache when it is under 5s old and otherwise fetches a REST `allMids` snapshot; the submit re-resolves through the same method instead of trusting its React closure, and `closeAllPositions` prices every position through it as well, since the main-runtime atom carries no age marker. While no source has a price, market Confirm is disabled with a spinner; once the background source has also answered with nothing, the spinner stops and the existing toast shows, and the limit path stays editable (only the Mid shortcut dims) as the exit. Close All never submits a subset: a position still without a price aborts the action with a visible error.

**The REST fallback is queried per dex and never written to the shared cache.** The WebSocket `allMids` stream carries every dex (1221 coins in the log), but REST `allMids` returns one dex: verified live, the main-dex call returns 951 coins with no `xyz:` keys and `{dex: "xyz"}` returns 118 `xyz:` keys. The coin in the log is `xyz:NVDA`, so the dex is derived from the coin prefix, and the snapshot is not stored in `hyperLiquidCache.allMids` because a main-dex-only write would wipe the sub-dex prices other readers depend on.

**Close dialog is single-instance, guarded by `isExist()` plus a 1s mount grace.** `Dialog.show` mounts its portal asynchronously, so `isExist()` is still false for the first frames; the timestamp covers that window. The submit guard is a ref, not state, because state cannot stop a same-frame second press, and it stays armed after a successful submit because `onClose()` does not await the 300ms exit animation.

**Favorites tab sorts only after an explicit header click on that tab.** This mirrors how the category tabs already behave (`isPerpTokenSelectorDynamicTabUserSort`). The header indicator follows the same rule, so Volume no longer shows as active while the list is in drag order; clicking it cycles user desc → user asc → drag order. Ordering moved into `usePerpsFavorites` so every consumer inherits it.

**Shadow is measured in a layout effect and its transition stays off until the measured state has painted.** The hook now exposes `shadowTransitionEnabled`, which flips on two animation frames after the first measurement; `CommonTableListView` renders `transition: none` until then, so the first painted frame is already the measured state with nothing to animate, and later scroll-driven changes keep the fade. `InviteCodeListTable` and `PerpsRecordTable` use the same hook and are unchanged (they ignore the new field).

## Changes Detail

| File | Purpose |
|---|---|
| `shared/src/utils/perpsUtils.ts` | `getValidPerpsPrice`: finite and > 0 or `undefined` (+ test). |
| `kit-bg/.../ServiceHyperLiquid/utils/marketOrderReferencePrice.ts` | Background cache under 5s, else per-dex REST snapshot; falls through to REST when the fresh cache lacks the coin (+ 6 tests). |
| `kit-bg/.../ServiceHyperliquid.ts` | `getMarketOrderReferencePrice` background method; per-dex REST memo (1s, not written to the shared cache). |
| `OrderInfoPanel/ClosePositionModal.tsx` | Missing price is `undefined`; gate polls the background price source; Confirm disabled + spinner until ready, toast once when no source has a price; submit re-resolves the price in bg; limit input stays editable; single active dialog; `submittingRef` guard kept armed after success. |
| `TradingPanel/inputs/PriceInput.tsx` | `midPriceDisabled` dims the Mid shortcut without disabling the input. |
| `states/jotai/contexts/hyperliquid/actions.ts` | `closeAllPositions` prices every position through the background owner and aborts with an error instead of closing a subset. |
| `Perp/pages/Perp.tsx` | Cherry-pick of #13097: iOS header spacer matches the measured header. |
| `shared/src/utils/perpsTokenSelectorFavorites.ts` | `sortTokenSelectorFavoritesBySequence` (+ test). |
| `Perp/hooks/usePerpsFavorites.ts` | Items ordered by the persisted sequence. |
| `FavoritesBar/FavoritesBar.web.tsx` | Uses the shared sequence helper instead of its own merge. |
| `Perp/utils/tokenSelectorTabs.ts` | `isPerpTokenSelectorFavoritesTabUserSort`; header-active rule covers Favorites (+ test). |
| `TokenSelector/PerpTokenSelector.tsx`, `MoblieTokenSelector.tsx` | Favorites tab re-sorts only on user sort for that tab. |
| `kit/src/hooks/useFixedColumnShadow.ts` | Overflow measured in `useLayoutEffect`; `shadowTransitionEnabled` after the first measured paint. |
| `OrderInfoPanel/List/CommonTableListView.tsx` | Fixed-column `transition` gated on `shadowTransitionEnabled`. |

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Web / Mobile (iOS and Android)
- **Risk Areas**: market close now performs one background RPC before `ordersClose` (in-memory when the WebSocket cache is under 5s old; one HTTP round trip otherwise); a sub-dex coin whose price is missing from both the cache and the per-dex REST snapshot fails with the existing toast instead of sending a stale-price order; the close-dialog guard blocks a re-open for up to 1s after a dialog is shown or for 300ms after one closes; the favorites tab default order changes from volume-sorted to drag order; `useFixedColumnShadow` is shared with two referral tables, which only gain an earlier measurement.

## Test plan

**iOS real device, cold start (OK-61259, OK-61504)**

- [ ] With an open position, kill the app → launch → tap the Perps tab immediately → tap Close on the position → Confirm shows a spinner and is **not** tappable until the mark price appears in the dialog.
- [ ] Once Confirm enables, tap it once → exactly one `ordersClose` in the log, no "Unable to get current market price" toast, dialog closes.
- [ ] Same flow on a hip-3 position (an `xyz:` coin such as NVDA) → same result.
- [ ] During the same window, switch the dialog to Limit → the price input is editable and Mid is dimmed until the price arrives; Confirm enables once a valid limit price is typed.
- [ ] Close All right after cold start → either every position closes or one error toast appears with nothing submitted; never a partial close with a success toast.
- [ ] Kill the app → launch → Home → tap the Perps tab → after first paint the ticker / order book / trading form must **not** move down.
- [ ] Repeat the cold start twice more → layout identical each time.

**Desktop web / desktop app (wallet with an open position)**

- [ ] Positions list → click **Market** three times as fast as possible → exactly one close dialog opens; closing it reveals no second dialog underneath.
- [ ] In the close dialog, double-click **Confirm** → one order is sent; no second order during the dialog's fade-out.
- [ ] Drag a favorite to a new slot in the top bar → the footer ticker (favorites mode) shows the new order immediately.
- [ ] Open the token selector → Favorites tab shows the same order; the Volume header shows **no** active indicator.
- [ ] Click Volume → sorted desc with indicator; click again → asc; click again → back to drag order.
- [ ] Widen the window until the TWAP table needs no horizontal scroll → switch Active / History / Fills repeatedly → no shadow line flashes at the fixed column edge.
- [ ] Narrow the window until the table overflows → the shadow is present and stays across sub-tab switches.

**Mobile viewport (web ≤767px)**

- [ ] Repeat the two Close checks above on the position card's Close button.
- [ ] The mobile token selector's Favorites tab shows the drag order with no active Volume indicator.

[OK-61259]: https://onekeyhq.atlassian.net/browse/OK-61259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61504]: https://onekeyhq.atlassian.net/browse/OK-61504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61486]: https://onekeyhq.atlassian.net/browse/OK-61486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61520]: https://onekeyhq.atlassian.net/browse/OK-61520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ