### PR TITLE
fix: add Top Coins to home market ｜ OK-61602

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import {
   Button,
+  Icon,
   IconButton,
   SizableText,
   Stack,
@@ -33,6 +34,16 @@ type IMarketCategoryTokenListProps = {
   onViewMore: () => void;
 };
 
+function getMarketCategoryTokenKey(item: IFavoriteTokenDisplay) {
+  if (item.marketAsset) {
+    return `market-${item.marketAsset.assetId}`;
+  }
+  if (item.perpsCoin) {
+    return `perps-${item.perpsCoin}`;
+  }
+  return `${item.chainId}-${item.contractAddress}`;
+}
+
 function MarketCategoryTokenList({
   tokens,
   isLoading,
@@ -48,6 +59,10 @@ function MarketCategoryTokenList({
 
   const columns = useMemo<ITableProps<IFavoriteTokenDisplay>['columns']>(() => {
     const renderStarButton = (record: IFavoriteTokenDisplay) => {
+      if (record.marketAsset) {
+        return <Icon name="StarOutline" size="$5" color="$iconSubdued" />;
+      }
+
       const checked = isTokenInWatchList(record);
       return (
         <IconButton
@@ -114,11 +129,7 @@ function MarketCategoryTokenList({
         showHeader={shouldUseTableLayout}
         dataSource={tokens}
         columns={columns}
-        keyExtractor={(item) =>
-          item.perpsCoin
-            ? `perps-${item.perpsCoin}`
-            : `${item.chainId}-${item.contractAddress}`
-        }
+        keyExtractor={getMarketCategoryTokenKey}
         estimatedItemSize={56}
         rowProps={{
           mx: '$2',

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -20,6 +20,7 @@ import { ListLoading } from '@onekeyhq/kit/src/components/Loading';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { MARKET_TOP_COINS_CATEGORY_ID } from '@onekeyhq/shared/src/consts/marketConsts';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -48,6 +49,7 @@ import {
 } from '../../../Market/hooks';
 import { CategorySelector } from '../../../Market/MarketHomeV2/components/CategorySelector';
 import { getNativeTokenInfo } from '../../../Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers';
+import { useMarketTopCoinResolver } from '../../../Market/MarketHomeV2/components/MarketTopCoinsList/hooks/useMarketTopCoins';
 import { EMarketHomeTab } from '../../../Market/MarketHomeV2/types';
 import { RichBlock } from '../RichBlock/RichBlock';
 import { RichTable } from '../RichTable';
@@ -58,7 +60,6 @@ import {
   FAVORITES_CATEGORY_ID,
   HOME_PERPS_HOT_CATEGORY_ID,
   HOME_PERPS_HOT_REQUEST_CATEGORY_ID,
-  HOME_WATCHLIST_TAB_TYPE,
 } from './constants';
 import { MarketCategoryTokenList } from './MarketCategoryTokenList';
 import {
@@ -68,6 +69,7 @@ import {
 } from './metricColumns';
 import { useHomeMarketCategoryTokens } from './useHomeMarketCategoryTokens';
 import {
+  buildHomeMarketCategories,
   getMarketTokenDisplayMarketCap,
   getMarketTokenDisplayPrice,
   getMarketTokenDisplayPriceChange24h,
@@ -187,6 +189,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   const shouldUseTableLayout = Boolean(tableLayout && !md);
   const navigation = useAppNavigation();
   const navigateToMarketTab = useNavigateToMarketTab();
+  const resolveMarketTopCoin = useMarketTopCoinResolver();
   const { navigateToPerps } = usePerpsNavigation(
     EPerpPageEnterSource.PopularTrading,
   );
@@ -262,34 +265,18 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   }, [intl, perpsCategories]);
 
   const homeCategories = useMemo<IMarketCategoryItem[]>(() => {
-    const buildWithPerpsHotCategory = (categories: IMarketCategoryItem[]) => {
-      if (!homePerpsHotCategory) {
-        return categories;
-      }
+    const topCoinsFallbackName =
+      marketCategories.find(
+        (category) => category.id === MARKET_TOP_COINS_CATEGORY_ID,
+      )?.name ?? 'Top Coins';
 
-      return [...categories, homePerpsHotCategory];
-    };
-
-    if (apiHomeTabs.length > 0) {
-      const categories = apiHomeTabs.map((tab) => {
-        if (tab.type === HOME_WATCHLIST_TAB_TYPE) {
-          return {
-            ...favoritesCategory,
-            name: tab.name,
-          };
-        }
-
-        return {
-          id: tab.type,
-          name: tab.name,
-          icon: tab.icon,
-        };
-      });
-
-      return buildWithPerpsHotCategory(categories);
-    }
-
-    return buildWithPerpsHotCategory([favoritesCategory, ...marketCategories]);
+    return buildHomeMarketCategories({
+      apiHomeTabs,
+      favoritesCategory,
+      marketCategories,
+      homePerpsHotCategory,
+      topCoinsFallbackName,
+    });
   }, [apiHomeTabs, favoritesCategory, homePerpsHotCategory, marketCategories]);
 
   const resolvedSelectedCategoryId = useMemo(() => {
@@ -312,6 +299,10 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
 
   const isTokenInWatchList = useCallback(
     (record: IFavoriteTokenDisplay) => {
+      if (record.marketAsset) {
+        return false;
+      }
+
       if (record.perpsCoin) {
         return watchListItems.some(
           (item) => item.perpsCoin === record.perpsCoin,
@@ -336,6 +327,10 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
 
   const handleMarketCategoryStarPress = useCallback(
     async (record: IFavoriteTokenDisplay) => {
+      if (record.marketAsset) {
+        return;
+      }
+
       const checked = isTokenInWatchList(record);
 
       try {
@@ -828,16 +823,8 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   );
   handleRemoveFromWatchlistRef.current = handleRemoveFromWatchlist;
 
-  // Navigate to Market Detail page or Perps trading page
-  const handleTokenPress = useCallback(
+  const navigateToMarketTokenDetail = useCallback(
     (record: IFavoriteTokenDisplay) => {
-      if (record.perpsCoin) {
-        // Mirror Home > Perps tab: switchTab(Perp) makes ExtPerp open the expand
-        // tab in the extension popup/side panel, so no ext-only branch is needed.
-        navigateToPerps(record.perpsCoin);
-        return;
-      }
-
       const shortCode = networkUtils.getNetworkShortCode({
         networkId: record.chainId,
       });
@@ -850,6 +837,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           tokenAddress: record.contractAddress,
           network: shortCode || record.chainId,
           isNative: record.isNative,
+          marketTokenId: record.marketTokenId,
           marketTokenCategory: selectedMarketCategoryId,
         });
         return;
@@ -864,6 +852,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               tokenAddress: record.contractAddress,
               network: shortCode || record.chainId,
               isNative: record.isNative,
+              marketTokenId: record.marketTokenId,
               marketTokenCategory: selectedMarketCategoryId,
             },
           },
@@ -887,11 +876,47 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     [
       marketTab,
       navigateToMarketTab,
-      navigateToPerps,
       navigation,
       resolvedSelectedCategoryId,
       selectedMarketCategoryId,
     ],
+  );
+
+  // Navigate to Market Detail page or Perps trading page
+  const handleTokenPress = useCallback(
+    (record: IFavoriteTokenDisplay) => {
+      if (record.marketAsset) {
+        void resolveMarketTopCoin(record.marketAsset).then((token) => {
+          if (!token) {
+            return;
+          }
+          navigateToMarketTokenDetail({
+            chainId: token.networkId,
+            contractAddress: token.tokenAddress,
+            isNative: Boolean(token.isNative),
+            symbol: token.symbol,
+            name: token.name ?? token.symbol,
+            logoUrl: token.tokenImageUri ?? '',
+            price: token.price ?? 0,
+            priceChange24h: token.change24h ?? 0,
+            marketCap: token.marketCap ?? 0,
+            volume24h: token.turnover ?? 0,
+            marketTokenId: token.marketTokenId,
+          });
+        });
+        return;
+      }
+
+      if (record.perpsCoin) {
+        // Mirror Home > Perps tab: switchTab(Perp) makes ExtPerp open the expand
+        // tab in the extension popup/side panel, so no ext-only branch is needed.
+        navigateToPerps(record.perpsCoin);
+        return;
+      }
+
+      navigateToMarketTokenDetail(record);
+    },
+    [navigateToMarketTokenDetail, navigateToPerps, resolveMarketTopCoin],
   );
 
   const renderEmptyStateCards = useCallback(() => {

--- a/packages/kit/src/views/Home/components/PopularTrading/types.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/types.ts
@@ -1,3 +1,4 @@
+import type { IMarketAssetListItem } from '@onekeyhq/shared/types/market';
 import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 
 interface IFavoriteTokenDisplay {
@@ -16,7 +17,9 @@ interface IFavoriteTokenDisplay {
   maxLeverage?: number;
   perpsSubtitle?: string;
   communityRecognized?: boolean;
+  marketTokenId?: string;
   stock?: IMarketStockInfo;
+  marketAsset?: IMarketAssetListItem;
 }
 
 export type { IFavoriteTokenDisplay };

--- a/packages/kit/src/views/Home/components/PopularTrading/useHomeMarketCategoryTokens.test.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/useHomeMarketCategoryTokens.test.tsx
@@ -1,0 +1,101 @@
+/** @jest-environment jsdom */
+
+import { renderHook } from '@testing-library/react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import type { IMarketAssetListItem } from '@onekeyhq/shared/types/market';
+
+import { useHomeMarketCategoryTokens } from './useHomeMarketCategoryTokens';
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceHyperliquid: {
+      getTokenSearchAliases: jest.fn(),
+    },
+    serviceMarket: {
+      fetchMarketAssetList: jest.fn(),
+    },
+    serviceMarketV2: {
+      fetchMarketPerpsTokenList: jest.fn(),
+      fetchMarketTokenList: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: jest.fn(),
+}));
+
+const mockUsePromiseResult = usePromiseResult as jest.Mock;
+const serviceMarket = backgroundApiProxy.serviceMarket as jest.Mocked<
+  typeof backgroundApiProxy.serviceMarket
+>;
+const serviceMarketV2 = backgroundApiProxy.serviceMarketV2 as jest.Mocked<
+  typeof backgroundApiProxy.serviceMarketV2
+>;
+
+const bitcoin: IMarketAssetListItem = {
+  assetId: 'bitcoin',
+  symbol: 'btc',
+  logoUrl: 'https://example.com/btc.png',
+  price: '100000',
+  priceChange24hPercent: '1',
+  priceChange7dPercent: '2',
+  marketCap: '2000000000000',
+  volume24h: '50000000000',
+  sparkline24h: [],
+};
+
+describe('useHomeMarketCategoryTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePromiseResult.mockReturnValue({
+      isLoading: false,
+      result: undefined,
+    });
+  });
+
+  it('loads Top Coins from the Asset API instead of the token list API', async () => {
+    serviceMarket.fetchMarketAssetList.mockResolvedValue({
+      list: [bitcoin],
+      total: 1,
+    });
+
+    renderHook(() =>
+      useHomeMarketCategoryTokens({
+        minLiquidity: 5000,
+        selectedMarketCategoryId: 'top_coins',
+      }),
+    );
+
+    const loadCategoryTokens = mockUsePromiseResult.mock
+      .calls[0][0] as () => Promise<{
+      requestKey: string;
+      tokens: unknown[];
+    }>;
+    const result = await loadCategoryTokens();
+
+    expect(serviceMarket.fetchMarketAssetList.mock.calls).toEqual([
+      [
+        {
+          currency: 'usd',
+          limit: 3,
+          page: 1,
+          type: 'top_coins',
+        },
+      ],
+    ]);
+    expect(serviceMarketV2.fetchMarketTokenList.mock.calls).toHaveLength(0);
+    expect(result).toMatchObject({
+      requestKey: 'top_coins:5000',
+      tokens: [
+        {
+          symbol: 'BTC',
+          marketAsset: bitcoin,
+        },
+      ],
+    });
+  });
+});

--- a/packages/kit/src/views/Home/components/PopularTrading/useHomeMarketCategoryTokens.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/useHomeMarketCategoryTokens.ts
@@ -1,5 +1,6 @@
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { MARKET_TOP_COINS_CATEGORY_ID } from '@onekeyhq/shared/src/consts/marketConsts';
 import { getTokenSubtitle } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
@@ -10,6 +11,7 @@ import {
 } from './constants';
 import {
   EMPTY_DISPLAY_TOKENS,
+  mapMarketAssetToDisplay,
   mapMarketPerpsTokenToDisplay,
   mapMarketTokenToDisplay,
 } from './utils';
@@ -82,6 +84,21 @@ function useHomeMarketCategoryTokens({
                 }),
               )
               .slice(0, HOME_MARKET_CATEGORY_REQUEST_LIMIT),
+          };
+        }
+
+        if (selectedMarketCategoryId === MARKET_TOP_COINS_CATEGORY_ID) {
+          const response =
+            await backgroundApiProxy.serviceMarket.fetchMarketAssetList({
+              currency: 'usd',
+              limit: HOME_MARKET_CATEGORY_REQUEST_LIMIT,
+              page: 1,
+              type: MARKET_TOP_COINS_CATEGORY_ID,
+            });
+
+          return {
+            requestKey: currentRequestKey,
+            tokens: response.list.map(mapMarketAssetToDisplay),
           };
         }
 

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
@@ -1,9 +1,13 @@
+import type { IMarketAssetListItem } from '@onekeyhq/shared/types/market';
 import type { IMarketTokenListItem } from '@onekeyhq/shared/types/marketV2';
 
 import {
+  buildHomeMarketCategories,
   getMarketTokenDisplayPrice,
   getMarketTokenDisplayPriceChange24h,
   getMarketTokenDisplayVolume24h,
+  getTokenKey,
+  mapMarketAssetToDisplay,
   mapMarketTokenToDisplay,
 } from './utils';
 
@@ -33,5 +37,86 @@ describe('PopularTrading market token display utils', () => {
     expect(Number.isNaN(displayToken?.priceChange24h)).toBe(false);
     expect(displayToken?.logoUrls).toEqual(item.logoUrls);
     expect(displayToken?.communityRecognized).toBe(true);
+  });
+
+  test('maps Top Coins assets without inventing a token identity', () => {
+    const item: IMarketAssetListItem = {
+      assetId: 'bitcoin',
+      symbol: 'btc',
+      logoUrl: 'btc.png',
+      price: '100000',
+      priceChange24hPercent: '1.25',
+      priceChange7dPercent: '-',
+      marketCap: '2000000000000',
+      volume24h: '50000000000',
+      sparkline24h: [],
+    };
+
+    const displayToken = mapMarketAssetToDisplay(item);
+
+    expect(displayToken).toMatchObject({
+      chainId: '',
+      contractAddress: '',
+      isNative: false,
+      symbol: 'BTC',
+      price: 100_000,
+      priceChange24h: 1.25,
+      marketCap: 2_000_000_000_000,
+      volume24h: 50_000_000_000,
+      marketAsset: item,
+    });
+    expect(getTokenKey(displayToken)).toBe('market:bitcoin');
+  });
+
+  test('inserts Top Coins before stocks in the wallet home tabs', () => {
+    const categories = buildHomeMarketCategories({
+      apiHomeTabs: [
+        { type: 'watchlist', name: '自选' },
+        { type: 'trending', name: '热门' },
+        { type: 'stocks', name: '股票' },
+      ],
+      favoritesCategory: {
+        id: 'favorites',
+        name: 'Favorites',
+        iconName: 'StarOutline',
+        iconOnly: true,
+      },
+      marketCategories: [],
+      homePerpsHotCategory: {
+        id: 'home-perps-hot',
+        name: '合约',
+      },
+      topCoinsFallbackName: 'Top Coins',
+    });
+
+    expect(categories).toEqual([
+      {
+        id: 'favorites',
+        name: '自选',
+        iconName: 'StarOutline',
+        iconOnly: true,
+      },
+      { id: 'trending', name: '热门', icon: undefined },
+      { id: 'top_coins', name: 'Top Coins' },
+      { id: 'stocks', name: '股票', icon: undefined },
+      { id: 'home-perps-hot', name: '合约' },
+    ]);
+  });
+
+  test('preserves a server-provided Top Coins tab and localized name', () => {
+    const categories = buildHomeMarketCategories({
+      apiHomeTabs: [
+        { type: 'watchlist', name: 'Watchlist' },
+        { type: 'top_coins', name: 'Mainstream Coins' },
+        { type: 'stocks', name: 'Stocks' },
+      ],
+      favoritesCategory: { id: 'favorites', name: 'Favorites' },
+      marketCategories: [],
+      topCoinsFallbackName: 'Top Coins',
+    });
+
+    expect(categories.filter((item) => item.id === 'top_coins')).toEqual([
+      { id: 'top_coins', name: 'Mainstream Coins', icon: undefined },
+    ]);
   });
 });

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.ts
@@ -1,4 +1,6 @@
+import type { IMarketAssetListItem } from '@onekeyhq/shared/types/market';
 import type {
+  IMarketBasicConfigHomeTab,
   IMarketPerpsTokenFromServer,
   IMarketTokenListItem,
 } from '@onekeyhq/shared/types/marketV2';
@@ -7,14 +9,22 @@ import {
   getNativeTokenInfo,
   normalizeStockMetadataValue,
 } from '../../../Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers';
+import { ensureMarketTopCoinsCategory } from '../../../Market/MarketHomeV2/utils';
+
+import { HOME_WATCHLIST_TAB_TYPE } from './constants';
 
 import type { IFavoriteTokenDisplay } from './types';
+import type { IMarketCategoryItem } from '../../../Market/MarketHomeV2/types';
 
 function getTokenKey(token: {
   chainId: string;
   contractAddress: string;
   perpsCoin?: string;
+  marketAsset?: Pick<IMarketAssetListItem, 'assetId'>;
 }) {
+  if (token.marketAsset) {
+    return `market:${token.marketAsset.assetId}`;
+  }
   if (token.perpsCoin) {
     return `perps:${token.perpsCoin}`;
   }
@@ -113,13 +123,73 @@ function mapMarketPerpsTokenToDisplay({
   };
 }
 
+function mapMarketAssetToDisplay(
+  item: IMarketAssetListItem,
+): IFavoriteTokenDisplay {
+  return {
+    chainId: '',
+    contractAddress: '',
+    isNative: false,
+    symbol: item.symbol.toUpperCase(),
+    name: item.symbol,
+    logoUrl: item.logoUrl,
+    price: parseMarketValue(item.price) ?? 0,
+    priceChange24h: parseMarketValue(item.priceChange24hPercent) ?? 0,
+    marketCap: parseMarketValue(item.marketCap) ?? 0,
+    volume24h: parseMarketValue(item.volume24h) ?? 0,
+    marketAsset: item,
+  };
+}
+
+function buildHomeMarketCategories({
+  apiHomeTabs,
+  favoritesCategory,
+  marketCategories,
+  homePerpsHotCategory,
+  topCoinsFallbackName,
+}: {
+  apiHomeTabs: IMarketBasicConfigHomeTab[];
+  favoritesCategory: IMarketCategoryItem;
+  marketCategories: IMarketCategoryItem[];
+  homePerpsHotCategory?: IMarketCategoryItem;
+  topCoinsFallbackName: string;
+}) {
+  const categories =
+    apiHomeTabs.length > 0
+      ? apiHomeTabs.map((tab) => {
+          if (tab.type === HOME_WATCHLIST_TAB_TYPE) {
+            return {
+              ...favoritesCategory,
+              name: tab.name,
+            };
+          }
+
+          return {
+            id: tab.type,
+            name: tab.name,
+            icon: tab.icon,
+          };
+        })
+      : [favoritesCategory, ...marketCategories];
+  const categoriesWithTopCoins = ensureMarketTopCoinsCategory(
+    categories,
+    topCoinsFallbackName,
+  );
+
+  return homePerpsHotCategory
+    ? [...categoriesWithTopCoins, homePerpsHotCategory]
+    : categoriesWithTopCoins;
+}
+
 export {
   EMPTY_DISPLAY_TOKENS,
+  buildHomeMarketCategories,
   getMarketTokenDisplayMarketCap,
   getMarketTokenDisplayPrice,
   getMarketTokenDisplayPriceChange24h,
   getMarketTokenDisplayVolume24h,
   getTokenKey,
+  mapMarketAssetToDisplay,
   mapMarketPerpsTokenToDisplay,
   mapMarketTokenToDisplay,
 };

--- a/packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx
@@ -70,6 +70,7 @@ function CategorySelectorImpl({
         {categories.map((item) => (
           <CategoryFilterItemWithLayout
             key={item.id}
+            testID={`market-category-${item.id}`}
             id={item.id}
             name={item.name}
             icon={item.icon}
@@ -101,6 +102,7 @@ function CategorySelectorImpl({
       {categories.map((item) => (
         <CategoryFilterItem
           key={item.id}
+          testID={`market-category-${item.id}`}
           name={item.name}
           icon={item.icon}
           iconName={item.iconName}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTopCoinsList/hooks/useMarketTopCoins.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTopCoinsList/hooks/useMarketTopCoins.ts
@@ -21,37 +21,18 @@ function toFiniteNumber(value: string) {
   return Number.isFinite(numberValue) ? numberValue : undefined;
 }
 
-export function useMarketTopCoins({
-  replaceCurrentDetail = false,
-}: { replaceCurrentDetail?: boolean } = {}) {
+type IUseMarketTopCoinNavigationOptions = {
+  replaceCurrentDetail?: boolean;
+};
+
+export function useMarketTopCoinResolver() {
   const intl = useIntl();
-  const toMarketDetailPage = useToDetailPage({
-    marketTokenCategory: MARKET_TOP_COINS_CATEGORY_ID,
-    replaceCurrentDetail,
-  });
   const isNavigatingRef = useRef(false);
 
-  const { result, isLoading } = usePromiseResult(
-    () =>
-      backgroundApiProxy.serviceMarket.fetchMarketAssetList({
-        currency: 'usd',
-        limit: 100,
-        page: 1,
-        type: MARKET_TOP_COINS_CATEGORY_ID,
-      }),
-    [],
-    {
-      pollingInterval: timerUtils.getTimeDurationMs({ seconds: 50 }),
-      revalidateOnReconnect: true,
-      watchLoading: true,
-    },
-  );
-  const data = result?.list ?? EMPTY_MARKET_ASSET_LIST;
-
-  const handleItemPress = useCallback(
+  return useCallback(
     async (item: IMarketAssetListItem) => {
       if (isNavigatingRef.current) {
-        return;
+        return undefined;
       }
       isNavigatingRef.current = true;
       try {
@@ -73,7 +54,7 @@ export function useMarketTopCoins({
         const decimals = selectedVariant.isNative
           ? networkInfo.decimals
           : undefined;
-        await toMarketDetailPage({
+        return {
           address: selectedVariant.tokenAddress,
           change24h: toFiniteNumber(market.priceChange24hPercent),
           ...(typeof decimals === 'number' ? { decimals } : undefined),
@@ -87,7 +68,44 @@ export function useMarketTopCoins({
           tokenAddress: selectedVariant.tokenAddress,
           tokenImageUri: asset.logoUrl,
           turnover: toFiniteNumber(market.volume24h),
+        };
+      } catch (_error) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.global_an_error_occurred,
+          }),
         });
+        return undefined;
+      } finally {
+        isNavigatingRef.current = false;
+      }
+    },
+    [intl],
+  );
+}
+
+export function useMarketTopCoinNavigation({
+  replaceCurrentDetail = false,
+}: IUseMarketTopCoinNavigationOptions = {}) {
+  const intl = useIntl();
+  const resolveMarketTopCoin = useMarketTopCoinResolver();
+  const toMarketDetailPage = useToDetailPage({
+    marketTokenCategory: MARKET_TOP_COINS_CATEGORY_ID,
+    replaceCurrentDetail,
+  });
+  const isNavigatingRef = useRef(false);
+
+  const handleItemPress = useCallback(
+    async (item: IMarketAssetListItem) => {
+      if (isNavigatingRef.current) {
+        return;
+      }
+      isNavigatingRef.current = true;
+      try {
+        const token = await resolveMarketTopCoin(item);
+        if (token) {
+          await toMarketDetailPage(token);
+        }
       } catch (_error) {
         Toast.error({
           title: intl.formatMessage({
@@ -98,8 +116,32 @@ export function useMarketTopCoins({
         isNavigatingRef.current = false;
       }
     },
-    [intl, toMarketDetailPage],
+    [intl, resolveMarketTopCoin, toMarketDetailPage],
   );
+
+  return handleItemPress;
+}
+
+export function useMarketTopCoins(
+  options: IUseMarketTopCoinNavigationOptions = {},
+) {
+  const handleItemPress = useMarketTopCoinNavigation(options);
+  const { result, isLoading } = usePromiseResult(
+    () =>
+      backgroundApiProxy.serviceMarket.fetchMarketAssetList({
+        currency: 'usd',
+        limit: 100,
+        page: 1,
+        type: MARKET_TOP_COINS_CATEGORY_ID,
+      }),
+    [],
+    {
+      pollingInterval: timerUtils.getTimeDurationMs({ seconds: 50 }),
+      revalidateOnReconnect: true,
+      watchLoading: true,
+    },
+  );
+  const data = result?.list ?? EMPTY_MARKET_ASSET_LIST;
 
   return {
     data,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61602](https://onekeyhq.atlassian.net/browse/OK-61602)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Add the Top Coins category before Stocks in the Wallet Home market section.
- Fetch the first three Top Coins using the Market Asset API.
- Map asset price, market cap, volume, and price change data for Home display.
- Resolve the selected network variant before opening Market V2 detail.
- Preserve `marketTokenId` and the originating category during navigation.
- Keep Top Coins separate from token watchlist actions.
- Preserve server-provided category names and ordering rules.

## Verification

- Verified Top Coins displays BTC, ETH, and SOL on Desktop.
- Verified category order and switching between Trending, Top Coins, and Stocks.
- Added unit tests for category construction, asset mapping, data fetching, and navigation.
- Passed 19 related tests.
- Passed `yarn agent:check --profile commit`.

## Jira

[OK-61602](https://onekeyhq.atlassian.net/browse/OK-61602)

[OK-61602]: https://onekeyhq.atlassian.net/browse/OK-61602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ