### PR TITLE
fix: stabilize market charts | OK-61554 & OK-61611

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/StockSimpleChart.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/StockSimpleChart.test.ts
@@ -1,6 +1,11 @@
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 
-import { fetchStockSimpleChartPoints } from './stockSimpleChartData';
+import {
+  STOCK_SHARE_SIMPLE_CHART_RANGES,
+  TOKEN_SIMPLE_CHART_RANGES,
+  fetchStockSimpleChartPoints,
+  resolveStockSimpleChartRequestScope,
+} from './stockSimpleChartData';
 
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
@@ -114,6 +119,57 @@ describe('fetchStockSimpleChartPoints', () => {
     expect(result).toEqual([[nowSeconds - 60, 100]]);
   });
 
+  it('normalizes a stale token All range to a bounded one-year request', async () => {
+    serviceMarketV2.fetchMarketTokenKline.mockResolvedValue({
+      total: 0,
+      points: [],
+    });
+
+    await fetchStockSimpleChartPoints({
+      isNative: false,
+      networkId: 'evm--1',
+      priceMode: 'token',
+      range: 'All',
+      stockId: 'AAPL',
+      tokenAddress: '0xaapl',
+    });
+
+    expect(serviceMarketV2.fetchMarketTokenKline.mock.calls).toEqual([
+      [
+        {
+          interval: '1D',
+          networkId: 'evm--1',
+          tokenAddress: '0xaapl',
+          timeFrom: nowSeconds - 365 * 24 * 60 * 60,
+          timeTo: nowSeconds,
+          autoHandleError: false,
+        },
+      ],
+    ]);
+  });
+
+  it('keeps All available for the stock share data source', async () => {
+    serviceMarketV2.fetchMarketStockChart.mockResolvedValue({
+      stockId: 'AAPL',
+      period: 'all',
+      currency: 'USD',
+      points: [],
+    });
+
+    await fetchStockSimpleChartPoints({
+      isNative: false,
+      networkId: 'evm--1',
+      priceMode: 'share',
+      range: 'All',
+      stockId: 'AAPL',
+      tokenAddress: '0xaapl',
+    });
+
+    expect(serviceMarketV2.fetchMarketStockChart.mock.calls).toEqual([
+      [{ stockId: 'AAPL', period: 'all', points: 100 }],
+    ]);
+  });
+
   it('uses CoinGecko chart data when V2 detail is unsupported', async () => {
     serviceMarket.fetchTokenChart.mockResolvedValue([
       [(nowSeconds - 2 * 24 * 60 * 60) * 1000, 80],
@@ -134,5 +190,56 @@ describe('fetchStockSimpleChartPoints', () => {
     ]);
     expect(serviceMarketV2.fetchMarketTokenKline.mock.calls).toHaveLength(0);
     expect(result).toEqual([[nowSeconds - 60, 84]]);
+  });
+});
+
+describe('stock simple chart request identity', () => {
+  it('exposes All only for the share data source', () => {
+    expect(TOKEN_SIMPLE_CHART_RANGES).not.toContain('All');
+    expect(STOCK_SHARE_SIMPLE_CHART_RANGES).toContain('All');
+  });
+
+  it('ignores token variants while showing share prices', () => {
+    const firstVariant = resolveStockSimpleChartRequestScope({
+      coinGeckoId: 'first',
+      isNative: false,
+      networkId: 'evm--1',
+      priceMode: 'share',
+      range: '1D',
+      stockId: 'AAPL',
+      tokenAddress: '0xfirst',
+    });
+    const secondVariant = resolveStockSimpleChartRequestScope({
+      coinGeckoId: 'second',
+      isNative: false,
+      networkId: 'evm--8453',
+      priceMode: 'share',
+      range: '1D',
+      stockId: 'AAPL',
+      tokenAddress: '0xsecond',
+    });
+
+    expect(secondVariant).toEqual(firstVariant);
+  });
+
+  it('keeps token variants in token-price request identity', () => {
+    const firstVariant = resolveStockSimpleChartRequestScope({
+      isNative: false,
+      networkId: 'evm--1',
+      priceMode: 'token',
+      range: '1D',
+      stockId: 'AAPL',
+      tokenAddress: '0xfirst',
+    });
+    const secondVariant = resolveStockSimpleChartRequestScope({
+      isNative: false,
+      networkId: 'evm--8453',
+      priceMode: 'token',
+      range: '1D',
+      stockId: 'AAPL',
+      tokenAddress: '0xsecond',
+    });
+
+    expect(secondVariant).not.toEqual(firstVariant);
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/StockSimpleChart.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/StockSimpleChart.tsx
@@ -23,6 +23,7 @@ import { useTokenDetail } from '../../hooks/useTokenDetail';
 import {
   type IStockSimpleChartRange,
   fetchStockSimpleChartPoints,
+  resolveStockSimpleChartRequestScope,
 } from './stockSimpleChartData';
 
 export type { IStockSimpleChartRange } from './stockSimpleChartData';
@@ -50,6 +51,23 @@ export function StockSimpleChart({
   const intl = useIntl();
   const { isNative, networkId, tokenAddress, tokenDetail } = useTokenDetail();
   const { stockDetail, stockId } = useStockDetail();
+  const {
+    coinGeckoId: requestCoinGeckoId,
+    isNative: requestIsNative,
+    networkId: requestNetworkId,
+    priceMode: requestPriceMode,
+    range: requestRange,
+    stockId: requestStockId,
+    tokenAddress: requestTokenAddress,
+  } = resolveStockSimpleChartRequestScope({
+    coinGeckoId,
+    isNative,
+    networkId,
+    priceMode,
+    range,
+    stockId,
+    tokenAddress,
+  });
 
   const {
     result: chartState,
@@ -59,13 +77,13 @@ export function StockSimpleChart({
     async () => {
       try {
         const data = await fetchStockSimpleChartPoints({
-          coinGeckoId,
-          isNative,
-          networkId,
-          priceMode,
-          range,
-          stockId,
-          tokenAddress,
+          coinGeckoId: requestCoinGeckoId,
+          isNative: requestIsNative,
+          networkId: requestNetworkId,
+          priceMode: requestPriceMode,
+          range: requestRange,
+          stockId: requestStockId,
+          tokenAddress: requestTokenAddress,
         });
 
         return {
@@ -76,7 +94,15 @@ export function StockSimpleChart({
         return { data: [], status: 'error' };
       }
     },
-    [coinGeckoId, isNative, networkId, priceMode, range, stockId, tokenAddress],
+    [
+      requestCoinGeckoId,
+      requestIsNative,
+      requestNetworkId,
+      requestPriceMode,
+      requestRange,
+      requestStockId,
+      requestTokenAddress,
+    ],
     {
       initResult: { data: [], status: 'pending' },
       watchLoading: true,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/index.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/index.ts
@@ -1,1 +1,6 @@
-export * from './StockSimpleChart';
+export { StockSimpleChart } from './StockSimpleChart';
+export {
+  STOCK_SHARE_SIMPLE_CHART_RANGES,
+  TOKEN_SIMPLE_CHART_RANGES,
+} from './stockSimpleChartData';
+export type { IStockSimpleChartRange } from './stockSimpleChartData';

--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/stockSimpleChartData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/stockSimpleChartData.ts
@@ -4,6 +4,61 @@ import type { IMarketStockPublicChartPeriod } from '@onekeyhq/shared/types/marke
 
 export type IStockSimpleChartRange = '1H' | '1D' | '1W' | '1M' | '1Y' | 'All';
 
+export const TOKEN_SIMPLE_CHART_RANGES = [
+  '1H',
+  '1D',
+  '1W',
+  '1M',
+  '1Y',
+] as const satisfies readonly IStockSimpleChartRange[];
+
+export const STOCK_SHARE_SIMPLE_CHART_RANGES = [
+  ...TOKEN_SIMPLE_CHART_RANGES,
+  'All',
+] as const satisfies readonly IStockSimpleChartRange[];
+
+type IStockSimpleChartRequestParams = {
+  coinGeckoId?: string;
+  isNative: boolean;
+  networkId: string;
+  priceMode: 'share' | 'token';
+  range: IStockSimpleChartRange;
+  stockId?: string;
+  tokenAddress: string;
+};
+
+export function resolveStockSimpleChartRequestScope({
+  coinGeckoId,
+  isNative,
+  networkId,
+  priceMode,
+  range,
+  stockId,
+  tokenAddress,
+}: IStockSimpleChartRequestParams): IStockSimpleChartRequestParams {
+  if (priceMode === 'share') {
+    return {
+      coinGeckoId: undefined,
+      isNative: false,
+      networkId: '',
+      priceMode,
+      range,
+      stockId,
+      tokenAddress: '',
+    };
+  }
+
+  return {
+    coinGeckoId,
+    isNative,
+    networkId,
+    priceMode,
+    range: range === 'All' ? '1Y' : range,
+    stockId: undefined,
+    tokenAddress,
+  };
+}
+
 const STOCK_SIMPLE_CHART_RANGE_SECONDS: Record<
   IStockSimpleChartRange,
   number | undefined
@@ -46,23 +101,19 @@ const STOCK_SHARE_CHART_PERIODS: Record<
   All: 'all',
 };
 
-export async function fetchStockSimpleChartPoints({
-  coinGeckoId,
-  isNative,
-  networkId,
-  priceMode,
-  range,
-  stockId,
-  tokenAddress,
-}: {
-  coinGeckoId?: string;
-  isNative: boolean;
-  networkId: string;
-  priceMode: 'share' | 'token';
-  range: IStockSimpleChartRange;
-  stockId?: string;
-  tokenAddress: string;
-}): Promise<IMarketTokenChart> {
+export async function fetchStockSimpleChartPoints(
+  params: IStockSimpleChartRequestParams,
+): Promise<IMarketTokenChart> {
+  const {
+    coinGeckoId,
+    isNative,
+    networkId,
+    priceMode,
+    range,
+    stockId,
+    tokenAddress,
+  } = resolveStockSimpleChartRequestScope(params);
+
   const isSharePrice = priceMode === 'share';
   if (isSharePrice && !stockId) {
     return [];

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.test.tsx
@@ -220,4 +220,41 @@ describe('DesktopLayout', () => {
       timeTo: 200,
     });
   });
+
+  it('keeps the embedded share chart independent of the token variant', () => {
+    render(
+      <DesktopLayout
+        isChartFullscreen={false}
+        isTradingViewNative={false}
+        onChartSwitch={jest.fn()}
+        onChartFullscreenChange={jest.fn()}
+        isNative={false}
+        networkId="evm--1"
+        tokenAddress="0xaapl"
+      />,
+    );
+
+    const marketTradingView = mockStockDesktopLayout.mock.calls.at(-1)?.[0]
+      ?.marketTradingView as {
+      key: string;
+      props: {
+        decimal?: number;
+        isNative?: boolean;
+        networkId: string;
+        tokenAddress: string;
+        tokenSymbol?: string;
+      };
+    };
+
+    expect(marketTradingView.key).toBe('stock-share:AAPL');
+    expect(marketTradingView.props).toEqual(
+      expect.objectContaining({
+        decimal: undefined,
+        isNative: false,
+        networkId: '',
+        tokenAddress: '',
+        tokenSymbol: 'AAPL',
+      }),
+    );
+  });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -346,15 +346,27 @@ export function DesktopLayout({
     return (
       <LazyDesktopMarketTradingView
         key={isStockSharePrice ? `stock-share:${stockId ?? ''}` : 'token'}
-        tokenAddress={effectiveMarketTradingViewParams?.tokenAddress ?? ''}
-        networkId={effectiveMarketTradingViewParams?.networkId ?? ''}
+        tokenAddress={
+          isStockSharePrice
+            ? ''
+            : (effectiveMarketTradingViewParams?.tokenAddress ?? '')
+        }
+        networkId={
+          isStockSharePrice
+            ? ''
+            : (effectiveMarketTradingViewParams?.networkId ?? '')
+        }
         tokenSymbol={
           isStockSharePrice
             ? stockId
             : effectiveMarketTradingViewParams?.tokenSymbol
         }
-        isNative={effectiveMarketTradingViewParams?.isNative}
-        decimal={marketTradingViewParams?.decimal}
+        isNative={
+          isStockSharePrice ? false : effectiveMarketTradingViewParams?.isNative
+        }
+        decimal={
+          isStockSharePrice ? undefined : marketTradingViewParams?.decimal
+        }
         dataSource={
           isStockSharePrice
             ? 'polling'

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.tsx
@@ -45,7 +45,9 @@ import {
 } from '../components/StockAnalystGauge';
 import {
   type IStockSimpleChartRange,
+  STOCK_SHARE_SIMPLE_CHART_RANGES,
   StockSimpleChart,
+  TOKEN_SIMPLE_CHART_RANGES,
 } from '../components/StockSimpleChart';
 import { SwapPanel } from '../components/SwapPanel/SwapPanel';
 import { ShareButton } from '../components/TokenDetailHeader/ShareButton';
@@ -89,15 +91,6 @@ const STOCK_CHART_TOOLBAR_HEIGHT = 40;
 // block, so one offset puts the switch on the widget's line in Pro and leaves
 // it in exactly the same place when the mode is toggled.
 const STOCK_CHART_TOOLBAR_VERTICAL_INSET = 4;
-
-const STOCK_SIMPLE_CHART_RANGES: IStockSimpleChartRange[] = [
-  '1H',
-  '1D',
-  '1W',
-  '1M',
-  '1Y',
-  'All',
-];
 
 const STOCK_SIMPLE_CHART_RANGE_WIDTHS: Record<IStockSimpleChartRange, number> =
   {
@@ -536,6 +529,13 @@ function StockChart({
   const [mode, setMode] = useState<IStockChartMode>('simple');
   const [range, setRange] = useState<IStockSimpleChartRange>('1D');
   const isSimpleMode = mode === 'simple';
+  const chartRanges =
+    priceMode === 'share'
+      ? STOCK_SHARE_SIMPLE_CHART_RANGES
+      : TOKEN_SIMPLE_CHART_RANGES;
+  const effectiveRange =
+    priceMode === 'token' && range === 'All' ? '1Y' : range;
+  const rangeSelectorWidth = priceMode === 'share' ? 214 : 178;
 
   // Simple leads the chart with its own toolbar row (Figma 25476:88858): range
   // selector on the left, Simple/Pro on the right.
@@ -572,8 +572,8 @@ function StockChart({
           alignItems="center"
           justifyContent="space-between"
         >
-          <XStack width={214} alignItems="center" gap="$0.5">
-            {STOCK_SIMPLE_CHART_RANGES.map((item) => {
+          <XStack width={rangeSelectorWidth} alignItems="center" gap="$0.5">
+            {chartRanges.map((item) => {
               const itemWidth = STOCK_SIMPLE_CHART_RANGE_WIDTHS[item];
               return (
                 <Stack
@@ -592,7 +592,7 @@ function StockChart({
                     px="$2"
                     borderWidth={0}
                     size="small"
-                    variant={range === item ? 'secondary' : 'tertiary'}
+                    variant={effectiveRange === item ? 'secondary' : 'tertiary'}
                     borderRadius="$full"
                     onPress={() => setRange(item)}
                   >
@@ -611,7 +611,7 @@ function StockChart({
       ) : null}
       {isSimpleMode ? (
         <StockSimpleChart
-          range={range}
+          range={effectiveRange}
           priceMode={priceMode}
           onHoverChange={onHoverChange}
         />

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
@@ -10,20 +10,12 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   type IStockSimpleChartRange,
   StockSimpleChart,
+  TOKEN_SIMPLE_CHART_RANGES,
 } from '../../components/StockSimpleChart';
 
 import { MarketDetailProChartControls } from './MarketDetailProChartControls';
 
 type ITokenChartMode = 'simple' | 'pro';
-
-const TOKEN_SIMPLE_CHART_RANGES: IStockSimpleChartRange[] = [
-  '1H',
-  '1D',
-  '1W',
-  '1M',
-  '1Y',
-  'All',
-];
 
 function TokenChartModeControl({
   mode,
@@ -83,7 +75,6 @@ export function TokenDetailChart({
   onChartSwitch: () => void;
   onEnterChartFullscreen: () => void;
 }) {
-  const intl = useIntl();
   const [mode, setMode] = useState<ITokenChartMode>('simple');
   const [range, setRange] = useState<IStockSimpleChartRange>('1D');
   const isSimpleMode = mode === 'simple' && !isChartFullscreen;
@@ -104,7 +95,7 @@ export function TokenDetailChart({
                 <Button
                   key={item}
                   testID={`market-token-chart-range-${item}`}
-                  minWidth={item === 'All' ? 46 : 40}
+                  minWidth={40}
                   height={32}
                   m="$0"
                   px="$2"
@@ -114,9 +105,7 @@ export function TokenDetailChart({
                   borderRadius="$full"
                   onPress={() => setRange(item)}
                 >
-                  {item === 'All'
-                    ? intl.formatMessage({ id: ETranslations.global_all })
-                    : item}
+                  {item}
                 </Button>
               ))}
             </XStack>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61554](https://onekeyhq.atlassian.net/browse/OK-61554) [OK-61611](https://onekeyhq.atlassian.net/browse/OK-61611)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Hide the unsupported `All` range from token price charts.
- Normalize stale token `All` requests to a bounded one-year range.
- Keep the `All` range available for stock share-price charts.
- Prevent Simple and Pro share-price charts from reloading when switching between token variants on different networks.
- Use `stockId` as the stable identity for stock share-price chart data.

## Test Plan

- Verify token price charts only display ranges up to `1Y`.
- Verify stock Share Price charts still display `All`.
- Switch between AAPLon, AAPLx, and other variants while viewing Share Price.
- Confirm the Simple chart does not show a loading skeleton again.
- Confirm the Pro chart/WebView does not reload.
- Focused Jest tests: 11 passed.
- Type-aware lint and formatting checks passed.

## Related Issues

- [OK-61554](https://onekeyhq.atlassian.net/browse/OK-61554)
- [OK-61611](https://onekeyhq.atlassian.net/browse/OK-61611)

[OK-61554]: https://onekeyhq.atlassian.net/browse/OK-61554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61611]: https://onekeyhq.atlassian.net/browse/OK-61611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ