### PR TITLE
fix: DeFi share links, banner looping, risk gate coverage and in-app …

### DIFF
--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 
+import { useIsFocused } from '@react-navigation/native';
 import { debounce } from 'lodash';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -24,6 +25,11 @@ import { PaginationItem } from './PaginationItem';
 import type { ICarouselProps, IPaginationItemProps } from './type';
 import type { LayoutChangeEvent, NativeSyntheticEvent } from 'react-native';
 import type NativePagerView from 'react-native-pager-view';
+
+// A press arriving within this window of the pager settling is the tail of a
+// swipe, not a tap. Long enough to cover the lift after a fast flick, short
+// enough that a deliberate tap right after one still registers.
+const PRESS_SUPPRESS_AFTER_SCROLL_MS = 150;
 
 const defaultRenderPaginationItem = <T,>(
   { dotStyle, activeDotStyle, onPress }: IPaginationItemProps<T>,
@@ -49,13 +55,28 @@ const defaultRenderPaginationItem = <T,>(
  */
 const CarouselContext = createContext<{
   pageIndex: number;
+  /**
+   * Whether a press landing right now came out of a swipe rather than a tap.
+   *
+   * The pager handles the horizontal gesture natively, so a Pressable inside a
+   * page never receives the move that would cancel it — it sees only down and
+   * up and fires onPress. Items with their own onPress consult this first.
+   */
+  shouldSuppressPress: () => boolean;
 }>({
   pageIndex: 0,
+  shouldSuppressPress: () => false,
 });
 
 const useCarouselContext = () => {
   const context = useContext(CarouselContext);
   return context;
+};
+
+/** Lets a carousel item ignore the press a swipe leaves behind. */
+export const useCarouselPressSuppressor = () => {
+  const { shouldSuppressPress } = useCarouselContext();
+  return shouldSuppressPress;
 };
 
 export const useCarouselIndex = () => {
@@ -205,6 +226,16 @@ export function Carousel<T>({
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPageVisibleRef = useRef(true);
+  // True from the moment the pager leaves `idle` — a finger on the page, or
+  // the deceleration after it — until the pager settles again. Autoplay yields
+  // to it and the infinite-wrap jump waits for it. Web's pager shim never
+  // reports the state, so it stays false there and behavior is unchanged.
+  const isInteractingRef = useRef(false);
+  // A wrap jump that arrived mid-gesture, held until the pager is idle.
+  const pendingCloneSwapRef = useRef<number | null>(null);
+  // When the pager last settled. A finger lifting at the end of a swipe still
+  // produces a press, so items stay press-proof for a moment afterwards.
+  const lastScrollEndAtRef = useRef(0);
 
   const stopAutoPlay = useCallback(() => {
     if (timerRef.current) {
@@ -217,7 +248,11 @@ export function Carousel<T>({
     if (loop && isPageVisibleRef.current) {
       stopAutoPlay();
       timerRef.current = setTimeout(() => {
-        scrollToNextPage();
+        // Turning the page out from under a finger is what puts the pager into
+        // the state that crashes; skip this beat and try again later instead.
+        if (!isInteractingRef.current) {
+          scrollToNextPage();
+        }
         startAutoPlay();
       }, autoPlayInterval);
     }
@@ -253,12 +288,30 @@ export function Carousel<T>({
     };
   }, [loop, startAutoPlay, stopAutoPlay]);
 
+  // Autoplay follows screen focus. Without this the timer is only ever paused
+  // and resumed by onPressIn/onPressOut, so tapping a card to navigate away
+  // stops it (onPressIn) and nothing ever starts it again — onPressOut does not
+  // arrive once the screen is leaving, and the IntersectionObserver above is
+  // web-only. Coming back re-focuses the screen and picks it up again.
+  const isFocused = useIsFocused();
+
   useEffect(() => {
-    startAutoPlay();
+    if (isFocused) {
+      startAutoPlay();
+    } else {
+      stopAutoPlay();
+    }
     return () => {
       stopAutoPlay();
     };
-  }, [loop, autoPlayInterval, scrollToNextPage, startAutoPlay, stopAutoPlay]);
+  }, [
+    isFocused,
+    loop,
+    autoPlayInterval,
+    scrollToNextPage,
+    startAutoPlay,
+    stopAutoPlay,
+  ]);
 
   useImperativeHandle(instanceRef, () => {
     return {
@@ -303,9 +356,17 @@ export function Carousel<T>({
         // no animation so nothing is visible, which puts content back on both
         // sides of the finger. The re-entrant onPageSelected this triggers
         // resolves to the same logical index, so it is a no-op.
-        pagerRef.current?.setPageWithoutAnimation(
-          toRenderedIndex(logicalIndex),
-        );
+        const renderedTarget = toRenderedIndex(logicalIndex);
+        if (isInteractingRef.current) {
+          // Jumping while the pager is still driven by the gesture is what
+          // takes the app down: UIPageViewController asserts if its view
+          // controllers are replaced during an in-flight transition, and
+          // ViewPager2 rejects setCurrentItem while dragging. Hold it until the
+          // pager reports idle.
+          pendingCloneSwapRef.current = renderedTarget;
+          return;
+        }
+        pagerRef.current?.setPageWithoutAnimation(renderedTarget);
       }
     },
     [
@@ -317,6 +378,33 @@ export function Carousel<T>({
       toRenderedIndex,
     ],
   );
+  // The pager's own gesture state, the only reliable signal that the user has
+  // taken over: the container's press handlers do not fire for a horizontal
+  // swipe, which the native pager claims outright.
+  const onPageScrollStateChanged = useCallback(
+    (
+      e: NativeSyntheticEvent<
+        Readonly<{ pageScrollState: 'idle' | 'dragging' | 'settling' }>
+      >,
+    ) => {
+      const isIdle = e.nativeEvent.pageScrollState === 'idle';
+      isInteractingRef.current = !isIdle;
+      if (!isIdle) {
+        stopAutoPlay();
+        return;
+      }
+      lastScrollEndAtRef.current = Date.now();
+      // Settled: it is now safe to finish a wrap that landed mid-gesture.
+      const pending = pendingCloneSwapRef.current;
+      if (pending !== null) {
+        pendingCloneSwapRef.current = null;
+        pagerRef.current?.setPageWithoutAnimation(pending);
+      }
+      startAutoPlay();
+    },
+    [startAutoPlay, stopAutoPlay],
+  );
+
   const [layout, setLayout] = useState<{ width: number; height: number }>({
     width: 0,
     height: 0,
@@ -355,7 +443,17 @@ export function Carousel<T>({
     startAutoPlay();
   }, [startAutoPlay]);
 
-  const value = useMemo(() => ({ pageIndex }), [pageIndex]);
+  const shouldSuppressPress = useCallback(
+    () =>
+      isInteractingRef.current ||
+      Date.now() - lastScrollEndAtRef.current < PRESS_SUPPRESS_AFTER_SCROLL_MS,
+    [],
+  );
+
+  const value = useMemo(
+    () => ({ pageIndex, shouldSuppressPress }),
+    [pageIndex, shouldSuppressPress],
+  );
 
   const containerSizeStyle = useMemo(
     () => ({
@@ -410,6 +508,7 @@ export function Carousel<T>({
                 initialPage={toRenderedIndex(defaultIndex)}
                 pageWidth={pageWidth}
                 onPageSelected={onPageSelected}
+                onPageScrollStateChanged={onPageScrollStateChanged}
                 // Only effective on native; web PagerView ignores this and uses "none"
                 // to avoid globally blurring focused inputs via dismissKeyboard().
                 keyboardDismissMode="on-drag"

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -81,6 +81,7 @@ export function Carousel<T>({
   showPagination = true,
   renderPaginationItem = defaultRenderPaginationItem,
   disableAnimation = false,
+  infinite = false,
   pagerProps,
   defaultIndex = 0,
 }: ICarouselProps<T>) {
@@ -91,15 +92,40 @@ export function Carousel<T>({
 
   const debouncedSetPageIndex = useDebouncedCallback(setPageIndex, 50);
 
+  // PagerView has no looping mode, so infinite paging clones the two edges and
+  // renders [last, ...data, first]. Landing on a clone jumps — without
+  // animation, onto the identical real page — so the wrap is invisible. A
+  // single page has nothing to wrap around, so it stays a plain pager.
+  const isInfinite = infinite && data.length > 1;
+  const pages = useMemo(
+    () =>
+      isInfinite ? [data[data.length - 1], ...data, data[0]] : data.slice(),
+    [data, isInfinite],
+  );
+  // `pageIndex` / `currentPage` / the pagination dots all speak logical
+  // indexes; only the pager itself sees the cloned ones.
+  const toRenderedIndex = useCallback(
+    (logicalIndex: number) => (isInfinite ? logicalIndex + 1 : logicalIndex),
+    [isInfinite],
+  );
+  const toLogicalIndex = useCallback(
+    (renderedIndex: number) =>
+      isInfinite
+        ? (renderedIndex - 1 + data.length) % data.length
+        : renderedIndex,
+    [data.length, isInfinite],
+  );
+
   const setPage = useCallback(
     (page: number) => {
+      const renderedPage = toRenderedIndex(page);
       if (disableAnimation) {
-        pagerRef.current?.setPageWithoutAnimation(page);
+        pagerRef.current?.setPageWithoutAnimation(renderedPage);
       } else {
-        pagerRef.current?.setPage(page);
+        pagerRef.current?.setPage(renderedPage);
       }
     },
-    [disableAnimation],
+    [disableAnimation, toRenderedIndex],
   );
 
   const isResizingRef = useRef(false);
@@ -121,14 +147,44 @@ export function Carousel<T>({
     };
   }, [pageWidthProp]);
 
+  // Step one rendered page in `direction`, so a wrap animates onto the adjacent
+  // clone instead of scrolling the whole strip back the long way; the
+  // onPageSelected handler then swaps the clone for the real page.
+  const scrollToAdjacentInfinitePage = useCallback(
+    (direction: 1 | -1) => {
+      pagerRef.current?.setPage(
+        toRenderedIndex(currentPage.current) + direction,
+      );
+      const nextPage =
+        (currentPage.current + direction + data.length) % data.length;
+      currentPage.current = nextPage;
+      debouncedSetPageIndex(nextPage);
+    },
+    [data.length, debouncedSetPageIndex, toRenderedIndex],
+  );
+
   const scrollToPreviousPage = useCallback(() => {
+    if (isInfinite) {
+      scrollToAdjacentInfinitePage(-1);
+      return;
+    }
     const previousPage =
       currentPage.current > 0 ? currentPage.current - 1 : data.length - 1;
     setPage(previousPage);
     currentPage.current = previousPage;
     debouncedSetPageIndex(previousPage);
-  }, [data.length, debouncedSetPageIndex, setPage]);
+  }, [
+    data.length,
+    debouncedSetPageIndex,
+    isInfinite,
+    scrollToAdjacentInfinitePage,
+    setPage,
+  ]);
   const scrollToNextPage = useCallback(() => {
+    if (isInfinite) {
+      scrollToAdjacentInfinitePage(1);
+      return;
+    }
     if (currentPage.current >= data.length - 1) {
       pagerRef.current?.setPageWithoutAnimation(0);
       currentPage.current = 0;
@@ -139,7 +195,13 @@ export function Carousel<T>({
     setPage(nextPage);
     currentPage.current = nextPage;
     debouncedSetPageIndex(nextPage);
-  }, [data.length, debouncedSetPageIndex, setPage]);
+  }, [
+    data.length,
+    debouncedSetPageIndex,
+    isInfinite,
+    scrollToAdjacentInfinitePage,
+    setPage,
+  ]);
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPageVisibleRef = useRef(true);
@@ -228,11 +290,32 @@ export function Carousel<T>({
       if (isResizingRef.current) {
         return;
       }
-      currentPage.current = e.nativeEvent.position;
-      debouncedSetPageIndex(currentPage.current);
-      onPageChanged?.(currentPage.current);
+      const renderedIndex = e.nativeEvent.position;
+      const logicalIndex = toLogicalIndex(renderedIndex);
+      currentPage.current = logicalIndex;
+      debouncedSetPageIndex(logicalIndex);
+      onPageChanged?.(logicalIndex);
+      if (
+        isInfinite &&
+        (renderedIndex === 0 || renderedIndex === data.length + 1)
+      ) {
+        // A clone is on screen: swap it for the real page it duplicates, with
+        // no animation so nothing is visible, which puts content back on both
+        // sides of the finger. The re-entrant onPageSelected this triggers
+        // resolves to the same logical index, so it is a no-op.
+        pagerRef.current?.setPageWithoutAnimation(
+          toRenderedIndex(logicalIndex),
+        );
+      }
     },
-    [debouncedSetPageIndex, onPageChanged],
+    [
+      data.length,
+      debouncedSetPageIndex,
+      isInfinite,
+      onPageChanged,
+      toLogicalIndex,
+      toRenderedIndex,
+    ],
   );
   const [layout, setLayout] = useState<{ width: number; height: number }>({
     width: 0,
@@ -324,7 +407,7 @@ export function Carousel<T>({
               <PagerView
                 ref={pagerRef as RefObject<NativePagerView>}
                 style={pagerViewStyle}
-                initialPage={defaultIndex}
+                initialPage={toRenderedIndex(defaultIndex)}
                 pageWidth={pageWidth}
                 onPageSelected={onPageSelected}
                 // Only effective on native; web PagerView ignores this and uses "none"
@@ -333,9 +416,9 @@ export function Carousel<T>({
                 disableAnimation={disableAnimation}
                 {...pagerProps}
               >
-                {data.map((item, index) => (
+                {pages.map((item, index) => (
                   <Stack key={index} style={pageItemStyle}>
-                    {renderItem({ item, index })}
+                    {renderItem({ item, index: toLogicalIndex(index) })}
                   </Stack>
                 ))}
               </PagerView>

--- a/packages/components/src/composite/Carousel/pager.tsx
+++ b/packages/components/src/composite/Carousel/pager.tsx
@@ -19,6 +19,9 @@ export function PagerView({
   ref,
   style,
   onPageSelected,
+  // Native-only signal. Destructured so it is never spread onto the DOM node
+  // below; the web shim drives scrolling itself and has no equivalent state.
+  onPageScrollStateChanged: _onPageScrollStateChanged,
   keyboardDismissMode,
   pageWidth: pageWidthProp,
   disableAnimation = false,

--- a/packages/components/src/composite/Carousel/type.ts
+++ b/packages/components/src/composite/Carousel/type.ts
@@ -47,6 +47,15 @@ export interface ICarouselProps<T> {
    */
   disableAnimation?: boolean;
   /**
+   * @description Wrap around at both ends, so the pager never sits at a content
+   * edge. Opt-in: at an edge the platform pager hands the horizontal gesture to
+   * its parent, which is what a nested carousel needs to avoid (OK-61479,
+   * OK-61516), but a standalone carousel may want the edge to be felt.
+   * Ignored for a single page, which has nothing to wrap around.
+   * @default false
+   */
+  infinite?: boolean;
+  /**
    * @platform native
    * @description Props for the PagerView component
    */

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -756,7 +756,7 @@ function ProtocolLendingActionDefiContent({
     };
     try {
       await Keyboard.dismissWithDelay(80);
-      await submitProtocolPositionAction({
+      const started = await submitProtocolPositionAction({
         action: source.action,
         selectedAssets: [selectedAsset],
         amount,
@@ -775,6 +775,12 @@ function ProtocolLendingActionDefiContent({
         onConfirmFail: releaseSubmitGuardOnceWithError,
         onConfirmCancel: releaseSubmitGuardOnce,
       });
+      // false means the flow never started (the risk disclaimer was declined,
+      // say): no callback fires and nothing throws, so the guard taken above is
+      // ours to release or the footer stays stuck loading forever.
+      if (started === false) {
+        releaseSubmitGuardOnce();
+      }
     } catch (error) {
       if (
         !isActionDialogClosed &&
@@ -1413,7 +1419,7 @@ function ProtocolLendingActionBorrowContent({
         providerDetailName: protocolInfo?.providerDetail.name,
       });
       if (actionType === 'repay') {
-        await handleBorrowRepay({
+        const repayStarted = await handleBorrowRepay({
           amount,
           provider,
           marketAddress,
@@ -1439,9 +1445,15 @@ function ProtocolLendingActionBorrowContent({
           onFail: releaseSubmitGuardOnceWithError,
           onCancel: releaseSubmitGuardOnce,
         });
+        // false means the flow never started (the risk disclaimer was declined,
+        // say): no callback fires and nothing throws, so the guard taken above
+        // is ours to release or the footer stays stuck loading forever.
+        if (repayStarted === false) {
+          releaseSubmitGuardOnce();
+        }
         return;
       }
-      await handleBorrowWithdraw({
+      const withdrawStarted = await handleBorrowWithdraw({
         amount,
         provider,
         marketAddress,
@@ -1467,6 +1479,10 @@ function ProtocolLendingActionBorrowContent({
         onFail: releaseSubmitGuardOnceWithError,
         onCancel: releaseSubmitGuardOnce,
       });
+      // Same "never started" release as the repay branch above.
+      if (withdrawStarted === false) {
+        releaseSubmitGuardOnce();
+      }
     } catch (error) {
       releaseSubmitGuardOnceWithError(error);
     }
@@ -1493,6 +1509,10 @@ function ProtocolLendingActionBorrowContent({
 
   const { needsApproval, approveLoading, onApprove } =
     useBorrowApproveAndSubmit({
+      // Labels the risk-disclaimer gate inside the approve step; without it the
+      // gate has no provider and silently lets the first on-chain action pass.
+      providerName: source.provider,
+      tokenSymbol: effectiveToken?.symbol,
       approveTarget,
       // useTrackTokenAllowance never fetches on mount - seed it with the
       // manage-page allowance, which tracks the selected reserve because

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -28,6 +28,7 @@ import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
 import { SendAutoSizeAmountInput } from '@onekeyhq/kit/src/views/Send/components/SendAutoSizeAmountInput';
+import { useEarnRiskWarningGate } from '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
@@ -852,6 +853,7 @@ function useProtocolPositionActionSubmit({
   ) => void | Promise<void>;
 }) {
   const intl = useIntl();
+  const ensureRiskAccepted = useEarnRiskWarningGate();
   const { navigationToMessageConfirmAsync, navigationToTxConfirm } =
     useSignatureConfirm({
       accountId,
@@ -871,9 +873,24 @@ function useProtocolPositionActionSubmit({
       onSettleResult,
       onConfirmFail,
       onConfirmCancel,
-    }: IProtocolPositionActionSubmitParams) => {
+    }: IProtocolPositionActionSubmitParams): Promise<boolean> => {
       if (selectedAssets.length === 0) {
         throw new OneKeyLocalError('DeFi action asset is missing');
+      }
+
+      // OK-59196: DeFi Portfolio one-click withdraw / claim / remove-liquidity
+      // build their own transactions and never reach the earn or borrow hooks,
+      // so this is the only place the one-time disclaimer can gate them.
+      // Returns false so a caller holding a submit guard can release it: no
+      // callback fires and nothing throws on this path.
+      if (
+        !(await ensureRiskAccepted({
+          provider: action.protocolId,
+          symbol: selectedAssets[0]?.symbol,
+          networkId,
+        }))
+      ) {
+        return false;
       }
 
       // The wire action for build-transaction; `action.action` keeps the
@@ -1083,6 +1100,8 @@ function useProtocolPositionActionSubmit({
         if (txConfirmInitError) {
           throw normalizeProtocolPositionActionError(txConfirmInitError);
         }
+
+        return true;
       } catch (error) {
         if (!isUserRejectedErrorMessage({ error, intl })) {
           if (isErrorToastSuppressed?.(error)) {
@@ -1096,6 +1115,7 @@ function useProtocolPositionActionSubmit({
     },
     [
       accountId,
+      ensureRiskAccepted,
       intl,
       navigationToMessageConfirmAsync,
       navigationToTxConfirm,
@@ -2013,7 +2033,7 @@ function ProtocolPositionActionDialogContent({
     };
     try {
       await Keyboard.dismissWithDelay(80);
-      await submitProtocolPositionAction({
+      const started = await submitProtocolPositionAction({
         action,
         selectedAssets,
         hasRewards,
@@ -2034,6 +2054,12 @@ function ProtocolPositionActionDialogContent({
         onConfirmFail: releaseSubmitGuardOnceWithError,
         onConfirmCancel: releaseSubmitGuardOnce,
       });
+      // false means the flow never started (the risk disclaimer was declined,
+      // say): no callback fires and nothing throws, so the guard taken above is
+      // ours to release or the footer stays stuck loading forever.
+      if (started === false) {
+        releaseSubmitGuardOnce();
+      }
     } catch (error) {
       if (
         !isActionDialogClosed &&

--- a/packages/kit/src/components/HyperlinkText/index.tsx
+++ b/packages/kit/src/components/HyperlinkText/index.tsx
@@ -10,11 +10,11 @@ import {
   getFontSize,
 } from '@onekeyhq/components';
 import type { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   openUrlExternal,
   openUrlInDiscovery,
 } from '@onekeyhq/shared/src/utils/openUrlUtils';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { isAllowedWebViewUrl } from '@onekeyhq/shared/src/utils/webViewUrlSafety';
 import { EQRCodeHandlerNames } from '@onekeyhq/shared/types/qrCode';
 

--- a/packages/kit/src/components/HyperlinkText/index.tsx
+++ b/packages/kit/src/components/HyperlinkText/index.tsx
@@ -12,8 +12,9 @@ import {
 import type { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   openUrlExternal,
-  openUrlInApp,
+  openUrlInDiscovery,
 } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { isAllowedWebViewUrl } from '@onekeyhq/shared/src/utils/webViewUrlSafety';
 import { EQRCodeHandlerNames } from '@onekeyhq/shared/types/qrCode';
 
@@ -207,9 +208,12 @@ export function HyperlinkText({
                 );
               },
               url: renderUrlChunk,
-              // Same link, opened inside the app so the page can talk to the
-              // wallet and closing it lands back on the page the link was on.
-              // <url> keeps handing plain web links to the system browser.
+              // Same link, kept inside the app so the page can talk to the
+              // wallet. It opens as a Discovery tab rather than a WebView
+              // overlay, so it joins the user's browser tabs and survives
+              // navigating away instead of being torn down with the screen it
+              // was opened from. <url> keeps handing plain web links to the
+              // system browser.
               urlInApp: (params: React.ReactNode[]) =>
                 renderUrlChunk(params, {
                   openWith: (link) => {
@@ -220,7 +224,14 @@ export function HyperlinkText({
                       openUrlExternal(link);
                       return;
                     }
-                    openUrlInApp(link, undefined, { enableDappBridge: true });
+                    // Discovery only exists on desktop and native; web and the
+                    // extension keep handing the link to the system browser,
+                    // the same fallback openUrlInApp made here before.
+                    if (!platformEnv.isNative && !platformEnv.isDesktop) {
+                      openUrlExternal(link);
+                      return;
+                    }
+                    openUrlInDiscovery({ url: link });
                   },
                   // The arrow reads as "leaves the app", which this one does not.
                   showExternalIndicator: false,

--- a/packages/kit/src/components/HyperlinkText/index.tsx
+++ b/packages/kit/src/components/HyperlinkText/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 import type { ReactElement } from 'react';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { createIntl, useIntl } from 'react-intl';
 
@@ -10,7 +10,11 @@ import {
   getFontSize,
 } from '@onekeyhq/components';
 import type { ETranslations } from '@onekeyhq/shared/src/locale';
-import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import {
+  openUrlExternal,
+  openUrlInApp,
+} from '@onekeyhq/shared/src/utils/openUrlUtils';
+import { isAllowedWebViewUrl } from '@onekeyhq/shared/src/utils/webViewUrlSafety';
 import { EQRCodeHandlerNames } from '@onekeyhq/shared/types/qrCode';
 
 import useParseQRCodeLazy from '../../views/ScanQrCode/hooks/useParseQRCodeLazy';
@@ -31,6 +35,13 @@ export type IHyperlinkTextProps = {
    * effects immediately, instead of returning parsed data for the caller.
    */
   autoExecuteParsedAction?: boolean;
+  /**
+   * Runs before a `<url>` link opens, and the open waits for it. Lets the host
+   * that owns the overlay this text sits in — a dialog, a sheet — dismiss
+   * itself first, instead of being left stacked behind the page the link
+   * navigates to (OK-61348).
+   */
+  onBeforeOpenUrl?: () => void | Promise<void>;
   urlTextProps?: ISizableTextProps;
   actionTextProps?: ISizableTextProps;
   underlineTextProps?: ISizableTextProps;
@@ -59,6 +70,7 @@ export function HyperlinkText({
   values,
   // HyperlinkText is action-oriented, so auto execution is enabled by default.
   autoExecuteParsedAction = true,
+  onBeforeOpenUrl,
   urlTextProps,
   actionTextProps,
   underlineTextProps,
@@ -93,6 +105,77 @@ export function HyperlinkText({
   // symptom only shows on web and desktop.
   const { numberOfLines, ellipse, ...inlineTextProps } = basicTextProps;
 
+  const renderUrlChunk = useCallback(
+    (
+      params: React.ReactNode[],
+      {
+        openWith = openUrlExternal,
+        showExternalIndicator = true,
+      }: {
+        openWith?: (link: string) => void;
+        showExternalIndicator?: boolean;
+      } = {},
+    ) => {
+      const [link, chunks] = params;
+      const isLinkString = typeof link === 'string';
+      const openUrl = () => {
+        setTimeout(() => {
+          onAction?.(isLinkString ? link : '');
+        }, 0);
+        if (isLinkString) {
+          void parseQRCode.parse(link, {
+            handlers: [
+              EQRCodeHandlerNames.marketDetail,
+              EQRCodeHandlerNames.sendProtection,
+              EQRCodeHandlerNames.rewardCenter,
+              EQRCodeHandlerNames.updatePreview,
+            ],
+            qrWalletScene: false,
+            autoExecuteParsedAction,
+            // OneKey deeplinks still resolve natively above; only a plain
+            // web link reaches this.
+            defaultHandler: openWith,
+          });
+        }
+      };
+      return (
+        <SizableText
+          {...inlineTextProps}
+          textDecorationLine="underline"
+          {...urlTextProps}
+          cursor="pointer"
+          hoverStyle={{ bg: '$bgHover' }}
+          pressStyle={{ bg: '$bgActive' }}
+          onPress={() => {
+            // Kept synchronous unless a caller opted in, so the existing press
+            // timing is untouched.
+            if (!onBeforeOpenUrl) {
+              openUrl();
+              return;
+            }
+            // The host (a dialog, a sheet) gets to dismiss itself first
+            // (OK-61348). Its failure must not swallow the link, so the open
+            // runs either way.
+            void Promise.resolve(onBeforeOpenUrl())
+              .catch(() => undefined)
+              .then(openUrl);
+          }}
+        >
+          {isLinkString ? chunks : link}
+          {autoExecuteParsedAction && showExternalIndicator ? ' ↗' : null}
+        </SizableText>
+      );
+    },
+    [
+      inlineTextProps,
+      urlTextProps,
+      onAction,
+      onBeforeOpenUrl,
+      parseQRCode,
+      autoExecuteParsedAction,
+    ],
+  );
+
   const text = useMemo(
     () =>
       translationId || defaultMessage
@@ -123,41 +206,25 @@ export function HyperlinkText({
                   </SizableText>
                 );
               },
-              url: (params: React.ReactNode[]) => {
-                const [link, chunks] = params;
-                const isLinkString = typeof link === 'string';
-                return (
-                  <SizableText
-                    {...inlineTextProps}
-                    textDecorationLine="underline"
-                    {...urlTextProps}
-                    cursor="pointer"
-                    hoverStyle={{ bg: '$bgHover' }}
-                    pressStyle={{ bg: '$bgActive' }}
-                    onPress={() => {
-                      setTimeout(() => {
-                        onAction?.(isLinkString ? link : '');
-                      }, 0);
-                      if (isLinkString) {
-                        void parseQRCode.parse(link, {
-                          handlers: [
-                            EQRCodeHandlerNames.marketDetail,
-                            EQRCodeHandlerNames.sendProtection,
-                            EQRCodeHandlerNames.rewardCenter,
-                            EQRCodeHandlerNames.updatePreview,
-                          ],
-                          qrWalletScene: false,
-                          autoExecuteParsedAction,
-                          defaultHandler: openUrlExternal,
-                        });
-                      }
-                    }}
-                  >
-                    {isLinkString ? chunks : link}
-                    {autoExecuteParsedAction ? ' ↗' : null}
-                  </SizableText>
-                );
-              },
+              url: renderUrlChunk,
+              // Same link, opened inside the app so the page can talk to the
+              // wallet and closing it lands back on the page the link was on.
+              // <url> keeps handing plain web links to the system browser.
+              urlInApp: (params: React.ReactNode[]) =>
+                renderUrlChunk(params, {
+                  openWith: (link) => {
+                    // The link comes from remote config, so apply the same
+                    // policy the WebView overlay uses (https, no credentials,
+                    // no local address, no punycode) before hosting it.
+                    if (!isAllowedWebViewUrl(link)) {
+                      openUrlExternal(link);
+                      return;
+                    }
+                    openUrlInApp(link, undefined, { enableDappBridge: true });
+                  },
+                  // The arrow reads as "leaves the app", which this one does not.
+                  showExternalIndicator: false,
+                }),
               subscripts: ([string]) => (
                 <SizableText
                   {...inlineTextProps}
@@ -245,9 +312,7 @@ export function HyperlinkText({
       inlineTextProps,
       actionTextProps,
       onAction,
-      urlTextProps,
-      parseQRCode,
-      autoExecuteParsedAction,
+      renderUrlChunk,
       scriptFontSize,
       subscriptsTextProps,
       underlineTextProps,

--- a/packages/kit/src/components/WebView/DesktopWebView.tsx
+++ b/packages/kit/src/components/WebView/DesktopWebView.tsx
@@ -339,6 +339,16 @@ const DesktopWebView = forwardRef(
             !onShouldStartLoadWithRequest({ url, isTopFrame: true })
           ) {
             webviewRef.current?.stop();
+            return;
+          }
+          // Electron does not raise `did-start-navigation` again for a 3xx
+          // target, so without this every consumer of onDidStartNavigation
+          // keeps the pre-redirect URL: the dApp modal would show the entry
+          // host in its header and notify account changes to the wrong origin,
+          // and a Discovery tab would keep the pre-redirect address. RN WebView
+          // reports the final URL, so this only closes a desktop-side gap.
+          if (isMainFrame) {
+            onDidStartNavigation?.(event);
           }
         };
 

--- a/packages/kit/src/components/WebView/WebViewWithFeatures.tsx
+++ b/packages/kit/src/components/WebView/WebViewWithFeatures.tsx
@@ -12,10 +12,19 @@ import type { IWebViewRef } from './types';
 export function WebViewWithFeatures(
   props: IWebViewProps & {
     features?: { notifyChangedEventsToDappOnFocus?: boolean };
+    /**
+     * Live URL of the page, when it can navigate away from `src`. The dApp
+     * notifications are addressed by origin, so after a cross-origin hop the
+     * initial `src` would target an origin that is no longer loaded and the
+     * page would never hear about an account or network switch. Kept separate
+     * from `src` on purpose: `src` is controlled, and moving it would reload
+     * the WebView on every navigation.
+     */
+    currentUrl?: string;
   },
 ) {
   const webviewRef = useRef<IWebViewRef | null>(null);
-  const { features, ...webviewProps } = props;
+  const { features, currentUrl, ...webviewProps } = props;
   const { onWebViewRef, src } = webviewProps;
   const handleWebViewRef = useCallback(
     (ref: IWebViewRef | null) => {
@@ -36,7 +45,7 @@ export function WebViewWithFeatures(
   useDAppNotifyChangesBase({
     getWebviewRef,
     isFocused,
-    url: src,
+    url: currentUrl || src,
     shouldSkipNotify,
   });
 

--- a/packages/kit/src/views/Borrow/components/BorrowClaimRewardsDialog.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowClaimRewardsDialog.tsx
@@ -183,8 +183,10 @@ function UnclaimableGroup({ group }: IUnclaimableGroupProps) {
 type IBorrowClaimRewardsDialogContentProps = {
   rewardsDetails: IEarnRewardsDetails;
   pendingClaimIds: string[];
-  onClaimItem: (item: IEarnRewardClaimItem) => Promise<void>;
-  onClaimAll: () => Promise<void>;
+  // Resolve false when the claim never started (the one-time risk disclaimer
+  // was declined), so this dialog stays open instead of vanishing on cancel.
+  onClaimItem: (item: IEarnRewardClaimItem) => Promise<boolean | void>;
+  onClaimAll: () => Promise<boolean | void>;
 };
 
 function BorrowClaimRewardsDialogContent({
@@ -214,8 +216,10 @@ function BorrowClaimRewardsDialogContent({
     async (item: IEarnRewardClaimItem) => {
       setClaimingItemId(item.id);
       try {
-        await onClaimItem(item);
-        void dialogInstance.close();
+        const started = await onClaimItem(item);
+        if (started !== false) {
+          void dialogInstance.close();
+        }
       } finally {
         setClaimingItemId(null);
       }
@@ -309,8 +313,10 @@ export function showBorrowClaimRewardsDialog({
 }: {
   rewardsDetails: IEarnRewardsDetails;
   pendingClaimIds?: string[];
-  onClaimItem: (item: IEarnRewardClaimItem) => Promise<void>;
-  onClaimAll: () => Promise<void>;
+  // See the content props: false keeps this dialog open, for a claim that never
+  // started because the risk disclaimer was declined.
+  onClaimItem: (item: IEarnRewardClaimItem) => Promise<boolean | void>;
+  onClaimAll: () => Promise<boolean | void>;
   onClose?: () => void;
 }) {
   return Dialog.show({

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
@@ -166,6 +166,8 @@ const approveTarget: IManagePositionApproveTarget = {
 
 describe('useBorrowApproveAndSubmit', () => {
   beforeEach(() => {
+    // Only the call log; the default "accepted" implementation stays.
+    mockEnsureRiskAccepted.mockClear();
     mockBag.allowance = '0';
     mockBag.loadingAllowance = false;
     mockBag.fetchAllowanceResponse.mockReset();
@@ -310,6 +312,40 @@ describe('useBorrowApproveAndSubmit', () => {
         await result.current.onApprove();
       });
 
+      expect(mockBag.navigationToTxConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens a single approval when the button is tapped twice while the disclaimer is being read', async () => {
+      // The gate is a bg round-trip, and `approveLoading` only disables the
+      // button on the next render, so without a synchronous lock both taps get
+      // through and two approvals are sent.
+      let releaseGate: (accepted: boolean) => void = () => {};
+      mockEnsureRiskAccepted.mockReturnValueOnce(
+        new Promise<boolean>((resolve) => {
+          releaseGate = resolve;
+        }),
+      );
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useBorrowApproveAndSubmit({
+          providerName: 'aave_v3',
+          tokenSymbol: 'USDC',
+          approveTarget,
+          currentAllowance: '0',
+          amountValue: '10',
+          onSubmit,
+        }),
+      );
+
+      await act(async () => {
+        const first = result.current.onApprove();
+        const second = result.current.onApprove();
+        releaseGate(true);
+        await Promise.all([first, second]);
+      });
+
+      expect(mockEnsureRiskAccepted).toHaveBeenCalledTimes(1);
       expect(mockBag.navigationToTxConfirm).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
@@ -1,5 +1,16 @@
 /* eslint-disable import/first */
 
+// The one-time DeFi risk disclaimer (OK-59196) gates every borrow trade hook.
+// Accept it by default here; the rejection path has its own test.
+const mockEnsureRiskAccepted = jest.fn(async () => true);
+jest.mock(
+  '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog',
+  () => ({
+    __esModule: true,
+    useEarnRiskWarningGate: () => mockEnsureRiskAccepted,
+  }),
+);
+
 jest.mock('react-intl', () => {
   const actualReactIntl =
     jest.requireActual<typeof import('react-intl')>('react-intl');
@@ -243,5 +254,63 @@ describe('useBorrowApproveAndSubmit', () => {
     expect(onBeforeNavigateConfirm).not.toHaveBeenCalled();
     expect(mockBag.navigationToTxConfirm).not.toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  describe('risk disclaimer gate (OK-59196)', () => {
+    it('stops before any on-chain step when the disclaimer is declined', async () => {
+      mockEnsureRiskAccepted.mockResolvedValueOnce(false);
+      const onBeforeNavigateConfirm = jest.fn();
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useBorrowApproveAndSubmit({
+          providerName: 'aave_v3',
+          tokenSymbol: 'USDC',
+          approveTarget,
+          currentAllowance: '0',
+          amountValue: '10',
+          onSubmit,
+          onBeforeNavigateConfirm,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onApprove();
+      });
+
+      expect(mockEnsureRiskAccepted).toHaveBeenCalledWith({
+        provider: 'aave_v3',
+        symbol: 'USDC',
+        networkId: approveTarget.networkId,
+      });
+      // Nothing started: no allowance fetch, no confirm page, and — crucially —
+      // the approve spinner was never taken, so the button is still usable.
+      expect(mockBag.fetchAllowanceResponse).not.toHaveBeenCalled();
+      expect(onBeforeNavigateConfirm).not.toHaveBeenCalled();
+      expect(mockBag.navigationToTxConfirm).not.toHaveBeenCalled();
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(result.current.approveLoading).toBe(false);
+    });
+
+    it('proceeds once the disclaimer is accepted', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useBorrowApproveAndSubmit({
+          providerName: 'aave_v3',
+          tokenSymbol: 'USDC',
+          approveTarget,
+          currentAllowance: '0',
+          amountValue: '10',
+          onSubmit,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onApprove();
+      });
+
+      expect(mockBag.navigationToTxConfirm).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
@@ -8,20 +8,26 @@ import { Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
+import { useEarnRiskWarningGate } from '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog';
 import { useTrackTokenAllowance } from '@onekeyhq/kit/src/views/Staking/hooks/useUtilsHooks';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EApproveType } from '@onekeyhq/shared/types/staking';
 
 import type { IManagePositionProps } from '../types';
 
 export function useBorrowApproveAndSubmit({
+  providerName,
+  tokenSymbol,
   approveTarget,
   currentAllowance,
   amountValue,
   onSubmit,
   onBeforeNavigateConfirm,
 }: {
+  providerName?: string;
+  tokenSymbol?: string;
   approveTarget?: IManagePositionProps['approveTarget'];
   currentAllowance?: string;
   amountValue: string;
@@ -33,6 +39,7 @@ export function useBorrowApproveAndSubmit({
   onApprove: () => Promise<void>;
 } {
   const intl = useIntl();
+  const ensureRiskAccepted = useEarnRiskWarningGate();
 
   const useApprove =
     !!approveTarget?.spenderAddress && !approveTarget?.token?.isNative;
@@ -196,6 +203,28 @@ export function useBorrowApproveAndSubmit({
 
   const onApprove = useCallback(async () => {
     if (!approveTarget?.token || !amountValue) return;
+    // OK-59196: the approve transaction is the user's first on-chain action in
+    // the two-step borrow flow and never reaches the borrow hooks, so the
+    // one-time disclaimer has to gate it here too. Before the approving lock:
+    // bailing after it would leave the button stuck loading.
+    // Fails open when the call site did not pass a provider — a broken gate
+    // must not block a trade — but that is loud in dev, because a silently
+    // skipped disclaimer is exactly how this shipped half-wired once.
+    if (!providerName && platformEnv.isDev) {
+      console.error(
+        '[useBorrowApproveAndSubmit] risk disclaimer skipped: pass providerName from the call site',
+      );
+    }
+    if (providerName) {
+      const riskAccepted = await ensureRiskAccepted({
+        provider: providerName,
+        symbol: tokenSymbol,
+        networkId: approveTarget.networkId,
+      });
+      if (!riskAccepted) {
+        return;
+      }
+    }
     const requestSnapshotKey = approveSnapshotKey;
     const requestOnSubmit = onSubmit;
     Keyboard.dismiss();
@@ -313,12 +342,15 @@ export function useBorrowApproveAndSubmit({
     amountValue,
     approveSnapshotKey,
     approveTarget,
+    ensureRiskAccepted,
     fetchAllowanceResponse,
     intl,
     isCurrentApproveRequest,
     navigationToTxConfirm,
     onBeforeNavigateConfirm,
     onSubmit,
+    providerName,
+    tokenSymbol,
     trackAllowance,
     waitForAllowanceAfterApprove,
   ]);

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
@@ -44,6 +44,15 @@ export function useBorrowApproveAndSubmit({
   const useApprove =
     !!approveTarget?.spenderAddress && !approveTarget?.token?.isNative;
   const [approving, setApproving] = useState(false);
+  // Synchronous mirror of `approving`. React only disables the button on the
+  // next render, and the disclaimer gate below adds a bg round-trip in front of
+  // it, so the state alone leaves a window where two quick taps both get
+  // through. Every write goes through updateApproving so the two stay in sync.
+  const approvingRef = useRef(false);
+  const updateApproving = useCallback((next: boolean) => {
+    approvingRef.current = next;
+    setApproving(next);
+  }, []);
   const allowanceAbortRef = useRef<AbortController | undefined>(undefined);
   const { navigationToTxConfirm } = useSignatureConfirm({
     accountId: approveTarget?.accountId ?? '',
@@ -110,9 +119,11 @@ export function useBorrowApproveAndSubmit({
     if (!isSameRequest) {
       allowanceAbortRef.current?.abort();
       allowanceAbortRef.current = undefined;
-      setApproving(false);
+      // Releases the synchronous lock as well; leaving it held would keep
+      // onApprove returning early for the rest of the session.
+      updateApproving(false);
     }
-  }, [approveSnapshotKey, onSubmit]);
+  }, [approveSnapshotKey, onSubmit, updateApproving]);
 
   const isCurrentApproveRequest = useCallback(
     ({
@@ -203,10 +214,14 @@ export function useBorrowApproveAndSubmit({
 
   const onApprove = useCallback(async () => {
     if (!approveTarget?.token || !amountValue) return;
+    // Claim the lock before the first await, so a second tap arriving while the
+    // disclaimer is being read cannot open a parallel approval.
+    if (approvingRef.current) return;
+    approvingRef.current = true;
     // OK-59196: the approve transaction is the user's first on-chain action in
     // the two-step borrow flow and never reaches the borrow hooks, so the
-    // one-time disclaimer has to gate it here too. Before the approving lock:
-    // bailing after it would leave the button stuck loading.
+    // one-time disclaimer has to gate it here too. It runs before the visible
+    // loading state: bailing after that would leave the button stuck loading.
     // Fails open when the call site did not pass a provider — a broken gate
     // must not block a trade — but that is loud in dev, because a silently
     // skipped disclaimer is exactly how this shipped half-wired once.
@@ -222,13 +237,14 @@ export function useBorrowApproveAndSubmit({
         networkId: approveTarget.networkId,
       });
       if (!riskAccepted) {
+        approvingRef.current = false;
         return;
       }
     }
     const requestSnapshotKey = approveSnapshotKey;
     const requestOnSubmit = onSubmit;
     Keyboard.dismiss();
-    setApproving(true);
+    updateApproving(true);
 
     let approveAllowance = allowance;
     try {
@@ -241,7 +257,7 @@ export function useBorrowApproveAndSubmit({
     const allowanceBN = new BigNumber(approveAllowance || '0');
     const amountBN = new BigNumber(amountValue || '0');
     if (!amountBN.isNaN() && allowanceBN.gte(amountBN)) {
-      setApproving(false);
+      updateApproving(false);
       if (
         isCurrentApproveRequest({
           snapshotKey: requestSnapshotKey,
@@ -276,7 +292,7 @@ export function useBorrowApproveAndSubmit({
               submit: requestOnSubmit,
             })
           ) {
-            setApproving(false);
+            updateApproving(false);
             return;
           }
           trackAllowance(data[0].decodedTx.txid);
@@ -322,19 +338,19 @@ export function useBorrowApproveAndSubmit({
                       }),
               });
             } finally {
-              setApproving(false);
+              updateApproving(false);
             }
           })();
         },
         onFail() {
-          setApproving(false);
+          updateApproving(false);
         },
         onCancel() {
-          setApproving(false);
+          updateApproving(false);
         },
       });
     } catch (error) {
-      setApproving(false);
+      updateApproving(false);
       throw error;
     }
   }, [
@@ -352,6 +368,7 @@ export function useBorrowApproveAndSubmit({
     providerName,
     tokenSymbol,
     trackAllowance,
+    updateApproving,
     waitForAllowanceAfterApprove,
   ]);
 

--- a/packages/kit/src/views/Borrow/components/ManagePosition/index.tsx
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/index.tsx
@@ -108,11 +108,17 @@ export function ManagePosition(props: IManagePositionProps) {
   const submitBorrowAction = useCallback(async () => {
     if (!onConfirm) return;
 
-    await onConfirm({
+    const started = await onConfirm({
       amount: amountValue,
       withdrawAll: baseState.isWithdrawAll,
       repayAll: baseState.isRepayAll,
     });
+
+    // The disclaimer was rejected, so nothing was submitted: keep the amount
+    // the user typed instead of clearing the form.
+    if (started === false) {
+      return;
+    }
 
     setAmountValue('');
   }, [
@@ -125,6 +131,8 @@ export function ManagePosition(props: IManagePositionProps) {
 
   const { needsApproval, approveLoading, onApprove } =
     useBorrowApproveAndSubmit({
+      providerName,
+      tokenSymbol,
       approveTarget,
       currentAllowance,
       amountValue,

--- a/packages/kit/src/views/Borrow/components/ManagePosition/types.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/types.ts
@@ -74,7 +74,9 @@ export interface IManagePositionProps {
   currentAllowance?: string;
 
   // Callbacks
-  onConfirm?: (params: IManagePositionConfirmParams) => Promise<void>;
+  // Resolves false when the flow never started (the user rejected the risk
+  // disclaimer, say), so the form can keep what the user typed.
+  onConfirm?: (params: IManagePositionConfirmParams) => Promise<boolean | void>;
 }
 
 // ============================================================================

--- a/packages/kit/src/views/Borrow/components/Overview.tsx
+++ b/packages/kit/src/views/Borrow/components/Overview.tsx
@@ -315,7 +315,7 @@ export const Overview = ({
             }),
           ],
         };
-        await handleBorrowClaim({
+        return handleBorrowClaim({
           provider,
           marketAddress,
           ids: [item.id],
@@ -341,7 +341,7 @@ export const Overview = ({
             }),
           ],
         };
-        await handleBorrowClaim({
+        return handleBorrowClaim({
           provider,
           marketAddress,
           ids: allIds,

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.test.tsx
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.test.tsx
@@ -1,5 +1,16 @@
 /* eslint-disable import/first */
 
+// The one-time DeFi risk disclaimer (OK-59196) gates every borrow trade hook.
+// Accept it by default here; the rejection path has its own test.
+const mockEnsureRiskAccepted = jest.fn(async () => true);
+jest.mock(
+  '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog',
+  () => ({
+    __esModule: true,
+    useEarnRiskWarningGate: () => mockEnsureRiskAccepted,
+  }),
+);
+
 jest.mock('react-intl', () => {
   const actualReactIntl =
     jest.requireActual<typeof import('react-intl')>('react-intl');

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
@@ -6,6 +6,7 @@ import { Toast } from '@onekeyhq/components';
 import type { IEncodedTx } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
+import { useEarnRiskWarningGate } from '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
@@ -24,6 +25,7 @@ import {
 import {
   type IBorrowBuildTxParams,
   attachBorrowOrderId,
+  getRiskGateSymbol,
   handleBorrowSuccess,
   parseBorrowEncodedTx,
   useUniversalBorrowRepay,
@@ -146,6 +148,8 @@ export function useUniversalBorrowSupply({
     networkId,
   });
 
+  const ensureRiskAccepted = useEarnRiskWarningGate();
+
   return useCallback(
     async ({
       amount,
@@ -155,7 +159,20 @@ export function useUniversalBorrowSupply({
       stakingInfo,
       onSuccess,
       onFail,
-    }: IBorrowBuildTxParams) => {
+    }: IBorrowBuildTxParams): Promise<boolean> => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses. Returns false so the caller can tell a rejection apart from a
+      // completed hand-off and leave the form untouched.
+      if (
+        !(await ensureRiskAccepted({
+          provider,
+          symbol: getRiskGateSymbol(stakingInfo),
+          networkId,
+        }))
+      ) {
+        return false;
+      }
+
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildSupplyTransaction({
           networkId,
@@ -186,8 +203,10 @@ export function useUniversalBorrowSupply({
         },
         onFail,
       });
+
+      return true;
     },
-    [accountId, networkId, navigationToTxConfirm],
+    [accountId, ensureRiskAccepted, networkId, navigationToTxConfirm],
   );
 }
 
@@ -203,6 +222,8 @@ export function useUniversalBorrowBorrow({
     networkId,
   });
 
+  const ensureRiskAccepted = useEarnRiskWarningGate();
+
   return useCallback(
     async ({
       amount,
@@ -212,7 +233,20 @@ export function useUniversalBorrowBorrow({
       stakingInfo,
       onSuccess,
       onFail,
-    }: IBorrowBuildTxParams) => {
+    }: IBorrowBuildTxParams): Promise<boolean> => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses. Returns false so the caller can tell a rejection apart from a
+      // completed hand-off and leave the form untouched.
+      if (
+        !(await ensureRiskAccepted({
+          provider,
+          symbol: getRiskGateSymbol(stakingInfo),
+          networkId,
+        }))
+      ) {
+        return false;
+      }
+
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildBorrowTransaction({
           networkId,
@@ -243,8 +277,10 @@ export function useUniversalBorrowBorrow({
         },
         onFail,
       });
+
+      return true;
     },
-    [accountId, networkId, navigationToTxConfirm],
+    [accountId, ensureRiskAccepted, networkId, navigationToTxConfirm],
   );
 }
 
@@ -256,6 +292,7 @@ export function useUniversalBorrowRepayWithCollateral({
   accountId: string;
 }) {
   const intl = useIntl();
+  const ensureRiskAccepted = useEarnRiskWarningGate();
   const { navigationToTxConfirm } = useSignatureConfirm({
     accountId,
     networkId,
@@ -314,6 +351,18 @@ export function useUniversalBorrowRepayWithCollateral({
       onSuccess,
       onFail,
     }: IBorrowBuildTxParams): Promise<boolean> => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses.
+      if (
+        !(await ensureRiskAccepted({
+          provider,
+          symbol: getRiskGateSymbol(stakingInfo),
+          networkId,
+        }))
+      ) {
+        return false;
+      }
+
       try {
         let setupLutFinalizationResult:
           | 'finalized'
@@ -485,7 +534,7 @@ export function useUniversalBorrowRepayWithCollateral({
         return false;
       }
     },
-    [accountId, intl, networkId, waitForTxConfirmResult],
+    [accountId, ensureRiskAccepted, intl, networkId, waitForTxConfirmResult],
   );
 }
 
@@ -510,6 +559,8 @@ export function useUniversalBorrowClaim({
     networkId,
   });
 
+  const ensureRiskAccepted = useEarnRiskWarningGate();
+
   return useCallback(
     async ({
       provider,
@@ -518,7 +569,19 @@ export function useUniversalBorrowClaim({
       stakingInfo,
       onSuccess,
       onFail,
-    }: IBorrowClaimTxParams) => {
+    }: IBorrowClaimTxParams): Promise<boolean> => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses.
+      if (
+        !(await ensureRiskAccepted({
+          provider,
+          symbol: getRiskGateSymbol(stakingInfo),
+          networkId,
+        }))
+      ) {
+        return false;
+      }
+
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildClaimTransaction({
           networkId,
@@ -548,7 +611,9 @@ export function useUniversalBorrowClaim({
         },
         onFail,
       });
+
+      return true;
     },
-    [accountId, networkId, navigationToTxConfirm],
+    [accountId, ensureRiskAccepted, networkId, navigationToTxConfirm],
   );
 }

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts
@@ -7,6 +7,7 @@ import {
   showDeFiActionTxConfirmDialog,
 } from '@onekeyhq/kit/src/components/DeFi/DeFiActionTxConfirmResult';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
+import { useEarnRiskWarningGate } from '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog';
 import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
 import { EOnChainHistoryTxStatus } from '@onekeyhq/shared/types/history';
 import { EEarnLabels, type IStakingInfo } from '@onekeyhq/shared/types/staking';
@@ -38,6 +39,11 @@ export type IBorrowBuildTxParams = {
   onFail?: IModalSendParamList['SendConfirm']['onFail'];
   onCancel?: IModalSendParamList['SendConfirm']['onCancel'];
 };
+
+// The dialog logs which asset the user was about to trade; borrow params carry
+// the token on stakingInfo rather than as a plain symbol.
+export const getRiskGateSymbol = (stakingInfo?: IStakingInfo) =>
+  stakingInfo?.send?.token.symbol ?? stakingInfo?.receive?.token.symbol;
 
 export function parseBorrowEncodedTx(tx: string): IEncodedTx {
   try {
@@ -142,6 +148,13 @@ export const handleBorrowSuccess = async ({
   onSuccess?.(data);
 };
 
+/**
+ * Resolves true once the flow has been handed to the transaction confirm page,
+ * false when it never started — today only a declined risk disclaimer, but the
+ * point is that no callback fires and nothing throws on that path. A caller
+ * that took a lock (submit guard, spinner) before calling MUST release it on
+ * false; `onSuccess` / `onFail` / `onCancel` are never invoked.
+ */
 export function useUniversalBorrowWithdraw({
   networkId,
   accountId,
@@ -153,6 +166,8 @@ export function useUniversalBorrowWithdraw({
     accountId,
     networkId,
   });
+
+  const ensureRiskAccepted = useEarnRiskWarningGate();
 
   return useCallback(
     async ({
@@ -167,7 +182,20 @@ export function useUniversalBorrowWithdraw({
       onSuccess,
       onFail,
       onCancel,
-    }: IBorrowBuildTxParams) => {
+    }: IBorrowBuildTxParams): Promise<boolean> => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses. Returns false so the caller can tell a rejection apart from a
+      // completed hand-off and leave the form untouched.
+      if (
+        !(await ensureRiskAccepted({
+          provider,
+          symbol: getRiskGateSymbol(stakingInfo),
+          networkId,
+        }))
+      ) {
+        return false;
+      }
+
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildWithdrawTransaction({
           networkId,
@@ -203,11 +231,20 @@ export function useUniversalBorrowWithdraw({
         onFail,
         onCancel,
       });
+
+      return true;
     },
-    [accountId, networkId, navigationToTxConfirm],
+    [accountId, ensureRiskAccepted, networkId, navigationToTxConfirm],
   );
 }
 
+/**
+ * Resolves true once the flow has been handed to the transaction confirm page,
+ * false when it never started — today only a declined risk disclaimer, but the
+ * point is that no callback fires and nothing throws on that path. A caller
+ * that took a lock (submit guard, spinner) before calling MUST release it on
+ * false; `onSuccess` / `onFail` / `onCancel` are never invoked.
+ */
 export function useUniversalBorrowRepay({
   networkId,
   accountId,
@@ -219,6 +256,8 @@ export function useUniversalBorrowRepay({
     accountId,
     networkId,
   });
+
+  const ensureRiskAccepted = useEarnRiskWarningGate();
 
   return useCallback(
     async ({
@@ -233,7 +272,20 @@ export function useUniversalBorrowRepay({
       onSuccess,
       onFail,
       onCancel,
-    }: IBorrowBuildTxParams) => {
+    }: IBorrowBuildTxParams): Promise<boolean> => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses. Returns false so the caller can tell a rejection apart from a
+      // completed hand-off and leave the form untouched.
+      if (
+        !(await ensureRiskAccepted({
+          provider,
+          symbol: getRiskGateSymbol(stakingInfo),
+          networkId,
+        }))
+      ) {
+        return false;
+      }
+
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildRepayTransaction({
           networkId,
@@ -269,7 +321,9 @@ export function useUniversalBorrowRepay({
         onFail,
         onCancel,
       });
+
+      return true;
     },
-    [accountId, networkId, navigationToTxConfirm],
+    [accountId, ensureRiskAccepted, networkId, navigationToTxConfirm],
   );
 }

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -13,8 +13,6 @@ import Animated, {
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { Stack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
-import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import type { IEarnBorrowPagerViewRef } from '../../Earn/components/EarnBorrowPagerView';
@@ -124,22 +122,11 @@ function OuterTabPagerViewComponent({
   const outerPagerRef = useAnimatedRef<PagerView>();
   const currentOuterIndexRef = useRef(initialPage);
   const [activePageIndex, setActivePageIndex] = useState(initialPage);
-  // OK-59246: pause outer horizontal scrolling while the earn home banner
-  // (a nested horizontal pager) is being dragged, otherwise the outer pager
-  // steals the gesture and switches top tabs
-  const [isEarnBannerDragging, setIsEarnBannerDragging] = useState(false);
-  useEffect(() => {
-    const listener = (payload: { dragging: boolean }) => {
-      setIsEarnBannerDragging(payload.dragging);
-    };
-    appEventBus.on(EAppEventBusNames.EarnHomeBannerDragStateChanged, listener);
-    return () => {
-      appEventBus.off(
-        EAppEventBusNames.EarnHomeBannerDragStateChanged,
-        listener,
-      );
-    };
-  }, []);
+  // OK-59246 used to pause this pager while the earn banner was being dragged.
+  // Flipping scrollEnabled on a native pager mid-gesture is itself a hazard
+  // (OK-61515), and it never covered the header's own RNGH tab-switch pan. The
+  // banner now keeps the gesture by looping (so it is never at a content edge)
+  // and the header excludes the banner area, so no lock is needed here.
   const wasUserDragRef = useRef(false);
   const isProgrammaticSwitchRef = useRef(false);
   const [isOuterPageTransitioning, setIsOuterPageTransitioning] =
@@ -494,7 +481,7 @@ function OuterTabPagerViewComponent({
       ref={outerPagerRef}
       style={styles.pager}
       initialPage={initialPage}
-      scrollEnabled={showDiscoveryPage && !isEarnBannerDragging}
+      scrollEnabled={showDiscoveryPage}
       overdrag
       overScrollMode="always"
       scrollSensitivity={4}

--- a/packages/kit/src/views/Earn/components/EarnHomeBanner.tsx
+++ b/packages/kit/src/views/Earn/components/EarnHomeBanner.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
   XStack,
   YStack,
+  useCarouselPressSuppressor,
 } from '@onekeyhq/components';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import type { IEarnPageBannerListItem } from '@onekeyhq/shared/types/earn';
@@ -78,8 +79,12 @@ const BANNER_DEFAULT_COLORS = {
 } as const;
 
 function EarnHomeBannerItem({ item }: { item: IEarnPageBannerListItem }) {
+  // The pager owns the horizontal gesture natively, so this Pressable never
+  // sees the move that would cancel it — a swipe ends in a press. The carousel
+  // reports when one just happened so the navigation can be skipped.
+  const shouldSuppressPress = useCarouselPressSuppressor();
   const handlePress = useCallback(async () => {
-    if (!item.href) {
+    if (!item.href || shouldSuppressPress()) {
       return;
     }
     // Official universal links (e.g. earn detail page URLs) should navigate
@@ -93,7 +98,7 @@ function EarnHomeBannerItem({ item }: { item: IEarnPageBannerListItem }) {
       return;
     }
     handleDeepLinkUrl({ url: item.href });
-  }, [item.href, item.hrefType]);
+  }, [item.href, item.hrefType, shouldSuppressPress]);
 
   const hasImageCopy = Boolean(item.imageTitle || item.imageSubtitle);
 

--- a/packages/kit/src/views/Earn/components/EarnHomeBanner.tsx
+++ b/packages/kit/src/views/Earn/components/EarnHomeBanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { StyleSheet } from 'react-native';
 
@@ -11,9 +11,6 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
-import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import type { IEarnPageBannerListItem } from '@onekeyhq/shared/types/earn';
 
@@ -24,10 +21,9 @@ import {
 import { EarnTestIDs } from '../testIDs';
 
 const BANNER_HEIGHT = 200;
-// Upper bound on how long the outer tab pager may stay locked for a banner
-// drag. Comfortably longer than any real swipe, short enough that a cancelled
-// gesture does not strand tab switching.
-const BANNER_DRAG_RELEASE_TIMEOUT = 1500;
+// Total height of the banner block (card + pagination row), also handed to the
+// header's gesture wrapper so it can exclude this area from the tab-switch pan.
+export const EARN_HOME_BANNER_BLOCK_HEIGHT = 248;
 // $pagePadding ($5) split into container padding + per-card margin, so the
 // card still lands on the design's 353pt width while its drop shadow has room
 // to fall inside the pager's clipping viewport. Both halves are s()-scaled
@@ -334,64 +330,14 @@ export function EarnHomeBanner({
     [],
   );
 
-  // OK-59246: the banner pager is nested inside the Discovery outer pager
-  // (market / DeFi / browser) — both are horizontal react-native-pager-views,
-  // and the outer one would win the gesture and switch top tabs mid-swipe.
-  // Report drag state so the outer pager pauses its own scrolling while the
-  // user is swiping the banner.
-  //
-  // Only a real finger drag counts. `settling` is also emitted by the 5s
-  // autoplay's programmatic setPage() — and autoplay never pauses on native
-  // (the Carousel's visibility observer is web-only) — so treating it as a
-  // drag would disable the outer pager for ~300ms every 5s even while the
-  // user sits on another top tab. After the finger lifts the gesture owner
-  // is already decided, so `settling` needs no gating either.
-  // Safety net for the outer-pager lock below. The lock is released by the
-  // 'settling'/'idle' that normally follows a drag, but a gesture cancelled by
-  // the OS (call, app switch, the pager being unmounted mid-swipe) can skip
-  // them, and a stuck lock means horizontal tab switching is dead until
-  // remount — one of the symptoms behind OK-60606.
-  const bannerDragReleaseTimerRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  const setOuterPagerBlocked = useCallback((dragging: boolean) => {
-    if (bannerDragReleaseTimerRef.current) {
-      clearTimeout(bannerDragReleaseTimerRef.current);
-      bannerDragReleaseTimerRef.current = null;
-    }
-    appEventBus.emit(EAppEventBusNames.EarnHomeBannerDragStateChanged, {
-      dragging,
-    });
-    if (dragging) {
-      bannerDragReleaseTimerRef.current = setTimeout(() => {
-        bannerDragReleaseTimerRef.current = null;
-        appEventBus.emit(EAppEventBusNames.EarnHomeBannerDragStateChanged, {
-          dragging: false,
-        });
-      }, BANNER_DRAG_RELEASE_TIMEOUT);
-    }
-  }, []);
-
-  const handleBannerPageScrollStateChanged = useCallback(
-    (event: { nativeEvent: { pageScrollState: string } }) => {
-      // A single banner has nothing to page to, so its pager still reports
-      // 'dragging' while consuming a gesture it cannot act on. Locking the
-      // outer pager for that leaves both frozen and the user unable to switch
-      // tabs from anywhere over the card (OK-60606).
-      if (validBanners.length <= 1) {
-        return;
-      }
-      setOuterPagerBlocked(event.nativeEvent.pageScrollState === 'dragging');
-    },
-    [setOuterPagerBlocked, validBanners.length],
-  );
-  useEffect(
-    () => () => {
-      // Never leave the outer pager blocked if the banner unmounts mid-drag
-      setOuterPagerBlocked(false);
-    },
-    [setOuterPagerBlocked],
-  );
+  // OK-59246 used to be handled here by reporting drag state on an event bus so
+  // OuterTabPagerView could flip its own scrollEnabled mid-gesture. That is
+  // gone: the tab-switch gesture over this area is now the header's RNGH pan
+  // (excluded by EARN_HOME_BANNER_BLOCK_HEIGHT in EarnMobileHomeContent), and
+  // `infinite` below keeps this pager off its content edges, which is where the
+  // platform pager hands the horizontal gesture to its parent in the first
+  // place. Mutating a native pager's props during a drag is what OK-61515 is
+  // most likely about, so the lock is not replaced by another one.
 
   if (validBanners.length === 0) {
     return null;
@@ -400,20 +346,20 @@ export function EarnHomeBanner({
   return (
     <YStack
       testID={EarnTestIDs.banner}
-      h={248}
+      h={EARN_HOME_BANNER_BLOCK_HEIGHT}
       px={BANNER_CONTAINER_PADDING}
       pb="$4"
     >
       <Carousel
         data={validBanners}
         renderItem={renderItem}
-        pagerProps={
-          platformEnv.isNative
-            ? { onPageScrollStateChanged: handleBannerPageScrollStateChanged }
-            : undefined
-        }
         autoPlayInterval={5000}
         loop={validBanners.length > 1}
+        // OK-61479: swiping past the last card must wrap instead of dead-ending.
+        // It also keeps the pager off its content edges, where iOS/Android hand
+        // the horizontal gesture up to the parent pager and switch the top tab
+        // mid-swipe (OK-61516).
+        infinite
         showPagination={validBanners.length > 1}
         // Extra 16px of height: render room for the card's drop shadow;
         // otherwise the Carousel viewport clips it and the depth effect is

--- a/packages/kit/src/views/Earn/components/EarnMobileHomeContent.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMobileHomeContent.tsx
@@ -14,7 +14,10 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IEarnPageBannerListItem } from '@onekeyhq/shared/types/earn';
 
 import { AvailableAssetsFlatList } from './AvailableAssetsFlatList';
-import { EarnHomeBanner } from './EarnHomeBanner';
+import {
+  EARN_HOME_BANNER_BLOCK_HEIGHT,
+  EarnHomeBanner,
+} from './EarnHomeBanner';
 import { EarnHomeShortcuts } from './EarnHomeShortcuts';
 import { EARN_SECTION_GAP } from './earnListRhythm';
 import { FAQContent } from './FAQContent';
@@ -85,6 +88,12 @@ function EarnMobileHomeContentComponent({
       <HeaderScrollGestureWrapper
         onHorizontalSwipe={onHeaderHorizontalSwipe}
         disableVerticalScroll
+        // OK-61516: the banner is the bottom-most block inside this wrapper, and
+        // the wrapper's horizontal pan (activeOffsetX 10) sits right on top of
+        // it — so every banner swipe also armed the top-tab switch. Exclude the
+        // banner's own height, the same escape hatch MarketDetailV2 uses for its
+        // chart.
+        excludeBottomEdgeHeight={EARN_HOME_BANNER_BLOCK_HEIGHT}
       >
         {/* Token spacing, not raw numbers: narrow Android screens scale the
             token scale by 0.9 and a literal would not follow (OK-59904) */}

--- a/packages/kit/src/views/Earn/components/RiskNoticeDialog.tsx
+++ b/packages/kit/src/views/Earn/components/RiskNoticeDialog.tsx
@@ -1,7 +1,13 @@
 import { useCallback, useState } from 'react';
 
 import type { ICheckedState } from '@onekeyhq/components';
-import { Checkbox, Dialog, XStack, YStack } from '@onekeyhq/components';
+import {
+  Checkbox,
+  Dialog,
+  XStack,
+  YStack,
+  useDialogInstance,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IEarnRiskNoticeDialog } from '@onekeyhq/shared/types/staking';
 
@@ -24,10 +30,19 @@ function RiskNoticeDialogContent({
   riskNoticeDialogContent: IEarnRiskNoticeDialog;
 }) {
   const [checkboxState, setCheckboxState] = useState<ICheckedState>(false);
+  const dialogInstance = useDialogInstance();
 
   const handleCheckboxChange = useCallback((value: ICheckedState) => {
     setCheckboxState(value);
   }, []);
+
+  // A link in the notice navigates away from this dialog, so the dialog has to
+  // go first (OK-61348): it lives in its own overlay while the page is pushed
+  // onto the navigation stack, and would otherwise still be sitting there when
+  // the user comes back. Awaited so the two do not animate over each other.
+  const handleBeforeOpenUrl = useCallback(async () => {
+    await dialogInstance.close();
+  }, [dialogInstance]);
 
   const handleConfirm = useCallback(
     () =>
@@ -62,6 +77,7 @@ function RiskNoticeDialogContent({
         size="$bodyMd"
         text={riskNoticeDialogContent.description}
         color="$text"
+        onBeforeOpenUrl={handleBeforeOpenUrl}
       />
 
       {riskNoticeDialogContent.checkboxes.map((checkbox) => (

--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -5,7 +5,6 @@ import {
   WEB_APP_URL,
   WEB_APP_URL_DEV,
 } from '@onekeyhq/shared/src/config/appConfig';
-import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -20,6 +19,11 @@ import {
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { shouldResetEarnRouteStackBeforePush } from './utils/earnNavigationPolicy';
+import {
+  getNetworkIdByShareName,
+  getShareNameByNetworkId,
+  getShareNetworkParam,
+} from './utils/earnShareNetworkUtils';
 
 import type { IAppNavigation } from '../../hooks/useAppNavigation';
 
@@ -30,22 +34,6 @@ type IEarnHomeTab = NonNullable<IEarnHomeParams['tab']>;
 
 const DEFAULT_EARN_HOME_TAB: IEarnHomeTab = 'assets';
 const EARN_HOME_TABS = new Set<IEarnHomeTab>(['assets', 'portfolio', 'faqs']);
-
-const NetworkNameToIdMap: Record<string, string> = {
-  ethereum: getNetworkIdsMap().eth,
-  btc: getNetworkIdsMap().btc,
-  sui: getNetworkIdsMap().sui,
-  solana: getNetworkIdsMap().sol,
-  aptos: getNetworkIdsMap().apt,
-  cosmos: getNetworkIdsMap().cosmoshub,
-  sbtc: getNetworkIdsMap().sbtc,
-  bsc: getNetworkIdsMap().bsc,
-  base: getNetworkIdsMap().base,
-};
-
-const NetworkIdToNameMap: Record<string, string> = Object.fromEntries(
-  Object.entries(NetworkNameToIdMap).map(([name, id]) => [id, name]),
-);
 
 function getEarnTargetTab() {
   return platformEnv.isNative ? ETabRoutes.Discovery : ETabRoutes.Earn;
@@ -132,19 +120,13 @@ function persistNativeEarnHomeTab(tab: IEarnHomeTab) {
 
 export const EarnNetworkUtils = {
   // convert network name to network id
-  getNetworkIdByName(networkName: string): string | undefined {
-    return NetworkNameToIdMap[networkName.toLowerCase()];
-  },
+  getNetworkIdByName: getNetworkIdByShareName,
 
   // convert network id to network name
-  getNetworkNameById(networkId: string): string | undefined {
-    return NetworkIdToNameMap[networkId];
-  },
+  getNetworkNameById: getShareNameByNetworkId,
 
   // generate share link network param
-  getShareNetworkParam(networkId: string): string {
-    return this.getNetworkNameById(networkId) || 'unknown';
-  },
+  getShareNetworkParam,
 };
 
 export async function safePushToEarnRoute(

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/components/ProtocolTipsSection.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/components/ProtocolTipsSection.tsx
@@ -6,6 +6,7 @@ import { StyleSheet } from 'react-native';
 import {
   Dialog,
   Divider,
+  ScrollView,
   SizableText,
   YStack,
   useDialogInstance,
@@ -13,6 +14,11 @@ import {
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IStakeEarnDetail } from '@onekeyhq/shared/types/staking';
+
+// Tips are dashboard-authored and can run long: several entries, each with a
+// multi-paragraph description. Without a ceiling the dialog grows past the
+// viewport on both phone and desktop and the end of the copy is unreachable.
+const PROTOCOL_TIPS_DIALOG_MAX_HEIGHT = 512;
 
 type IProtocolTips = NonNullable<IStakeEarnDetail['protocolTips']>;
 type IProtocolTipItem = IProtocolTips['tips'][number];
@@ -60,14 +66,16 @@ function ProtocolTipsDialogContent({ tips }: { tips: IProtocolTipItem[] }) {
   }, [dialogInstance]);
 
   return (
-    <YStack gap="$4" pb="$2">
-      {tips.map((tip, index) => (
-        <YStack key={index} gap="$4">
-          {index > 0 ? <Divider /> : null}
-          <ProtocolTipRow tip={tip} onBeforeOpenUrl={handleBeforeOpenUrl} />
-        </YStack>
-      ))}
-    </YStack>
+    <ScrollView maxHeight={PROTOCOL_TIPS_DIALOG_MAX_HEIGHT} nestedScrollEnabled>
+      <YStack gap="$4" pb="$2">
+        {tips.map((tip, index) => (
+          <YStack key={index} gap="$4">
+            {index > 0 ? <Divider /> : null}
+            <ProtocolTipRow tip={tip} onBeforeOpenUrl={handleBeforeOpenUrl} />
+          </YStack>
+        ))}
+      </YStack>
+    </ScrollView>
   );
 }
 
@@ -93,6 +101,10 @@ export function ProtocolTipsSection({
     Dialog.show({
       title: protocolTipsHeader,
       showFooter: false,
+      // The tips scroll internally, and on phones the sheet's own drag-to-close
+      // competes with that scroll for the same vertical gesture. Overlay press
+      // and the system back button still close it.
+      disableDrag: true,
       renderContent: <ProtocolTipsDialogContent tips={tips} />,
     });
   }, [protocolTipsHeader, tips]);

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/components/ProtocolTipsSection.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/components/ProtocolTipsSection.tsx
@@ -3,7 +3,13 @@ import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
-import { Dialog, Divider, SizableText, YStack } from '@onekeyhq/components';
+import {
+  Dialog,
+  Divider,
+  SizableText,
+  YStack,
+  useDialogInstance,
+} from '@onekeyhq/components';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IStakeEarnDetail } from '@onekeyhq/shared/types/staking';
@@ -18,11 +24,49 @@ function pickInlineTip(tips: IProtocolTipItem[]): IProtocolTipItem {
   return tips.find((tip) => tip.showDefault) ?? tips[0];
 }
 
-function ProtocolTipRow({ tip }: { tip: IProtocolTipItem }) {
+function ProtocolTipRow({
+  tip,
+  onBeforeOpenUrl,
+}: {
+  tip: IProtocolTipItem;
+  onBeforeOpenUrl?: () => Promise<void>;
+}) {
   return (
     <YStack gap="$1">
-      <EarnText text={tip.title} size="$bodyMdMedium" />
-      <EarnText text={tip.description} size="$bodyMd" color="$textSubdued" />
+      <EarnText
+        text={tip.title}
+        size="$bodyMdMedium"
+        onBeforeOpenUrl={onBeforeOpenUrl}
+      />
+      <EarnText
+        text={tip.description}
+        size="$bodyMd"
+        color="$textSubdued"
+        onBeforeOpenUrl={onBeforeOpenUrl}
+      />
+    </YStack>
+  );
+}
+
+// A tip link navigates away from this dialog, so the dialog has to go first
+// (OK-61348): it lives in its own overlay while the page is pushed onto the
+// navigation stack, and would otherwise still be sitting there when the user
+// comes back — on native it stays stacked under the page the whole time.
+// Awaited so the dismissal and the push do not animate over each other.
+function ProtocolTipsDialogContent({ tips }: { tips: IProtocolTipItem[] }) {
+  const dialogInstance = useDialogInstance();
+  const handleBeforeOpenUrl = useCallback(async () => {
+    await dialogInstance.close();
+  }, [dialogInstance]);
+
+  return (
+    <YStack gap="$4" pb="$2">
+      {tips.map((tip, index) => (
+        <YStack key={index} gap="$4">
+          {index > 0 ? <Divider /> : null}
+          <ProtocolTipRow tip={tip} onBeforeOpenUrl={handleBeforeOpenUrl} />
+        </YStack>
+      ))}
     </YStack>
   );
 }
@@ -49,16 +93,7 @@ export function ProtocolTipsSection({
     Dialog.show({
       title: protocolTipsHeader,
       showFooter: false,
-      renderContent: (
-        <YStack gap="$4" pb="$2">
-          {tips.map((tip, index) => (
-            <YStack key={index} gap="$4">
-              {index > 0 ? <Divider /> : null}
-              <ProtocolTipRow tip={tip} />
-            </YStack>
-          ))}
-        </YStack>
-      ),
+      renderContent: <ProtocolTipsDialogContent tips={tips} />,
     });
   }, [protocolTipsHeader, tips]);
 

--- a/packages/kit/src/views/Earn/utils/earnShareNetworkUtils.test.ts
+++ b/packages/kit/src/views/Earn/utils/earnShareNetworkUtils.test.ts
@@ -1,0 +1,80 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+
+import {
+  UNKNOWN_SHARE_NETWORK_NAME,
+  getNetworkIdByShareName,
+  getShareNameByNetworkId,
+  getShareNetworkParam,
+} from './earnShareNetworkUtils';
+
+describe('earnShareNetworkUtils', () => {
+  describe('legacy names', () => {
+    it.each([
+      ['ethereum', 'eth'],
+      ['solana', 'sol'],
+      ['aptos', 'apt'],
+      ['cosmos', 'cosmoshub'],
+      ['btc', 'btc'],
+      ['sui', 'sui'],
+      ['sbtc', 'sbtc'],
+      ['bsc', 'bsc'],
+      ['base', 'base'],
+    ] as const)(
+      'keeps generating and resolving "%s"',
+      (shareName, shortcode) => {
+        const networkId = getNetworkIdsMap()[shortcode];
+        expect(getShareNetworkParam(networkId)).toBe(shareName);
+        expect(getNetworkIdByShareName(shareName)).toBe(networkId);
+      },
+    );
+
+    it('resolves legacy names case-insensitively', () => {
+      expect(getNetworkIdByShareName('Ethereum')).toBe(getNetworkIdsMap().eth);
+    });
+
+    it('still resolves the shortcode of a legacy network', () => {
+      // Generation prefers "ethereum", but a hand-written /earn/eth/... link
+      // must not 404.
+      expect(getNetworkIdByShareName('eth')).toBe(getNetworkIdsMap().eth);
+    });
+  });
+
+  describe('networks outside the legacy list (OK-61675)', () => {
+    it('names Katana by its shortcode instead of unknown', () => {
+      const katanaNetworkId = getNetworkIdsMap().katana;
+      expect(getShareNetworkParam(katanaNetworkId)).toBe('katana');
+      expect(getShareNetworkParam(katanaNetworkId)).not.toBe(
+        UNKNOWN_SHARE_NETWORK_NAME,
+      );
+    });
+
+    it('round-trips every preset network', () => {
+      Object.values(getNetworkIdsMap()).forEach((networkId) => {
+        const shareName = getShareNetworkParam(networkId);
+        expect(shareName).not.toBe(UNKNOWN_SHARE_NETWORK_NAME);
+        expect(getNetworkIdByShareName(shareName)).toBe(networkId);
+      });
+    });
+
+    it('accepts a raw network id as the share segment', () => {
+      const katanaNetworkId = getNetworkIdsMap().katana;
+      expect(getNetworkIdByShareName(katanaNetworkId)).toBe(katanaNetworkId);
+    });
+  });
+
+  describe('unresolvable input', () => {
+    it.each(['', 'unknown', 'not-a-network', 'evm--999999'])(
+      'returns undefined for %p',
+      (networkName) => {
+        expect(getNetworkIdByShareName(networkName)).toBeUndefined();
+      },
+    );
+
+    it('falls back to unknown for a non-preset network id', () => {
+      expect(getShareNameByNetworkId('evm--999999')).toBeUndefined();
+      expect(getShareNetworkParam('evm--999999')).toBe(
+        UNKNOWN_SHARE_NETWORK_NAME,
+      );
+    });
+  });
+});

--- a/packages/kit/src/views/Earn/utils/earnShareNetworkUtils.ts
+++ b/packages/kit/src/views/Earn/utils/earnShareNetworkUtils.ts
@@ -1,0 +1,103 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
+
+// Slug used when a network cannot be named at all. It is not a valid route
+// param: the detail page rejects it, so it only ever means "this link is
+// broken" — keep it as the last resort, never as a normal path (OK-61675).
+export const UNKNOWN_SHARE_NETWORK_NAME = 'unknown';
+
+// The names Earn share links have used since the feature shipped. They stay
+// canonical in both directions: links already shared point at these spellings,
+// and generating the raw shortcode instead would change the URL of every
+// network listed here (eth -> ethereum, sol -> solana, apt -> aptos,
+// cosmoshub -> cosmos).
+const getLegacyNameToNetworkIdMap = memoFn<Record<string, string>>(() => {
+  const networkIdsMap = getNetworkIdsMap();
+  return {
+    ethereum: networkIdsMap.eth,
+    btc: networkIdsMap.btc,
+    sui: networkIdsMap.sui,
+    solana: networkIdsMap.sol,
+    aptos: networkIdsMap.apt,
+    cosmos: networkIdsMap.cosmoshub,
+    sbtc: networkIdsMap.sbtc,
+    bsc: networkIdsMap.bsc,
+    base: networkIdsMap.base,
+  };
+});
+
+const getLegacyNetworkIdToNameMap = memoFn<Record<string, string>>(() =>
+  Object.fromEntries(
+    Object.entries(getLegacyNameToNetworkIdMap()).map(([name, id]) => [
+      id,
+      name,
+    ]),
+  ),
+);
+
+// Every preset network carries a shortcode, and getNetworkIdsMap() is already
+// keyed by it. Falling back to it means a network added after the legacy list
+// above (Katana, Arbitrum, ...) gets a working slug for free instead of
+// generating /earn/unknown/... which nothing can resolve.
+// Lower-cased on the way in and out: a handful of shortcodes are camelCase
+// (assetHub, ksmAssetHub) and a URL segment must survive a round trip through
+// anything that normalizes case.
+const getNetworkIdToShortcodeSlugMap = memoFn<Record<string, string>>(() =>
+  Object.fromEntries(
+    Object.entries(getNetworkIdsMap()).map(([shortcode, id]) => [
+      id,
+      shortcode.toLowerCase(),
+    ]),
+  ),
+);
+
+const getShortcodeSlugToNetworkIdMap = memoFn<Record<string, string>>(() =>
+  Object.fromEntries(
+    Object.entries(getNetworkIdToShortcodeSlugMap()).map(([id, slug]) => [
+      slug,
+      id,
+    ]),
+  ),
+);
+
+/**
+ * Resolve the network id behind a share-link `:network` segment.
+ * Accepts, in order: the legacy names above, any preset network shortcode, and
+ * a raw network id (hand-written links and links generated before the network
+ * had a slug both carry one).
+ */
+export function getNetworkIdByShareName(
+  networkName: string,
+): string | undefined {
+  if (!networkName) {
+    return undefined;
+  }
+  const normalized = networkName.toLowerCase();
+  const legacyNetworkId = getLegacyNameToNetworkIdMap()[normalized];
+  if (legacyNetworkId) {
+    return legacyNetworkId;
+  }
+  const shortcodeNetworkId = getShortcodeSlugToNetworkIdMap()[normalized];
+  if (shortcodeNetworkId) {
+    return shortcodeNetworkId;
+  }
+  return getNetworkIdToShortcodeSlugMap()[normalized] ? normalized : undefined;
+}
+
+/**
+ * Reverse of {@link getNetworkIdByShareName}. Returns undefined only for a
+ * network that is not preset at all.
+ */
+export function getShareNameByNetworkId(networkId: string): string | undefined {
+  if (!networkId) {
+    return undefined;
+  }
+  return (
+    getLegacyNetworkIdToNameMap()[networkId] ??
+    getNetworkIdToShortcodeSlugMap()[networkId]
+  );
+}
+
+export function getShareNetworkParam(networkId: string): string {
+  return getShareNameByNetworkId(networkId) ?? UNKNOWN_SHARE_NETWORK_NAME;
+}

--- a/packages/kit/src/views/Staking/components/EarnRiskWarningDialog.tsx
+++ b/packages/kit/src/views/Staking/components/EarnRiskWarningDialog.tsx
@@ -208,3 +208,30 @@ export async function showEarnRiskWarningDialog({
     });
   });
 }
+
+/**
+ * Hook form of {@link showEarnRiskWarningDialog} for the trade hooks: it owns
+ * the localized title so every gate stays worded the same, and resolves true
+ * when the user may proceed (immediately so, once accepted on this device).
+ */
+export function useEarnRiskWarningGate() {
+  const intl = useIntl();
+  return useCallback(
+    ({
+      provider,
+      symbol,
+      networkId,
+    }: {
+      provider: string;
+      symbol?: string;
+      networkId?: string;
+    }) =>
+      showEarnRiskWarningDialog({
+        provider,
+        symbol: symbol ?? '',
+        networkId,
+        title: intl.formatMessage({ id: ETranslations.global_warning }),
+      }),
+    [intl],
+  );
+}

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -451,7 +451,11 @@ type IUniversalStakeProps = {
   currentAllowance?: string;
 
   approveType?: EApproveType;
-  onConfirm?: (params: IApproveConfirmFnParams) => Promise<void>;
+  // Resolves false when the flow never started (risk disclaimer rejected, a
+  // pre-flight check failed), so the form keeps the amount the user typed.
+  // Deliberately not `boolean | void`: a caller that forgets to return the
+  // hook's result would silently reset the form.
+  onConfirm?: (params: IApproveConfirmFnParams) => Promise<boolean>;
   onFeeRateChange?: (rate: string) => void;
 
   tokenInfo?: IEarnTokenInfo;
@@ -1349,18 +1353,20 @@ export function UniversalStake({
       }
     }
 
-    // OK-59196 (review P2): gate here, before submitting/wrap progress state
-    // transitions, so rejecting the risk dialog leaves the form untouched —
-    // the gate inside useUniversalStake would otherwise return void and the
-    // caller would resetAmount() as if the flow had completed
-    const earnRiskConfirmed = await showEarnRiskWarningDialog({
-      provider: providerName,
-      symbol: actionSymbol,
-      networkId,
-      title: intl.formatMessage({ id: ETranslations.global_warning }),
-    });
-    if (!earnRiskConfirmed) {
-      return;
+    // OK-59196: Stakefish signs a provider-facing message before any hook runs,
+    // so the disclaimer has to gate this pre-transaction step. Not a duplicate
+    // of the gate inside useUniversalStake — that one only covers the transaction
+    // itself, and once accepted this call resolves immediately.
+    if (isStakefishEthStake && !stakefishPermitSignatureRef.current) {
+      const riskAcceptedBeforeSigning = await showEarnRiskWarningDialog({
+        provider: providerName,
+        symbol: actionSymbol,
+        networkId,
+        title: intl.formatMessage({ id: ETranslations.global_warning }),
+      });
+      if (!riskAcceptedBeforeSigning) {
+        return;
+      }
     }
 
     // Stakefish ETH: sign before building the staking transaction.
@@ -1436,7 +1442,7 @@ export function UniversalStake({
           setStakeProgressStep(EStakeProgressStep.approve);
         }
 
-        await onConfirm?.({
+        const started = await onConfirm?.({
           amount: amountValue,
           effectiveApy: transactionConfirmation?.effectiveApy,
           stakeType,
@@ -1444,6 +1450,11 @@ export function UniversalStake({
           ...permitSignatureParams,
           ...stakefishParams,
         });
+        // The disclaimer was rejected, so nothing was submitted: leave the form
+        // and the progress step exactly as the user left them.
+        if (started === false) {
+          return;
+        }
         resetAmount();
         // Auto-refresh quote countdown after swap completes
         onQuoteReset?.();

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -693,6 +693,15 @@ export function UniversalWithdraw({
   const useApprove =
     (isPendleProvider || isQueuedWithdraw) && !!approveTarget?.spenderAddress;
   const [approving, setApproving] = useState(false);
+  // Synchronous mirror of `approving`. React only disables the button on the
+  // next render, and the disclaimer gate below adds a bg round-trip in front of
+  // it, so the state alone leaves a window where two quick taps both get
+  // through. Every write goes through updateApproving so the two stay in sync.
+  const approvingRef = useRef(false);
+  const updateApproving = useCallback((next: boolean) => {
+    approvingRef.current = next;
+    setApproving(next);
+  }, []);
   const allowanceAbortRef = useRef<AbortController | undefined>(undefined);
 
   const ensureRiskAccepted = useEarnRiskWarningGate();
@@ -794,10 +803,14 @@ export function UniversalWithdraw({
 
   const onApprove = useCallback(async () => {
     if (!approveTarget?.token || !approveAmountValue) return;
+    // Claim the lock before the first await, so a second tap arriving while the
+    // disclaimer is being read cannot open a parallel approval.
+    if (approvingRef.current) return;
+    approvingRef.current = true;
     // OK-59196: the approve transaction is the user's first on-chain action in
     // the two-step withdraw flow and never reaches useUniversalWithdraw, so the
-    // one-time disclaimer has to gate it here too. Before the approving lock:
-    // bailing after it would leave the button stuck loading.
+    // one-time disclaimer has to gate it here too. It runs before the visible
+    // loading state: bailing after that would leave the button stuck loading.
     if (
       !(await ensureRiskAccepted({
         provider: providerName ?? '',
@@ -805,10 +818,11 @@ export function UniversalWithdraw({
         networkId,
       }))
     ) {
+      approvingRef.current = false;
       return;
     }
     Keyboard.dismiss();
-    setApproving(true);
+    updateApproving(true);
 
     let approveAllowance = allowance;
     try {
@@ -822,7 +836,7 @@ export function UniversalWithdraw({
     const amountBN = new BigNumber(approveAmountValue);
     if (!amountBN.isNaN() && allowanceBN.gte(amountBN)) {
       // Already approved
-      setApproving(false);
+      updateApproving(false);
       return;
     }
 
@@ -856,15 +870,15 @@ export function UniversalWithdraw({
             }
             await onPressRef.current?.();
           } finally {
-            setApproving(false);
+            updateApproving(false);
           }
         })();
       },
       onFail() {
-        setApproving(false);
+        updateApproving(false);
       },
       onCancel() {
-        setApproving(false);
+        updateApproving(false);
       },
     });
   }, [
@@ -878,6 +892,7 @@ export function UniversalWithdraw({
     navigationToTxConfirm,
     fetchAllowanceResponse,
     trackAllowance,
+    updateApproving,
     waitForAllowanceAfterApprove,
   ]);
   const actionSymbol = useMemo(
@@ -1015,6 +1030,20 @@ export function UniversalWithdraw({
         withdrawAllRef.current &&
         !withdrawSignatureRef.current
       ) {
+        // OK-59196: this message is signed for the provider before anything
+        // reaches useUniversalWithdraw, so the disclaimer has to gate it here —
+        // otherwise declining happens after the signature already exists. Not a
+        // duplicate of the gate inside the hook: once accepted this resolves
+        // immediately. Mirrors the stake side in UniversalStake.
+        if (
+          !(await ensureRiskAccepted({
+            provider: providerName ?? '',
+            symbol: actionSymbol ?? '',
+            networkId,
+          }))
+        ) {
+          return;
+        }
         try {
           const { signature, message } = await signPersonalMessage({
             networkId: networkId || '',
@@ -1105,6 +1134,7 @@ export function UniversalWithdraw({
     }
   }, [
     amountValue,
+    ensureRiskAccepted,
     onConfirm,
     onQuoteReset,
     resetAmount,

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -36,6 +36,7 @@ import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRo
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import { useBrowserAction } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
 import { validateAmountInputForStaking } from '@onekeyhq/kit/src/utils/validateAmountInput';
+import { useEarnRiskWarningGate } from '@onekeyhq/kit/src/views/Staking/components/EarnRiskWarningDialog';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -176,7 +177,11 @@ type IUniversalWithdrawProps = {
     onStepChange?: (step: number) => void;
     onEthenaCooldownUnstakeReady?: () => void;
     withdrawType?: IEarnWithdrawType;
-  }) => Promise<void>;
+    // Resolves false when the flow never started (risk disclaimer rejected), so
+    // the form keeps the amount the user typed. Deliberately not
+    // `boolean | void`: a caller that forgets to return the hook's result would
+    // silently reset the form, which is how this shipped half-wired once.
+  }) => Promise<boolean>;
   beforeFooter?: ReactElement | null;
   footerActionOverride?: IFooterActionOverride;
   showApyDetail?: boolean;
@@ -690,6 +695,7 @@ export function UniversalWithdraw({
   const [approving, setApproving] = useState(false);
   const allowanceAbortRef = useRef<AbortController | undefined>(undefined);
 
+  const ensureRiskAccepted = useEarnRiskWarningGate();
   const { navigationToTxConfirm } = useSignatureConfirm({
     accountId: approveTarget?.accountId ?? '',
     networkId: approveTarget?.networkId ?? '',
@@ -788,6 +794,19 @@ export function UniversalWithdraw({
 
   const onApprove = useCallback(async () => {
     if (!approveTarget?.token || !approveAmountValue) return;
+    // OK-59196: the approve transaction is the user's first on-chain action in
+    // the two-step withdraw flow and never reaches useUniversalWithdraw, so the
+    // one-time disclaimer has to gate it here too. Before the approving lock:
+    // bailing after it would leave the button stuck loading.
+    if (
+      !(await ensureRiskAccepted({
+        provider: providerName ?? '',
+        symbol: tokenSymbol,
+        networkId,
+      }))
+    ) {
+      return;
+    }
     Keyboard.dismiss();
     setApproving(true);
 
@@ -852,6 +871,10 @@ export function UniversalWithdraw({
     allowance,
     approveAmountValue,
     approveTarget,
+    ensureRiskAccepted,
+    networkId,
+    providerName,
+    tokenSymbol,
     navigationToTxConfirm,
     fetchAllowanceResponse,
     trackAllowance,
@@ -1034,7 +1057,7 @@ export function UniversalWithdraw({
         }
       }
 
-      await onConfirm?.({
+      const started = await onConfirm?.({
         amount: isCancelWithdrawal ? '0' : amountValue,
         withdrawAll: withdrawAllRef.current,
         signature: withdrawSignatureRef.current,
@@ -1060,6 +1083,11 @@ export function UniversalWithdraw({
             }
           : undefined,
       });
+      // The disclaimer was rejected, so nothing was submitted: leave the form
+      // and the progress step exactly as the user left them.
+      if (started === false) {
+        return;
+      }
       if (shouldUseEthenaCooldown) {
         if (ethenaCooldownCompletedRef.current) {
           resetAmount();

--- a/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
@@ -315,6 +315,11 @@ export function useUniversalStake({
           networkId,
         });
 
+        // Past this point the wrap has been signed and broadcast, so the flow
+        // has started whatever happens next: these bail-outs resolve true so
+        // the caller clears the form. Resolving false would keep the amount
+        // primed and turn a single tap into a second wrap of the same funds —
+        // the wrap step has no resume, it always starts from the beginning.
         const wrapTxId =
           wrapConfirmResult.data[0]?.signedTx?.txid ??
           wrapConfirmResult.data[0]?.decodedTx?.txid;
@@ -324,7 +329,7 @@ export function useUniversalStake({
               id: ETranslations.global_failed,
             }),
           });
-          return false;
+          return true;
         }
 
         const wrapStatus = await waitForTxFinalStatus({
@@ -333,12 +338,14 @@ export function useUniversalStake({
           txid: wrapTxId,
         });
         if (wrapStatus !== EOnChainHistoryTxStatus.Success) {
+          // Covers a reverted wrap and a status poll that timed out; the two
+          // are not distinguishable here, so assume the funds moved.
           Toast.error({
             title: intl.formatMessage({
               id: ETranslations.global_failed,
             }),
           });
-          return false;
+          return true;
         }
 
         const postWrapStakingInfo = stakingInfo
@@ -426,11 +433,13 @@ export function useUniversalStake({
             });
           } catch (error) {
             onFail?.(error as Error);
-            return false;
+            return true;
           }
 
           if (approveConfirmResult.status !== 'success') {
-            return false;
+            // Declining the approval leaves the user holding the wrapped
+            // token; the stake can be finished from the wrapped balance.
+            return true;
           }
 
           await timerUtils.wait(150);
@@ -442,7 +451,7 @@ export function useUniversalStake({
                 id: ETranslations.global_failed,
               }),
             });
-            return false;
+            return true;
           }
 
           onStepChange?.(3);

--- a/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
@@ -32,7 +32,10 @@ import {
 import type { IToken } from '@onekeyhq/shared/types/token';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
-import { showEarnRiskWarningDialog } from '../components/EarnRiskWarningDialog';
+import {
+  showEarnRiskWarningDialog,
+  useEarnRiskWarningGate,
+} from '../components/EarnRiskWarningDialog';
 import { useShowClaimEstimateGasAlert } from '../components/EstimateNetworkFee';
 
 const createStakeInfoWithOrderId = ({
@@ -211,7 +214,7 @@ export function useUniversalStake({
         title: intl.formatMessage({ id: ETranslations.global_warning }),
       });
       if (!riskConfirmed) {
-        return;
+        return false;
       }
       const buildStakeConfirmPayload = async ({
         confirmStakeType = stakeType,
@@ -299,11 +302,11 @@ export function useUniversalStake({
           });
         } catch (error) {
           onFail?.(error as Error);
-          return;
+          return false;
         }
 
         if (wrapConfirmResult.status !== 'success') {
-          return;
+          return false;
         }
 
         await handleStakeSuccess({
@@ -321,7 +324,7 @@ export function useUniversalStake({
               id: ETranslations.global_failed,
             }),
           });
-          return;
+          return false;
         }
 
         const wrapStatus = await waitForTxFinalStatus({
@@ -335,7 +338,7 @@ export function useUniversalStake({
               id: ETranslations.global_failed,
             }),
           });
-          return;
+          return false;
         }
 
         const postWrapStakingInfo = stakingInfo
@@ -423,11 +426,11 @@ export function useUniversalStake({
             });
           } catch (error) {
             onFail?.(error as Error);
-            return;
+            return false;
           }
 
           if (approveConfirmResult.status !== 'success') {
-            return;
+            return false;
           }
 
           await timerUtils.wait(150);
@@ -439,7 +442,7 @@ export function useUniversalStake({
                 id: ETranslations.global_failed,
               }),
             });
-            return;
+            return false;
           }
 
           onStepChange?.(3);
@@ -466,7 +469,7 @@ export function useUniversalStake({
           useFeeInTx: normalConfirmPayload.useFeeInTx,
           feeInfoEditable: normalConfirmPayload.feeInfoEditable,
         });
-        return;
+        return true;
       }
 
       const stakeConfirmPayload = await buildStakeConfirmPayload();
@@ -486,6 +489,8 @@ export function useUniversalStake({
         useFeeInTx: stakeConfirmPayload.useFeeInTx,
         feeInfoEditable: stakeConfirmPayload.feeInfoEditable,
       });
+
+      return true;
     },
     [accountId, intl, networkId, navigationToTxConfirm, waitForTxConfirmResult],
   );
@@ -549,6 +554,8 @@ export function useUniversalWithdraw({
       }),
     [navigationToTxConfirm],
   );
+  const ensureRiskAccepted = useEarnRiskWarningGate();
+
   return useCallback(
     async ({
       amount,
@@ -597,6 +604,13 @@ export function useUniversalWithdraw({
       onEthenaCooldownUnstakeReady?: () => void;
       signal?: AbortSignal;
     }) => {
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses. Returning false lets the caller tell a rejection apart from a
+      // completed hand-off and leave the form untouched.
+      if (!(await ensureRiskAccepted({ provider, symbol, networkId }))) {
+        return false;
+      }
+
       let stakeTx: IStakeTxResponse | undefined;
       const stakingConfig =
         await backgroundApiProxy.serviceStaking.getStakingConfigs({
@@ -689,11 +703,11 @@ export function useUniversalWithdraw({
             });
           } catch (error) {
             onFail?.(error as Error);
-            return;
+            return false;
           }
 
           if (unstakeConfirmResult.status !== 'success') {
-            return;
+            return false;
           }
 
           onStepChange?.(3);
@@ -707,7 +721,7 @@ export function useUniversalWithdraw({
 
         if (resumeEthenaCooldownUnstake) {
           await openEthenaCooldownUnstakeConfirm();
-          return;
+          return true;
         }
 
         // Ethena two-step: 1) swap PT-sUSDe → sUSDe, 2) unstake sUSDe → USDe
@@ -748,11 +762,11 @@ export function useUniversalWithdraw({
           });
         } catch (error) {
           onFail?.(error as Error);
-          return;
+          return false;
         }
 
         if (swapConfirmResult.status !== 'success') {
-          return;
+          return false;
         }
 
         await handleStakeSuccess({
@@ -762,7 +776,7 @@ export function useUniversalWithdraw({
         });
 
         if (signal?.aborted) {
-          return;
+          return false;
         }
 
         onStepChange?.(2);
@@ -785,12 +799,12 @@ export function useUniversalWithdraw({
                 }),
               });
             }
-            return;
+            return false;
           }
         }
 
         if (signal?.aborted) {
-          return;
+          return false;
         }
 
         onEthenaCooldownUnstakeReady?.();
@@ -800,11 +814,11 @@ export function useUniversalWithdraw({
         await timerUtils.wait(150);
 
         if (signal?.aborted) {
-          return;
+          return false;
         }
 
         await openEthenaCooldownUnstakeConfirm();
-        return;
+        return true;
       } else {
         stakeTx =
           await backgroundApiProxy.serviceStaking.buildUnstakeTransaction({
@@ -836,7 +850,7 @@ export function useUniversalWithdraw({
           }),
         });
         onSuccess?.([]);
-        return;
+        return true;
       }
 
       const encodedTx =
@@ -893,8 +907,17 @@ export function useUniversalWithdraw({
         },
         onFail,
       });
+
+      return true;
     },
-    [accountId, networkId, navigationToTxConfirm, waitForTxConfirmResult, intl],
+    [
+      accountId,
+      ensureRiskAccepted,
+      networkId,
+      navigationToTxConfirm,
+      waitForTxConfirmResult,
+      intl,
+    ],
   );
 }
 
@@ -910,6 +933,8 @@ export function useUniversalClaim({
     networkId,
   });
   const showClaimEstimateGasAlert = useShowClaimEstimateGasAlert();
+  const ensureRiskAccepted = useEarnRiskWarningGate();
+
   return useCallback(
     async ({
       identity,
@@ -942,6 +967,12 @@ export function useUniversalClaim({
       const normalizedAmount = amountNumber.isNaN()
         ? '0'
         : amountNumber.toFixed();
+      // OK-59196: one-time DeFi risk disclaimer, same gate the earn stake flow
+      // uses.
+      if (!(await ensureRiskAccepted({ provider, symbol, networkId }))) {
+        return false;
+      }
+
       const continueClaim = async () => {
         const stakeTx =
           await backgroundApiProxy.serviceStaking.buildClaimTransaction({
@@ -1021,12 +1052,22 @@ export function useUniversalClaim({
               estFiatValue: estimateFeeResp.feeFiatValue,
               onConfirm: continueClaim,
             });
-            return;
+            // The alert owns the flow from here; it either continues or the
+            // user dismisses it, so the hand-off counts as started.
+            return true;
           }
         }
       }
       await continueClaim();
+
+      return true;
     },
-    [navigationToTxConfirm, accountId, networkId, showClaimEstimateGasAlert],
+    [
+      ensureRiskAccepted,
+      navigationToTxConfirm,
+      accountId,
+      networkId,
+      showClaimEstimateGasAlert,
+    ],
   );
 }

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/StakeSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/StakeSection.tsx
@@ -562,14 +562,15 @@ export const StakeSection = ({
       stakeType: confirmStakeType,
       onStepChange,
     }: IApproveConfirmFnParams) => {
-      if (!hasRequiredData) return;
+      // Nothing was started, so the form keeps what the user typed.
+      if (!hasRequiredData) return false;
 
       const token = effectiveStakeTokenInfo?.token as IToken;
       const effectiveStakeType = confirmStakeType ?? nativeStakeType;
 
-      if (borrowApiCtx.isBorrow) return;
+      if (borrowApiCtx.isBorrow) return false;
 
-      await handleStake({
+      return handleStake({
         amount,
         approveType,
         permitSignature,
@@ -678,7 +679,10 @@ export const StakeSection = ({
   const onBorrowConfirm = useCallback(
     async (params: IManagePositionConfirmParams) => {
       const { amount } = params;
-      if (!hasRequiredData || !borrowApiCtx.isBorrow) return;
+      if (!hasRequiredData || !borrowApiCtx.isBorrow) {
+        // Nothing was started, so the form keeps what the user typed.
+        return false;
+      }
 
       const token = tokenInfo?.token as IToken;
       const { provider, marketAddress, reserveAddress, action } =
@@ -694,7 +698,7 @@ export const StakeSection = ({
         tags.push(protocolInfo.stakeTag);
       }
 
-      await (action === 'borrow' ? handleBorrowBorrow : handleBorrowSupply)({
+      return (action === 'borrow' ? handleBorrowBorrow : handleBorrowSupply)({
         amount,
         provider,
         marketAddress,

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/WithdrawSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/WithdrawSection.tsx
@@ -561,15 +561,16 @@ export const WithdrawSection = ({
       onEthenaCooldownUnstakeReady?: () => void;
       withdrawType?: IEarnWithdrawType;
     }) => {
-      if (!hasRequiredData) return;
+      // Nothing was started, so the form keeps what the user typed.
+      if (!hasRequiredData) return false;
 
-      if (borrowApiCtx.isBorrow) return;
+      if (borrowApiCtx.isBorrow) return false;
 
       withdrawAbortRef.current?.abort();
       const abortController = new AbortController();
       withdrawAbortRef.current = abortController;
 
-      await handleWithdraw({
+      return handleWithdraw({
         amount,
         // identity,
         protocolVault: earnUtils.shouldSendEarnProtocolVault({
@@ -758,7 +759,8 @@ export const WithdrawSection = ({
       withdrawAll?: boolean;
       repayAll?: boolean;
     }) => {
-      if (!borrowApiCtx.isBorrow) return;
+      // Nothing was started, so the form keeps what the user typed.
+      if (!borrowApiCtx.isBorrow) return false;
 
       const { provider, marketAddress, action } = borrowApiCtx.borrowApiParams;
       // Use effective reserve address (from selected asset or default)
@@ -778,7 +780,7 @@ export const WithdrawSection = ({
       };
 
       if (action === 'repay') {
-        await handleBorrowRepay({
+        return handleBorrowRepay({
           amount,
           provider,
           marketAddress,
@@ -797,10 +799,9 @@ export const WithdrawSection = ({
             onSuccess?.();
           },
         });
-        return;
       }
 
-      await handleBorrowWithdraw({
+      return handleBorrowWithdraw({
         amount,
         provider,
         marketAddress,
@@ -1006,7 +1007,7 @@ export const WithdrawSection = ({
         accountId={accountId}
         networkId={networkId}
         providerName=""
-        onConfirm={async () => {}}
+        onConfirm={async () => false}
         protocolVault=""
         isDisabled
         isInModalContext={isInModalContext}

--- a/packages/kit/src/views/Staking/pages/Stake/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Stake/index.tsx
@@ -398,10 +398,11 @@ function BasicStakePage() {
       onStepChange,
     }: IApproveConfirmFnParams) => {
       if (!token) {
-        return;
+        // Nothing was started, so the form keeps what the user typed.
+        return false;
       }
       const effectiveStakeType = confirmStakeType ?? nativeStakeType;
-      await handleStake({
+      return handleStake({
         amount,
         approveType,
         permitSignature,

--- a/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
@@ -122,7 +122,7 @@ const WithdrawPage = () => {
       const abortController = new AbortController();
       withdrawAbortRef.current = abortController;
 
-      await handleWithdraw({
+      return handleWithdraw({
         amount,
         identity,
         protocolVault: earnUtils.shouldSendEarnProtocolVault({

--- a/packages/kit/src/views/WebView/pages/WebViewModal/index.tsx
+++ b/packages/kit/src/views/WebView/pages/WebViewModal/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useWebViewBridge } from '@onekeyfe/onekey-cross-webview';
 import { useRoute } from '@react-navigation/core';
@@ -15,20 +15,28 @@ import {
 } from '@onekeyhq/components';
 import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import WebView from '@onekeyhq/kit/src/components/WebView';
+import { WebViewWithFeatures } from '@onekeyhq/kit/src/components/WebView/WebViewWithFeatures';
 import { WebViewWebEmbed } from '@onekeyhq/kit/src/components/WebViewWebEmbed';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useCrossDomainRedirect } from '@onekeyhq/kit/src/hooks/useCrossDomainRedirect';
+import { handleDeepLinkUrl } from '@onekeyhq/kit/src/routes/config/deeplink';
 import { useSettingsFiatPaySiteWhitelistPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/settings';
 import { EWebEmbedPrivateRequestMethod } from '@onekeyhq/shared/src/consts/webEmbedConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EModalWebViewRoutes,
   IModalWebViewParamList,
 } from '@onekeyhq/shared/src/routes/webView';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
 
 import { WebViewTestIDs } from '../../testIDs';
+import {
+  EDappWebViewNavigationDecision,
+  resolveDappWebViewNavigation,
+} from '../../utils/dappWebViewNavigationPolicy';
 
 import type {
   IJsBridgeMessagePayload,
@@ -48,6 +56,7 @@ export default function WebViewModal() {
     hashRouteQueryParams,
     redirectExternalNavigation,
     hideHeaderRight,
+    enableDappBridge,
   } = route.params;
   const navigation = useAppNavigation();
 
@@ -157,14 +166,42 @@ export default function WebViewModal() {
 
   const [navigationTitle, setNavigationTitle] = useState(title);
   useEffect(() => {
-    setNavigationTitle('');
+    // A dApp page can ask to connect before it reports a document title, so
+    // fall back to the host: the user must be able to see which site is asking.
+    setNavigationTitle(
+      enableDappBridge ? uriUtils.getHostNameFromUrl({ url }) : '',
+    );
+    // Runs once on mount, same as before.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // Desktop never emits onNavigationStateChange (the Electron adapter only
+  // forwards onDidStartNavigation), so the live-origin header and the dApp
+  // notification target would keep the entry host there. Feed both platforms
+  // through the same updater.
+  const onDesktopDidStartNavigation = useCallback(
+    ({ url: nextUrl, isMainFrame }: { url: string; isMainFrame: boolean }) => {
+      if (isUnmounting.current || !isMainFrame || !nextUrl) return;
+      setCurrentUrl(nextUrl);
+      if (enableDappBridge) {
+        setNavigationTitle(uriUtils.getHostNameFromUrl({ url: nextUrl }));
+      }
+    },
+    [enableDappBridge],
+  );
+
   const onNavigationStateChange = useCallback(
     ({ title: webTitle, url: newUrl }: { title: string; url?: string }) => {
       // Guard against events after unmount started
       if (isUnmounting.current) return;
 
-      if (!title) {
+      if (enableDappBridge) {
+        // Never show the page's own document.title in a dApp session: it is
+        // attacker-controlled chrome right where the user decides whether to
+        // connect. Track the live URL instead, so a cross-origin hop is visible.
+        setNavigationTitle(
+          uriUtils.getHostNameFromUrl({ url: newUrl || currentUrl || url }),
+        );
+      } else if (!title) {
         setNavigationTitle(webTitle);
       }
       // Update current URL when navigation occurs
@@ -172,7 +209,7 @@ export default function WebViewModal() {
         setCurrentUrl(newUrl);
       }
     },
-    [title, setNavigationTitle],
+    [enableDappBridge, currentUrl, url, title, setNavigationTitle],
   );
   const webembedCustomReceiveHandler = useCallback(
     (payload: IJsBridgeMessagePayload) => {
@@ -213,6 +250,46 @@ export default function WebViewModal() {
     !!redirectExternalNavigation,
   );
 
+  // The entry URL was checked once before this modal opened, but the page can
+  // navigate the top frame anywhere while keeping the wallet bridge, so every
+  // navigation is re-checked here — the same guard the Discovery browser runs.
+  const onDappShouldStartLoadWithRequest = useCallback(
+    ({ url: navUrl, isTopFrame }: { url: string; isTopFrame?: boolean }) => {
+      const decision = resolveDappWebViewNavigation({
+        url: navUrl,
+        isTopFrame,
+      });
+      if (decision === EDappWebViewNavigationDecision.Deeplink) {
+        handleDeepLinkUrl({ url: navUrl });
+        return false;
+      }
+      if (decision === EDappWebViewNavigationDecision.Deny) {
+        defaultLogger.discovery.browser.logRejectUrl(navUrl);
+        return false;
+      }
+      return true;
+    },
+    [],
+  );
+
+  const shouldStartLoadWithRequestHandler = useMemo(() => {
+    if (enableDappBridge) {
+      return onDappShouldStartLoadWithRequest;
+    }
+    return redirectExternalNavigation
+      ? onShouldStartLoadWithRequest
+      : undefined;
+  }, [
+    enableDappBridge,
+    onDappShouldStartLoadWithRequest,
+    onShouldStartLoadWithRequest,
+    redirectExternalNavigation,
+  ]);
+
+  // Same inpage provider either way; the wrapper only adds the account/network
+  // change notifications a live dApp session needs.
+  const WebViewComponent = enableDappBridge ? WebViewWithFeatures : WebView;
+
   return (
     <Page>
       <Page.Header
@@ -227,18 +304,26 @@ export default function WebViewModal() {
             customReceiveHandler={webembedCustomReceiveHandler}
           />
         ) : (
-          <WebView
+          <WebViewComponent
             onWebViewRef={(ref) => ref && setWebViewRef(ref)}
             src={url}
             mediaPermissionWhitelist={fiatPaySiteWhitelist}
             allowpopups={!!redirectExternalNavigation}
             onNavigationStateChange={onNavigationStateChange}
-            onShouldStartLoadWithRequest={
-              redirectExternalNavigation
-                ? onShouldStartLoadWithRequest
-                : undefined
-            }
+            onDidStartNavigation={onDesktopDidStartNavigation}
+            onShouldStartLoadWithRequest={shouldStartLoadWithRequestHandler}
             onOpenWindow={redirectExternalNavigation ? onOpenWindow : undefined}
+            {...(enableDappBridge
+              ? // important: without this the dApp is never told about the
+                // connected account, so it stays disconnected after the user
+                // approves (see PageWebviewPerpTrade). currentUrl keeps those
+                // notifications addressed to the page that is actually loaded
+                // after a cross-origin hop, without reloading the WebView.
+                {
+                  features: { notifyChangedEventsToDappOnFocus: true },
+                  currentUrl,
+                }
+              : undefined)}
           />
         )}
       </Page.Body>

--- a/packages/kit/src/views/WebView/utils/__tests__/dappWebViewNavigationPolicy.test.ts
+++ b/packages/kit/src/views/WebView/utils/__tests__/dappWebViewNavigationPolicy.test.ts
@@ -1,0 +1,39 @@
+import {
+  EDappWebViewNavigationDecision,
+  resolveDappWebViewNavigation,
+} from '../dappWebViewNavigationPolicy';
+
+describe('resolveDappWebViewNavigation', () => {
+  it('allows ordinary https navigation', () => {
+    expect(
+      resolveDappWebViewNavigation({ url: 'https://app.uniswap.org/swap' }),
+    ).toBe(EDappWebViewNavigationDecision.Allow);
+  });
+
+  it('denies script and local targets that keep the wallet bridge alive', () => {
+    for (const url of [
+      // eslint-disable-next-line no-script-url
+      'javascript:alert(1)',
+      'http://127.0.0.1:8545',
+      'http://localhost:3000',
+      'https://192.168.1.10/admin',
+      '',
+    ]) {
+      expect(resolveDappWebViewNavigation({ url })).toBe(
+        EDappWebViewNavigationDecision.Deny,
+      );
+    }
+  });
+
+  it('denies punycode hosts', () => {
+    expect(
+      resolveDappWebViewNavigation({ url: 'https://xn--80ak6aa92e.com' }),
+    ).toBe(EDappWebViewNavigationDecision.Deny);
+  });
+
+  it('routes OneKey deeplinks to the app instead of loading them', () => {
+    expect(
+      resolveDappWebViewNavigation({ url: 'onekey-wallet://market/tokens' }),
+    ).toBe(EDappWebViewNavigationDecision.Deeplink);
+  });
+});

--- a/packages/kit/src/views/WebView/utils/dappWebViewNavigationPolicy.ts
+++ b/packages/kit/src/views/WebView/utils/dappWebViewNavigationPolicy.ts
@@ -1,0 +1,64 @@
+import { devSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
+import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
+
+/**
+ * Per-navigation policy for a WebView that carries the wallet inpage provider.
+ *
+ * The entry URL is validated once by the caller, but a page that passed that
+ * check can still drive the top frame somewhere else while keeping the bridge,
+ * so every navigation has to be re-checked — the same thing the Discovery
+ * browser does in its own `onShouldStartLoadWithRequest`.
+ *
+ * Deliberately NOT `isAllowedWebViewUrl`: that is the overlay route's policy
+ * (https only, no punycode, no download extensions) and is too strict for real
+ * dApps. This mirrors Discovery's `validateWebviewSrc` instead.
+ *
+ * Known gap: Discovery also checks its phishing LRU cache, which lives in the
+ * Discovery jotai context and cannot be read from here (and this callback must
+ * answer synchronously). Protocol / local-address / punycode / deeplink only.
+ */
+export enum EDappWebViewNavigationDecision {
+  Allow = 'Allow',
+  Deny = 'Deny',
+  // A OneKey deeplink: the app handles it natively, the WebView must not load it.
+  Deeplink = 'Deeplink',
+}
+
+function isLocalhostUrlAllowedInDAppBrowser() {
+  const devSettings = jotaiDefaultStore.get(devSettingsPersistAtom.atom());
+  return Boolean(
+    devSettings?.enabled &&
+    devSettings.settings?.allowLocalhostUrlInDAppBrowser,
+  );
+}
+
+export function resolveDappWebViewNavigation({
+  url,
+  isTopFrame = true,
+}: {
+  url: string;
+  isTopFrame?: boolean;
+}): EDappWebViewNavigationDecision {
+  if (!url) {
+    return EDappWebViewNavigationDecision.Deny;
+  }
+
+  const { action } = uriUtils.parseDappRedirect(url, [], {
+    isTopFrame,
+    allowLocalhostUrl: isLocalhostUrlAllowedInDAppBrowser(),
+  });
+  if (action === uriUtils.EDAppOpenActionEnum.DENY) {
+    return EDappWebViewNavigationDecision.Deny;
+  }
+
+  if (uriUtils.containsPunycode(url)) {
+    return EDappWebViewNavigationDecision.Deny;
+  }
+
+  if (uriUtils.isValidDeepLink(url)) {
+    return EDappWebViewNavigationDecision.Deeplink;
+  }
+
+  return EDappWebViewNavigationDecision.Allow;
+}

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -605,9 +605,6 @@ export interface IAppEventBusPayload {
     retry?: number;
     message?: string;
   };
-  [EAppEventBusNames.EarnHomeBannerDragStateChanged]: {
-    dragging: boolean;
-  };
   [EAppEventBusNames.SwitchDiscoveryTabInNative]: {
     tab:
       | ETranslations.global_market

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -172,9 +172,6 @@ export enum EAppEventBusNames {
   BtcFindAddressUpdated = 'BtcFindAddressUpdated',
   ClientLogUploadProgress = 'ClientLogUploadProgress',
   SwitchDiscoveryTabInNative = 'SwitchDiscoveryTabInNative',
-  // OK-59246: earn home banner drag state, used to pause the outer
-  // Discovery pager so nested horizontal swipes don't switch top tabs
-  EarnHomeBannerDragStateChanged = 'EarnHomeBannerDragStateChanged',
   SwitchEarnMode = 'SwitchEarnMode',
   SwitchEarnTab = 'SwitchEarnTab',
   SwitchTabBar = 'SwitchTabBar',

--- a/packages/shared/src/routes/webView.ts
+++ b/packages/shared/src/routes/webView.ts
@@ -13,6 +13,12 @@ export type IModalWebViewParamList = {
     hashRouteQueryParams?: Record<string, string>;
     redirectExternalNavigation?: boolean;
     hideHeaderRight?: boolean;
+    /**
+     * Inject the full dApp session features (account/network change events on
+     * top of the inpage provider every WebView already carries). Opt-in: the
+     * plain modal is used for docs/onramp pages that never connect a wallet.
+     */
+    enableDappBridge?: boolean;
   };
 };
 

--- a/packages/shared/src/utils/openUrlUtils.ts
+++ b/packages/shared/src/utils/openUrlUtils.ts
@@ -57,7 +57,11 @@ export function clearPendingDiscoveryUrl(): void {
   pendingDiscoveryUrl = null;
 }
 
-const openUrlByWebview = (url: string, title?: string) => {
+const openUrlByWebview = (
+  url: string,
+  title?: string,
+  options?: IOpenUrlInAppOptions,
+) => {
   appGlobals.$navigationRef.current?.navigate(ERootRoutes.Modal, {
     screen: EModalRoutes.WebViewModal,
     params: {
@@ -65,6 +69,7 @@ const openUrlByWebview = (url: string, title?: string) => {
       params: {
         url,
         title,
+        enableDappBridge: options?.enableDappBridge,
       },
     },
   });
@@ -108,9 +113,22 @@ const openUrlOutsideNative = (url: string): void => {
   }
 };
 
-export const openUrlInApp = (url: string, title?: string) => {
+export interface IOpenUrlInAppOptions {
+  /**
+   * The page is expected to talk to the wallet (connect, sign). Adds the
+   * account/network change notifications a dApp session needs; see
+   * WebViewWithFeatures.
+   */
+  enableDappBridge?: boolean;
+}
+
+export const openUrlInApp = (
+  url: string,
+  title?: string,
+  options?: IOpenUrlInAppOptions,
+) => {
   if (platformEnv.isNative || platformEnv.isDesktop) {
-    openUrlByWebview(url.trim(), title);
+    openUrlByWebview(url.trim(), title, options);
   } else {
     openUrlOutsideNative(url.trim());
   }


### PR DESCRIPTION
…tip links (OK-61675, OK-61479, OK-61516, OK-61515, OK-61348, OK-59196, OK-61325)

- earn share links: derive the :network slug from the preset network shortcode instead of a hardcoded table, so Katana and friends stop generating /earn/unknown/... that the detail page rejects; the old ethereum/solana/aptos/cosmos spellings stay valid on parse
- earn home banner: add an opt-in `infinite` mode to Carousel so the banner wraps around and never sits at a content edge, where the platform pager hands the gesture to its parent; exclude the banner area from the header's tab-switch pan, which sat on top of it; drop the mid-gesture scrollEnabled lock on the outer pager, which never covered that pan anyway
- risk disclaimer: extend the one-time gate from earn deposit to every remaining trade entry (earn withdraw/claim and their approvals, all borrow actions and the borrow approve step, DeFi Portfolio one-click actions), and return a boolean from the trade hooks so a declined disclaimer keeps the typed amount and releases the submit guards instead of sticking on loading
- risk notice / protocol tips dialogs now close before a link opens, instead of staying stacked behind the page
- add the <urlInApp> rich-text tag: opens tip links in the in-app webview with the dapp bridge on, re-checking every top-frame navigation and showing the live host; <url> keeps going to the system browser. Server-side gating ships separately in server-service-earn, keyed on jsbundle version because the app version header does not move for a hot update