### PR TITLE
fix: restore full market chart history ｜OK-61558

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/StockSimpleChart.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/StockSimpleChart.test.ts
@@ -17,6 +17,9 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       fetchMarketStockChart: jest.fn(),
       fetchMarketTokenKline: jest.fn(),
     },
+    serviceToken: {
+      fetchTokenInfoOnly: jest.fn(),
+    },
   },
 }));
 
@@ -26,6 +29,9 @@ describe('fetchStockSimpleChartPoints', () => {
   >;
   const serviceMarketV2 = backgroundApiProxy.serviceMarketV2 as jest.Mocked<
     typeof backgroundApiProxy.serviceMarketV2
+  >;
+  const serviceToken = backgroundApiProxy.serviceToken as jest.Mocked<
+    typeof backgroundApiProxy.serviceToken
   >;
   const nowSeconds = 2_000_000_000;
 
@@ -79,7 +85,7 @@ describe('fetchStockSimpleChartPoints', () => {
     expect(result).toEqual([[nowSeconds - 20 * 24 * 60 * 60, 101]]);
   });
 
-  it('keeps token price mode on the token k-line API', async () => {
+  it('keeps bounded token ranges on the token k-line API', async () => {
     serviceMarketV2.fetchMarketTokenKline.mockResolvedValue({
       total: 1,
       points: [
@@ -115,34 +121,64 @@ describe('fetchStockSimpleChartPoints', () => {
         },
       ],
     ]);
+    expect(serviceMarket.fetchTokenChart.mock.calls).toHaveLength(0);
     expect(serviceMarketV2.fetchMarketStockChart.mock.calls).toHaveLength(0);
     expect(result).toEqual([[nowSeconds - 60, 100]]);
   });
 
-  it('normalizes a stale token All range to a bounded one-year request', async () => {
-    serviceMarketV2.fetchMarketTokenKline.mockResolvedValue({
-      total: 0,
-      points: [],
+  it('loads the complete native-token history by its CoinGecko ID', async () => {
+    serviceToken.fetchTokenInfoOnly.mockResolvedValue({
+      info: { coingeckoId: 'bitcoin' },
+    } as Awaited<ReturnType<typeof serviceToken.fetchTokenInfoOnly>>);
+    serviceMarket.fetchTokenChart.mockResolvedValue([
+      [(nowSeconds - 60) * 1000, 78_432],
+    ]);
+
+    const result = await fetchStockSimpleChartPoints({
+      isNative: true,
+      networkId: 'btc--0',
+      priceMode: 'token',
+      range: 'All',
+      tokenAddress: '',
     });
+
+    expect(serviceMarket.fetchTokenChart.mock.calls).toEqual([
+      [
+        'bitcoin',
+        'max',
+        {
+          requestCurrency: 'usd',
+        },
+      ],
+    ]);
+    expect(serviceMarketV2.fetchMarketTokenKline.mock.calls).toHaveLength(0);
+    expect(result).toEqual([[nowSeconds - 60, 78_432]]);
+  });
+
+  it('falls back to the token identity when no CoinGecko ID exists', async () => {
+    serviceToken.fetchTokenInfoOnly.mockResolvedValue({
+      info: {},
+    } as Awaited<ReturnType<typeof serviceToken.fetchTokenInfoOnly>>);
+    serviceMarket.fetchTokenChart.mockResolvedValue([
+      [(nowSeconds - 60) * 1000, 1],
+    ]);
 
     await fetchStockSimpleChartPoints({
       isNative: false,
       networkId: 'evm--1',
       priceMode: 'token',
       range: 'All',
-      stockId: 'AAPL',
-      tokenAddress: '0xaapl',
+      tokenAddress: '0xtoken',
     });
 
-    expect(serviceMarketV2.fetchMarketTokenKline.mock.calls).toEqual([
+    expect(serviceMarket.fetchTokenChart.mock.calls).toEqual([
       [
+        undefined,
+        'max',
         {
-          interval: '1D',
           networkId: 'evm--1',
-          tokenAddress: '0xaapl',
-          timeFrom: nowSeconds - 365 * 24 * 60 * 60,
-          timeTo: nowSeconds,
-          autoHandleError: false,
+          requestCurrency: 'usd',
+          tokenAddress: '0xtoken',
         },
       ],
     ]);
@@ -194,8 +230,8 @@ describe('fetchStockSimpleChartPoints', () => {
 });
 
 describe('stock simple chart request identity', () => {
-  it('exposes All only for the share data source', () => {
-    expect(TOKEN_SIMPLE_CHART_RANGES).not.toContain('All');
+  it('exposes All for both token and share data sources', () => {
+    expect(TOKEN_SIMPLE_CHART_RANGES).toContain('All');
     expect(STOCK_SHARE_SIMPLE_CHART_RANGES).toContain('All');
   });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/stockSimpleChartData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockSimpleChart/stockSimpleChartData.ts
@@ -10,12 +10,11 @@ export const TOKEN_SIMPLE_CHART_RANGES = [
   '1W',
   '1M',
   '1Y',
-] as const satisfies readonly IStockSimpleChartRange[];
-
-export const STOCK_SHARE_SIMPLE_CHART_RANGES = [
-  ...TOKEN_SIMPLE_CHART_RANGES,
   'All',
 ] as const satisfies readonly IStockSimpleChartRange[];
+
+export const STOCK_SHARE_SIMPLE_CHART_RANGES =
+  TOKEN_SIMPLE_CHART_RANGES satisfies readonly IStockSimpleChartRange[];
 
 type IStockSimpleChartRequestParams = {
   coinGeckoId?: string;
@@ -53,7 +52,7 @@ export function resolveStockSimpleChartRequestScope({
     isNative,
     networkId,
     priceMode,
-    range: range === 'All' ? '1Y' : range,
+    range,
     stockId: undefined,
     tokenAddress,
   };
@@ -100,6 +99,31 @@ const STOCK_SHARE_CHART_PERIODS: Record<
   '1Y': '1y',
   All: 'all',
 };
+
+async function resolveTokenChartCoinGeckoId({
+  coinGeckoId,
+  networkId,
+  tokenAddress,
+}: {
+  coinGeckoId?: string;
+  networkId: string;
+  tokenAddress: string;
+}) {
+  const normalizedCoinGeckoId = coinGeckoId?.trim();
+  if (normalizedCoinGeckoId) {
+    return normalizedCoinGeckoId;
+  }
+
+  try {
+    const tokenInfo = await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
+      networkId,
+      tokenAddress,
+    });
+    return tokenInfo?.info?.coingeckoId?.trim() || undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
 
 export async function fetchStockSimpleChartPoints(
   params: IStockSimpleChartRequestParams,
@@ -149,11 +173,22 @@ export async function fetchStockSimpleChartPoints(
       .toSorted((a, b) => a[0] - b[0]);
   }
 
-  if (coinGeckoId) {
+  if (coinGeckoId || range === 'All') {
+    const resolvedCoinGeckoId =
+      range === 'All'
+        ? await resolveTokenChartCoinGeckoId({
+            coinGeckoId,
+            networkId,
+            tokenAddress,
+          })
+        : coinGeckoId;
     const response = await backgroundApiProxy.serviceMarket.fetchTokenChart(
-      coinGeckoId,
+      resolvedCoinGeckoId,
       COINGECKO_CHART_DAYS[range],
-      { requestCurrency: 'usd' },
+      {
+        requestCurrency: 'usd',
+        ...(!resolvedCoinGeckoId ? { networkId, tokenAddress } : undefined),
+      },
     );
     return response
       .map(
@@ -173,6 +208,10 @@ export async function fetchStockSimpleChartPoints(
           timestamp <= timeTo,
       )
       .toSorted((a, b) => a[0] - b[0]);
+  }
+
+  if (timeFrom === undefined) {
+    return [];
   }
 
   const response =

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.test.tsx
@@ -14,6 +14,7 @@ const mockStockSimpleChart = jest.fn(
 );
 
 jest.mock('react-intl', () => ({
+  ...jest.requireActual<typeof import('react-intl')>('react-intl'),
   useIntl: () => ({
     formatMessage: ({ id }: { id: string }) => id,
   }),
@@ -64,6 +65,11 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
     { mode: 'simple' },
     mockSetChartDisplayMode,
   ],
+}));
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {},
 }));
 
 jest.mock('@onekeyhq/kit/src/components/Token', () => ({
@@ -125,12 +131,21 @@ jest.mock('./components/StockNewsSection', () => ({
   StockNewsSection: () => null,
 }));
 
-jest.mock('../components/StockSimpleChart', () => ({
-  StockSimpleChart: (props: { priceMode: 'share' | 'token'; range: string }) =>
-    mockStockSimpleChart(props),
-  STOCK_SHARE_SIMPLE_CHART_RANGES: ['1H', '1D', '1W', '1M', '1Y', 'All'],
-  TOKEN_SIMPLE_CHART_RANGES: ['1H', '1D', '1W', '1M', '1Y', 'All'],
-}));
+jest.mock('../components/StockSimpleChart', () => {
+  const { STOCK_SHARE_SIMPLE_CHART_RANGES, TOKEN_SIMPLE_CHART_RANGES } =
+    jest.requireActual<
+      typeof import('../components/StockSimpleChart/stockSimpleChartData')
+    >('../components/StockSimpleChart/stockSimpleChartData');
+
+  return {
+    StockSimpleChart: (props: {
+      priceMode: 'share' | 'token';
+      range: string;
+    }) => mockStockSimpleChart(props),
+    STOCK_SHARE_SIMPLE_CHART_RANGES,
+    TOKEN_SIMPLE_CHART_RANGES,
+  };
+});
 
 jest.mock('./components/MarketDetailProChartControls', () => ({
   MarketDetailProChartControls: ({ children }: { children?: ReactNode }) => (

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.test.tsx
@@ -1,0 +1,172 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { StockChart } from './StockDesktopLayout';
+
+const mockSetChartDisplayMode = jest.fn();
+const mockStockSimpleChart = jest.fn(
+  (_props: { priceMode: 'share' | 'token'; range: string }) => (
+    <div data-testid="stock-simple-chart" />
+  ),
+);
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  const Stack = ({
+    children,
+    testID,
+    width,
+  }: {
+    children?: ReactNode;
+    testID?: string;
+    width?: number | string;
+  }) => (
+    <div data-testid={testID} data-width={width}>
+      {children}
+    </div>
+  );
+  const Button = ({
+    children,
+    onPress,
+    testID,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    testID?: string;
+  }) => (
+    <button data-testid={testID} onClick={onPress} type="button">
+      {children}
+    </button>
+  );
+
+  return {
+    Button,
+    Icon: Stack,
+    NumberSizeableText: Stack,
+    SizableText: Stack,
+    Skeleton: Stack,
+    Stack,
+    XStack: Stack,
+    YStack: Stack,
+  };
+});
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useMarketDetailChartDisplayModePersistAtom: () => [
+    { mode: 'simple' },
+    mockSetChartDisplayMode,
+  ],
+}));
+
+jest.mock('@onekeyhq/kit/src/components/Token', () => ({
+  Token: () => null,
+}));
+jest.mock('@onekeyhq/kit/src/hooks/useFormatDate', () => ({
+  __esModule: true,
+  default: () => ({ formatDate: jest.fn() }),
+}));
+jest.mock('@onekeyhq/kit/src/views/Market/components/MarketTokenPrice', () => ({
+  MarketTokenPrice: () => null,
+}));
+jest.mock(
+  '@onekeyhq/kit/src/views/Market/components/PriceChangePercentage',
+  () => ({ PriceChangePercentage: () => null }),
+);
+jest.mock('@onekeyhq/shared/src/logger/scopes/dex', () => ({
+  EWatchlistFrom: {},
+}));
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../components/MarketStarV2', () => ({
+  MarketStarV2: () => null,
+}));
+jest.mock('../../components/PerpsBadges', () => ({
+  StockMarketStatusBadge: () => null,
+}));
+jest.mock('../components/InformationTabs/components/Portfolio', () => ({
+  Portfolio: () => null,
+}));
+jest.mock('../components/StockAnalystGauge', () => ({
+  StockAnalystGauge: () => null,
+  parseStockAnalystRatingCounts: jest.fn(),
+}));
+jest.mock('../components/SwapPanel/SwapPanel', () => ({
+  SwapPanel: () => null,
+}));
+jest.mock('../components/TokenDetailHeader/ShareButton', () => ({
+  ShareButton: () => null,
+}));
+jest.mock('../components/TokenSelector/MarketTokenSelector', () => ({
+  MarketTokenSelector: () => null,
+}));
+jest.mock('../hooks/StockDetailContext', () => ({
+  useStockDetail: jest.fn(),
+}));
+jest.mock('../hooks/useStockPortfolioData', () => ({
+  useStockPortfolioData: jest.fn(),
+}));
+jest.mock('../hooks/useTokenDetail', () => ({
+  useTokenDetail: jest.fn(),
+}));
+jest.mock('./components/StockEventsSection', () => ({
+  StockEventsSection: () => null,
+}));
+jest.mock('./components/StockNewsSection', () => ({
+  StockNewsSection: () => null,
+}));
+
+jest.mock('../components/StockSimpleChart', () => ({
+  StockSimpleChart: (props: { priceMode: 'share' | 'token'; range: string }) =>
+    mockStockSimpleChart(props),
+  STOCK_SHARE_SIMPLE_CHART_RANGES: ['1H', '1D', '1W', '1M', '1Y', 'All'],
+  TOKEN_SIMPLE_CHART_RANGES: ['1H', '1D', '1W', '1M', '1Y', 'All'],
+}));
+
+jest.mock('./components/MarketDetailProChartControls', () => ({
+  MarketDetailProChartControls: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+describe('StockChart', () => {
+  beforeEach(() => {
+    mockSetChartDisplayMode.mockReset();
+    mockStockSimpleChart.mockClear();
+  });
+
+  it('passes All through in token mode and sizes all six ranges', () => {
+    const view = render(
+      <StockChart
+        marketTradingView={<div />}
+        priceMode="token"
+        chartMode="native"
+        onHoverChange={jest.fn()}
+        onChartSwitch={jest.fn()}
+        isChartFullscreen={false}
+        onEnterChartFullscreen={jest.fn()}
+      />,
+    );
+
+    expect(view.getByTestId('stock-chart-range-selector').dataset.width).toBe(
+      '214',
+    );
+
+    fireEvent.click(view.getByTestId('stock-chart-range-All'));
+
+    expect(mockStockSimpleChart).toHaveBeenLastCalledWith({
+      priceMode: 'token',
+      range: 'All',
+      onHoverChange: expect.any(Function),
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/StockDesktopLayout.tsx
@@ -102,6 +102,7 @@ const STOCK_SIMPLE_CHART_RANGE_WIDTHS: Record<IStockSimpleChartRange, number> =
     '1Y': 32,
     All: 34,
   };
+const STOCK_SIMPLE_CHART_RANGE_GAP = 2;
 
 function StockPageHeader({
   showFavoriteButton,
@@ -507,7 +508,7 @@ function StockChartModeControl({
   );
 }
 
-function StockChart({
+export function StockChart({
   marketTradingView,
   priceMode,
   chartMode,
@@ -535,9 +536,13 @@ function StockChart({
     priceMode === 'share'
       ? STOCK_SHARE_SIMPLE_CHART_RANGES
       : TOKEN_SIMPLE_CHART_RANGES;
-  const effectiveRange =
-    priceMode === 'token' && range === 'All' ? '1Y' : range;
-  const rangeSelectorWidth = priceMode === 'share' ? 214 : 178;
+  const rangeSelectorWidth = chartRanges.reduce(
+    (total, item, index) =>
+      total +
+      STOCK_SIMPLE_CHART_RANGE_WIDTHS[item] +
+      (index > 0 ? STOCK_SIMPLE_CHART_RANGE_GAP : 0),
+    0,
+  );
   const handleModeChange = (nextMode: IMarketDetailChartDisplayMode) => {
     setChartDisplayMode({ mode: nextMode });
   };
@@ -561,7 +566,12 @@ function StockChart({
           alignItems="center"
           justifyContent="space-between"
         >
-          <XStack width={rangeSelectorWidth} alignItems="center" gap="$0.5">
+          <XStack
+            testID="stock-chart-range-selector"
+            width={rangeSelectorWidth}
+            alignItems="center"
+            gap="$0.5"
+          >
             {chartRanges.map((item) => {
               const itemWidth = STOCK_SIMPLE_CHART_RANGE_WIDTHS[item];
               return (
@@ -581,7 +591,7 @@ function StockChart({
                     px="$2"
                     borderWidth={0}
                     size="small"
-                    variant={effectiveRange === item ? 'secondary' : 'tertiary'}
+                    variant={range === item ? 'secondary' : 'tertiary'}
                     borderRadius="$full"
                     onPress={() => setRange(item)}
                   >
@@ -600,7 +610,7 @@ function StockChart({
       ) : null}
       {isSimpleMode ? (
         <StockSimpleChart
-          range={effectiveRange}
+          range={range}
           priceMode={priceMode}
           onHoverChange={onHoverChange}
         />

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.test.tsx
@@ -7,9 +7,11 @@ import { fireEvent, render } from '@testing-library/react';
 import { TokenDetailChart } from './TokenDetailChart';
 
 const mockSetChartDisplayMode = jest.fn();
-const mockStockSimpleChart = jest.fn(() => (
-  <div data-testid="market-token-simple-chart" />
-));
+const mockStockSimpleChart = jest.fn(
+  (_props: { priceMode: 'token'; range: string }) => (
+    <div data-testid="market-token-simple-chart" />
+  ),
+);
 let mockChartDisplayMode: 'simple' | 'pro' = 'simple';
 
 jest.mock('react-intl', () => ({
@@ -56,8 +58,9 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
 }));
 
 jest.mock('../../components/StockSimpleChart', () => ({
-  StockSimpleChart: () => mockStockSimpleChart(),
-  TOKEN_SIMPLE_CHART_RANGES: ['1H', '1D', '1W', '1M', '1Y'],
+  StockSimpleChart: (props: { priceMode: 'token'; range: string }) =>
+    mockStockSimpleChart(props),
+  TOKEN_SIMPLE_CHART_RANGES: ['1H', '1D', '1W', '1M', '1Y', 'All'],
 }));
 
 jest.mock('./MarketDetailProChartControls', () => ({
@@ -112,5 +115,18 @@ describe('TokenDetailChart', () => {
     fireEvent.click(view.getByTestId('market-token-chart-mode-simple'));
 
     expect(mockSetChartDisplayMode).toHaveBeenCalledWith({ mode: 'simple' });
+  });
+
+  it('localizes All and passes it to the simple chart', () => {
+    const view = renderTokenDetailChart();
+    const allRangeButton = view.getByTestId('market-token-chart-range-All');
+
+    expect(allRangeButton.textContent).toBe('global.all');
+    fireEvent.click(allRangeButton);
+
+    expect(mockStockSimpleChart).toHaveBeenLastCalledWith({
+      priceMode: 'token',
+      range: 'All',
+    });
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
@@ -77,6 +77,7 @@ export function TokenDetailChart({
   onChartSwitch: () => void;
   onEnterChartFullscreen: () => void;
 }) {
+  const intl = useIntl();
   const [{ mode }, setChartDisplayMode] =
     useMarketDetailChartDisplayModePersistAtom();
   const [range, setRange] = useState<IStockSimpleChartRange>('1D');
@@ -111,7 +112,9 @@ export function TokenDetailChart({
                   borderRadius="$full"
                   onPress={() => setRange(item)}
                 >
-                  {item}
+                  {item === 'All'
+                    ? intl.formatMessage({ id: ETranslations.global_all })
+                    : item}
                 </Button>
               ))}
             </XStack>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61558](https://onekeyhq.atlassian.net/browse/OK-61558)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Fix the Simple chart failing to load the complete price history when selecting the `All` range.

Jira: https://onekeyhq.atlassian.net/browse/OK-61558

## Root Cause

The `All` range was routed to the token K-line API without a valid `timeFrom`. The API requires this parameter, so the request failed and the chart entered the retry state.

## Changes

- Restore the `All` range for token Simple charts.
- Resolve the token's CoinGecko ID and request complete history with `days=max`.
- Fall back to `networkId` and `tokenAddress` when no CoinGecko ID is available.
- Keep bounded ranges (`1H`–`1Y`) on the existing K-line API.
- Add regression coverage for native tokens and the token-identity fallback.

## Verification

- Confirmed the BTC `All` range requests:
  - `/utility/v1/market/token/chart?coingeckoId=bitcoin&days=max&points=500`
- Confirmed the full-history chart renders successfully without entering the retry state.
- Targeted Jest tests passed: 9 tests.
- `yarn agent:check --profile commit` passed.

[OK-61558]: https://onekeyhq.atlassian.net/browse/OK-61558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ