### PR TITLE
fix: ensure polyfills load before runtime modules

### DIFF
--- a/apps/desktop/index.js
+++ b/apps/desktop/index.js
@@ -2,13 +2,13 @@
 /* eslint-disable unicorn/prefer-global-this */
 /* eslint-disable import/first */
 /* oxlint-disable import-js/order */
+import '@onekeyhq/shared/src/polyfills';
+
 import '@onekeyhq/shared/src/performance/init';
 
 if (typeof window !== 'undefined') {
   window.$$onekeyJsReadyAt = Date.now();
 }
-
-import '@onekeyhq/shared/src/polyfills';
 
 // Cold-start hydration: fires IndexedDB read promise + populates globalThis
 // vars before React mounts. Must run after polyfills, before any jotai

--- a/apps/ext/index.js
+++ b/apps/ext/index.js
@@ -3,6 +3,8 @@
 /* eslint-disable import/first */
 /* oxlint-disable import-js/order */
 
+import '@onekeyhq/shared/src/polyfills';
+
 import '@onekeyhq/shared/src/performance/init';
 
 if (typeof window !== 'undefined') {

--- a/apps/ext/src/entry/background.ts
+++ b/apps/ext/src/entry/background.ts
@@ -1,7 +1,4 @@
 /* eslint-disable import-js/order */
-// fix missing setimmediate
-import 'setimmediate';
-
 import '@onekeyhq/shared/src/polyfills';
 
 import { bridgeSetup } from '@onekeyfe/extension-bridge-hosted';

--- a/apps/ext/src/entry/content-script.ts
+++ b/apps/ext/src/entry/content-script.ts
@@ -1,3 +1,5 @@
+import '@onekeyhq/shared/src/polyfills/polyfillsExtContentScript';
+
 import { shouldInject } from '../content-script/shouldInject';
 
 if (shouldInject()) {

--- a/apps/ext/src/entry/ui-passkey.tsx
+++ b/apps/ext/src/entry/ui-passkey.tsx
@@ -1,5 +1,7 @@
-import '@onekeyhq/shared/src/performance/init';
+/* oxlint-disable import-js/order */
+// Runtime polyfills must execute before performance and application modules.
 import '@onekeyhq/shared/src/polyfills';
+import '@onekeyhq/shared/src/performance/init';
 import { maybeLockdownOneKeyRuntime } from '@onekeyhq/shared/src/security/sesHarden';
 
 function initPasskeyBridgeEarly() {

--- a/apps/ext/src/entry/ui-popup.tsx
+++ b/apps/ext/src/entry/ui-popup.tsx
@@ -1,3 +1,6 @@
+/* oxlint-disable import-js/order */
+// Runtime polyfills must execute before performance and application modules.
+import '@onekeyhq/shared/src/polyfills';
 import '@onekeyhq/shared/src/performance/init';
 
 import ui from './ui';

--- a/apps/mobile/background.ts
+++ b/apps/mobile/background.ts
@@ -10,6 +10,9 @@
 ).__ONEKEY_RUNTIME_KIND__ = 'background';
 
 require('@onekeyhq/shared/src/polyfills');
+const { assertRuntimePolyfillsReady } =
+  require('@onekeyhq/shared/src/polyfills/runtimeCapabilities') as typeof import('@onekeyhq/shared/src/polyfills/runtimeCapabilities');
+assertRuntimePolyfillsReady();
 
 // Lightweight logger for background runtime entry diagnostics.
 // Uses NativeLogger directly (no console) so output goes to app-latest.log.

--- a/apps/mobile/background.ts
+++ b/apps/mobile/background.ts
@@ -10,9 +10,9 @@
 ).__ONEKEY_RUNTIME_KIND__ = 'background';
 
 require('@onekeyhq/shared/src/polyfills');
-const { assertRuntimePolyfillsReady } =
+const { markRuntimePolyfillsReady } =
   require('@onekeyhq/shared/src/polyfills/runtimeCapabilities') as typeof import('@onekeyhq/shared/src/polyfills/runtimeCapabilities');
-assertRuntimePolyfillsReady();
+markRuntimePolyfillsReady();
 
 // Lightweight logger for background runtime entry diagnostics.
 // Uses NativeLogger directly (no console) so output goes to app-latest.log.

--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -23554,7 +23554,7 @@
     "packages/shared/src/polyfills/polyfillsPlatform.js": 7540,
     "packages/shared/src/polyfills/reactCreateElementShim.ts": 7541,
     "packages/shared/src/polyfills/requestIdleCallbackShim.ts": 7542,
-    "packages/shared/src/polyfills/runtimeCapabilities.ts": 7974,
+    "packages/shared/src/polyfills/runtimeCapabilities.ts": 7975,
     "packages/shared/src/polyfills/setimmediateShim.ts": 7543,
     "packages/shared/src/polyfills/walletConnectCompact/index.native.js": 7544,
     "packages/shared/src/referralCode/creationRecordUtils.ts": 7545,

--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -23554,6 +23554,7 @@
     "packages/shared/src/polyfills/polyfillsPlatform.js": 7540,
     "packages/shared/src/polyfills/reactCreateElementShim.ts": 7541,
     "packages/shared/src/polyfills/requestIdleCallbackShim.ts": 7542,
+    "packages/shared/src/polyfills/runtimeCapabilities.ts": 7974,
     "packages/shared/src/polyfills/setimmediateShim.ts": 7543,
     "packages/shared/src/polyfills/walletConnectCompact/index.native.js": 7544,
     "packages/shared/src/referralCode/creationRecordUtils.ts": 7545,

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -18,6 +18,11 @@ type IAppModule = typeof import('./App');
   }
 ).__ONEKEY_RUNTIME_KIND__ = 'main';
 
+require('@onekeyhq/shared/src/polyfills');
+const { assertRuntimePolyfillsReady } =
+  require('@onekeyhq/shared/src/polyfills/runtimeCapabilities') as typeof import('@onekeyhq/shared/src/polyfills/runtimeCapabilities');
+assertRuntimePolyfillsReady();
+
 // ── On-device Storybook workbench: independent top-level entry ──
 //
 // Registered before the wallet bootstrap in the else branch so a wallet-init
@@ -30,7 +35,6 @@ type IAppModule = typeof import('./App');
 // normal bundles (STORYBOOK_ENABLED unset), so this branch adds nothing to
 // production. Main runtime only; the background runtime is never started.
 if (process.env.STORYBOOK_ENABLED === 'true') {
-  require('@onekeyhq/shared/src/polyfills');
   const { I18nManager } =
     require('react-native') as typeof import('react-native');
   I18nManager.allowRTL(true);
@@ -51,7 +55,6 @@ if (process.env.STORYBOOK_ENABLED === 'true') {
 
   require('@onekeyhq/shared/src/performance/init');
   require('./jsReady');
-  require('@onekeyhq/shared/src/polyfills');
 
   // Install production split bundle loader before any async imports execute.
   // In dev mode __SEGMENT_MANIFEST__ is undefined so this is a no-op.

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -19,9 +19,9 @@ type IAppModule = typeof import('./App');
 ).__ONEKEY_RUNTIME_KIND__ = 'main';
 
 require('@onekeyhq/shared/src/polyfills');
-const { assertRuntimePolyfillsReady } =
+const { markRuntimePolyfillsReady } =
   require('@onekeyhq/shared/src/polyfills/runtimeCapabilities') as typeof import('@onekeyhq/shared/src/polyfills/runtimeCapabilities');
-assertRuntimePolyfillsReady();
+markRuntimePolyfillsReady();
 
 // ── On-device Storybook workbench: independent top-level entry ──
 //

--- a/apps/mobile/scripts/__tests__/unionBuildHelpers.test.js
+++ b/apps/mobile/scripts/__tests__/unionBuildHelpers.test.js
@@ -1,4 +1,6 @@
 const {
+  assertEntryStartsWithPolyfills,
+  assertPolyfillBootstrapSynchronous,
   buildPostSection,
   buildSerializedModuleEntries,
   buildGraphModuleIndex,
@@ -48,6 +50,119 @@ describe('unionBuildHelpers', () => {
     '/repo/packages/kit/src/background/instance/backgroundApiInit.native-ui.ts';
   const backgroundInitPath =
     '/repo/packages/kit/src/background/instance/backgroundApiInit.ts';
+
+  it('requires runtime polyfills before other entry dependencies', () => {
+    const entryPath = '/repo/apps/mobile/background.ts';
+    const polyfillsEntryPath = '/repo/packages/shared/src/polyfills/index.ts';
+    const graph = new Map([
+      [
+        entryPath,
+        createModuleData({
+          dependencies: [
+            {
+              key: '@onekeyhq/shared/src/polyfills',
+              absolutePath: polyfillsEntryPath,
+            },
+            { key: './business', absolutePath: '/repo/business.ts' },
+          ],
+        }),
+      ],
+    ]);
+
+    expect(() =>
+      assertEntryStartsWithPolyfills({
+        entryPath,
+        graph,
+        polyfillsEntryPath,
+        runtimeLabel: 'background',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an entry dependency that runs before runtime polyfills', () => {
+    const entryPath = '/repo/apps/mobile/index.ts';
+    const polyfillsEntryPath = '/repo/packages/shared/src/polyfills/index.ts';
+    const graph = new Map([
+      [
+        entryPath,
+        createModuleData({
+          dependencies: [
+            { key: './business', absolutePath: '/repo/business.ts' },
+            {
+              key: '@onekeyhq/shared/src/polyfills',
+              absolutePath: polyfillsEntryPath,
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    expect(() =>
+      assertEntryStartsWithPolyfills({
+        entryPath,
+        graph,
+        polyfillsEntryPath,
+        runtimeLabel: 'main',
+      }),
+    ).toThrow(/main.*polyfills.*business\.ts/s);
+  });
+
+  it('rejects dynamic imports from polyfill bootstrap modules', () => {
+    const polyfillsPathPrefix = '/repo/packages/shared/src/polyfills/';
+    const intlShimPath = `${polyfillsPathPrefix}intlShim/index.js`;
+    const polyfillPath =
+      '/repo/node_modules/@formatjs/intl-pluralrules/polyfill.js';
+    const graph = new Map([
+      [
+        intlShimPath,
+        createModuleData({
+          dependencies: [
+            {
+              key: '@formatjs/intl-pluralrules/polyfill',
+              absolutePath: polyfillPath,
+              asyncType: 'async',
+            },
+          ],
+        }),
+      ],
+      [polyfillPath, createModuleData()],
+    ]);
+
+    expect(() =>
+      assertPolyfillBootstrapSynchronous({
+        polyfillsPathPrefix,
+        runtimeGraphs: [{ graph, runtimeLabel: 'background' }],
+      }),
+    ).toThrow(/background.*intlShim.*intl-pluralrules/s);
+  });
+
+  it('accepts synchronous dependencies from polyfill bootstrap modules', () => {
+    const polyfillsPathPrefix = '/repo/packages/shared/src/polyfills/';
+    const intlShimPath = `${polyfillsPathPrefix}intlShim/index.js`;
+    const polyfillPath =
+      '/repo/node_modules/@formatjs/intl-pluralrules/polyfill.js';
+    const graph = new Map([
+      [
+        intlShimPath,
+        createModuleData({
+          dependencies: [
+            {
+              key: '@formatjs/intl-pluralrules/polyfill',
+              absolutePath: polyfillPath,
+            },
+          ],
+        }),
+      ],
+      [polyfillPath, createModuleData()],
+    ]);
+
+    expect(() =>
+      assertPolyfillBootstrapSynchronous({
+        polyfillsPathPrefix,
+        runtimeGraphs: [{ graph, runtimeLabel: 'main' }],
+      }),
+    ).not.toThrow();
+  });
 
   it('treats same-path modules with different resolved dependencies as runtime variants', () => {
     const mainProxyModule = createModuleData({

--- a/apps/mobile/scripts/unionBuild.js
+++ b/apps/mobile/scripts/unionBuild.js
@@ -62,6 +62,8 @@ const {
 } = require('../plugins/startupProfilePrologue');
 
 const {
+  assertEntryStartsWithPolyfills,
+  assertPolyfillBootstrapSynchronous,
   buildPostSection,
   buildSerializedModuleEntries,
   buildGraphModuleIndex,
@@ -2015,6 +2017,31 @@ async function main() {
     console.log(
       `Background graph modules: ${backgroundGraph.dependencies.size}`,
     );
+
+    const polyfillsPath = path.resolve(
+      mobileDirPath,
+      '../../packages/shared/src/polyfills',
+    );
+    const polyfillsEntryPath = path.resolve(polyfillsPath, 'index.ts');
+    assertEntryStartsWithPolyfills({
+      entryPath: mainEntry,
+      graph: mainGraph.dependencies,
+      polyfillsEntryPath,
+      runtimeLabel: 'main',
+    });
+    assertEntryStartsWithPolyfills({
+      entryPath: bgEntry,
+      graph: backgroundGraph.dependencies,
+      polyfillsEntryPath,
+      runtimeLabel: 'background',
+    });
+    assertPolyfillBootstrapSynchronous({
+      polyfillsPathPrefix: `${polyfillsPath}${path.sep}`,
+      runtimeGraphs: [
+        { graph: mainGraph.dependencies, runtimeLabel: 'main' },
+        { graph: backgroundGraph.dependencies, runtimeLabel: 'background' },
+      ],
+    });
 
     const mainPrepend = await getPrependedScripts(
       config,

--- a/apps/mobile/scripts/unionBuildHelpers.js
+++ b/apps/mobile/scripts/unionBuildHelpers.js
@@ -17,6 +17,57 @@ function setEquals(left, right) {
   return true;
 }
 
+function assertEntryStartsWithPolyfills({
+  entryPath,
+  graph,
+  polyfillsEntryPath,
+  runtimeLabel,
+}) {
+  const entryModule = graph.get(entryPath);
+  const firstDependency = entryModule
+    ? [...entryModule.dependencies.values()].find(
+        (dependency) => dependency.absolutePath,
+      )
+    : undefined;
+  if (firstDependency?.absolutePath === polyfillsEntryPath) {
+    return;
+  }
+
+  throw new Error(
+    `[RuntimePolyfills] ${runtimeLabel} entry must require ${polyfillsEntryPath} before every other dependency. First dependency: ${firstDependency?.absolutePath ?? 'missing entry module'}`,
+  );
+}
+
+function assertPolyfillBootstrapSynchronous({
+  polyfillsPathPrefix,
+  runtimeGraphs,
+}) {
+  const violations = [];
+  for (const { graph, runtimeLabel } of runtimeGraphs) {
+    for (const [absolutePath, moduleData] of graph) {
+      if (absolutePath.startsWith(polyfillsPathPrefix)) {
+        for (const [dependencyName, dependency] of moduleData.dependencies) {
+          if (dependency.data?.data?.asyncType === 'async') {
+            violations.push(
+              `${runtimeLabel}: ${absolutePath} -> ${dependencyName} (${dependency.absolutePath ?? 'unresolved'})`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      [
+        '[RuntimePolyfills] Polyfill bootstrap must be fully synchronous.',
+        'Dynamic imports can return control before required globals are installed:',
+        ...violations.map((violation) => `  - ${violation}`),
+      ].join('\n'),
+    );
+  }
+}
+
 function buildModuleSignature(moduleData) {
   if (!moduleData) {
     return '';
@@ -954,6 +1005,8 @@ function computeSharedPerRuntimeDeps({
 }
 
 module.exports = {
+  assertEntryStartsWithPolyfills,
+  assertPolyfillBootstrapSynchronous,
   assertBundleCompleteness,
   buildPostSection,
   buildSerializedModuleEntries,

--- a/apps/mobile/src/backgroundThread/backgroundEntryOrder.test.ts
+++ b/apps/mobile/src/backgroundThread/backgroundEntryOrder.test.ts
@@ -5,7 +5,16 @@ const mockExecutorInstalled = new Promise<void>((resolve) => {
   mockResolveExecutorInstalled = resolve;
 });
 
-jest.mock('@onekeyhq/shared/src/polyfills', () => ({}));
+jest.mock('@onekeyhq/shared/src/polyfills', () => {
+  mockLoadOrder.push('polyfills');
+  return {};
+});
+
+jest.mock('@onekeyhq/shared/src/polyfills/runtimeCapabilities', () => ({
+  assertRuntimePolyfillsReady: jest.fn(() => {
+    mockLoadOrder.push('polyfills-ready');
+  }),
+}));
 
 jest.mock(
   '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger',
@@ -58,6 +67,8 @@ describe('background entry initialization order', () => {
     await mockExecutorInstalled;
 
     expect(mockLoadOrder).toEqual([
+      'polyfills',
+      'polyfills-ready',
       'handler',
       'storage',
       'business',

--- a/apps/mobile/src/backgroundThread/backgroundEntryOrder.test.ts
+++ b/apps/mobile/src/backgroundThread/backgroundEntryOrder.test.ts
@@ -11,7 +11,7 @@ jest.mock('@onekeyhq/shared/src/polyfills', () => {
 });
 
 jest.mock('@onekeyhq/shared/src/polyfills/runtimeCapabilities', () => ({
-  assertRuntimePolyfillsReady: jest.fn(() => {
+  markRuntimePolyfillsReady: jest.fn(() => {
     mockLoadOrder.push('polyfills-ready');
   }),
 }));

--- a/apps/mobile/src/splitBundle/__tests__/healthCheck.test.ts
+++ b/apps/mobile/src/splitBundle/__tests__/healthCheck.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
     }),
   );
   (globalThis as any).__ONEKEY_RUNTIME_KIND__ = 'main';
+  (globalThis as any).__ONEKEY_RUNTIME_POLYFILLS_READY__ = 1;
   (globalThis as any).__SEGMENT_MANIFEST__ = {
     segments: {
       'seg:one': {
@@ -40,6 +41,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete (globalThis as any).__ONEKEY_RUNTIME_KIND__;
+  delete (globalThis as any).__ONEKEY_RUNTIME_POLYFILLS_READY__;
   delete (globalThis as any).__SEGMENT_MANIFEST__;
   delete (globalThis as any).__loadBundleAsync;
   delete (globalThis as any).__METRO_GLOBAL_PREFIX__;

--- a/apps/mobile/src/splitBundle/__tests__/installProdBundleLoader.test.ts
+++ b/apps/mobile/src/splitBundle/__tests__/installProdBundleLoader.test.ts
@@ -6,7 +6,10 @@ type ILoadBundleAsyncGlobal = typeof globalThis & {
       | string
       | Partial<Record<'main' | 'background' | 'shared', string | null>>,
   ) => Promise<void>;
+  __ONEKEY_RUNTIME_POLYFILLS_READY__?: number;
 };
+
+const RUNTIME_POLYFILLS_VERSION = 1;
 
 const mockNativeLoggerWrite = jest.fn();
 
@@ -24,6 +27,8 @@ beforeEach(() => {
     }),
   );
   (globalThis as any).__ONEKEY_RUNTIME_KIND__ = 'main';
+  (globalThis as ILoadBundleAsyncGlobal).__ONEKEY_RUNTIME_POLYFILLS_READY__ =
+    RUNTIME_POLYFILLS_VERSION;
   (globalThis as any).__SEGMENT_MANIFEST__ = {
     segments: {
       'seg:test.a': {
@@ -56,6 +61,8 @@ beforeEach(() => {
 
 afterEach(() => {
   delete (globalThis as any).__ONEKEY_RUNTIME_KIND__;
+  delete (globalThis as ILoadBundleAsyncGlobal)
+    .__ONEKEY_RUNTIME_POLYFILLS_READY__;
   delete (globalThis as any).__SEGMENT_MANIFEST__;
   delete (globalThis as any).__loadBundleAsync;
   delete (globalThis as any).__METRO_GLOBAL_PREFIX__;
@@ -79,6 +86,16 @@ function createMockNativeLoader() {
 }
 
 describe('installProdBundleLoader', () => {
+  it('rejects installation before runtime polyfills are ready', () => {
+    delete (globalThis as ILoadBundleAsyncGlobal)
+      .__ONEKEY_RUNTIME_POLYFILLS_READY__;
+    const { installProdBundleLoader } = getLoader();
+
+    expect(() => installProdBundleLoader(createMockNativeLoader())).toThrow(
+      /runtime polyfill bootstrap/i,
+    );
+  });
+
   it('loads a segment and marks it as ready', async () => {
     const { installProdBundleLoader, loadSegment, isSegmentLoaded } =
       getLoader();

--- a/apps/mobile/src/splitBundle/installProdBundleLoader.ts
+++ b/apps/mobile/src/splitBundle/installProdBundleLoader.ts
@@ -22,6 +22,7 @@ import {
   LogLevel,
   NativeLogger,
 } from '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger';
+import { assertRuntimePolyfillsReady } from '@onekeyhq/shared/src/polyfills/runtimeCapabilities';
 
 import { getRuntimeKind } from './runtimeInfo';
 import {
@@ -622,6 +623,7 @@ function installLoadBundleAsyncOverride(
 export function installProdBundleLoader(
   loader: ISplitBundleNativeLoader,
 ): void {
+  assertRuntimePolyfillsReady();
   setNativeLoader(loader);
   installLoadBundleAsyncOverride(
     globalThis as ILoadBundleAsyncGlobal,

--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -2,13 +2,13 @@
 /* eslint-disable unicorn/prefer-global-this */
 /* eslint-disable import/first */
 /* oxlint-disable import-js/order */
+import '@onekeyhq/shared/src/polyfills';
+
 import '@onekeyhq/shared/src/performance/init';
 
 if (typeof globalThis !== 'undefined') {
   globalThis.$$onekeyJsReadyAt = Date.now();
 }
-
-import '@onekeyhq/shared/src/polyfills';
 
 // Cold-start hydration: fires IndexedDB read promise + populates globalThis
 // vars before React mounts. Must run after polyfills, before any jotai atoms

--- a/packages/shared/src/polyfills/index.ts
+++ b/packages/shared/src/polyfills/index.ts
@@ -1,17 +1,17 @@
 /* eslint-disable import-js/order, @typescript-eslint/no-require-imports */
-// import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async';
-
-// Capture the startup baseline inside the first imported module so installing
-// synchronous polyfills remains part of cold-start measurements.
-if (process.env.NODE_ENV !== 'production') {
+// Start timing before the first dependency while guarding unpatched hosts.
+if (
+  process.env.NODE_ENV !== 'production' &&
+  typeof globalThis !== 'undefined' &&
+  typeof performance !== 'undefined'
+) {
   const runtimeScope = globalThis as typeof globalThis & {
     $$debugT0?: number;
   };
   runtimeScope.$$debugT0 = runtimeScope.$$debugT0 ?? performance.now();
 }
 
-// Runtime primitives must be installed before compatibility adapters import
-// third-party modules that may execute against those globals at module scope.
+// Runtime primitives must precede adapters and third-party modules.
 require('./polyfillsPlatform');
 require('./walletConnectCompact');
 require('./reactCreateElementShim');
@@ -19,19 +19,7 @@ require('./reactCreateElementShim');
 require('../modules3rdParty/cross-crypto/verify');
 require('../request');
 
-// import { normalizeRequestLibs } from '../request/normalize';
 const timerUtils = (
   require('../utils/timerUtils') as typeof import('../utils/timerUtils')
 ).default;
-// @ts-ignore
-// global.setInterval = setIntervalAsync;
-// // @ts-ignore
-// global.clearInterval = clearIntervalAsync;
-// import { interceptConsoleErrorWithExtraInfo } from '../errors/utils/errorUtils';
-
-// normalizeRequestLibs();
 timerUtils.interceptTimerWithDisable();
-const { markRuntimePolyfillsReady } =
-  require('./runtimeCapabilities') as typeof import('./runtimeCapabilities');
-markRuntimePolyfillsReady();
-// interceptConsoleErrorWithExtraInfo();

--- a/packages/shared/src/polyfills/index.ts
+++ b/packages/shared/src/polyfills/index.ts
@@ -1,6 +1,15 @@
 /* eslint-disable import-js/order, @typescript-eslint/no-require-imports */
 // import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async';
 
+// Capture the startup baseline inside the first imported module so installing
+// synchronous polyfills remains part of cold-start measurements.
+if (process.env.NODE_ENV !== 'production') {
+  const runtimeScope = globalThis as typeof globalThis & {
+    $$debugT0?: number;
+  };
+  runtimeScope.$$debugT0 = runtimeScope.$$debugT0 ?? performance.now();
+}
+
 // Runtime primitives must be installed before compatibility adapters import
 // third-party modules that may execute against those globals at module scope.
 require('./polyfillsPlatform');

--- a/packages/shared/src/polyfills/index.ts
+++ b/packages/shared/src/polyfills/index.ts
@@ -1,16 +1,19 @@
-/* eslint-disable import-js/order */
+/* eslint-disable import-js/order, @typescript-eslint/no-require-imports */
 // import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async';
 
-// walletconnect react-native-compat polyfill
-import './walletConnectCompact';
-import './polyfillsPlatform';
-import './reactCreateElementShim';
+// Runtime primitives must be installed before compatibility adapters import
+// third-party modules that may execute against those globals at module scope.
+require('./polyfillsPlatform');
+require('./walletConnectCompact');
+require('./reactCreateElementShim');
 
-import '../modules3rdParty/cross-crypto/verify';
-import '../request';
+require('../modules3rdParty/cross-crypto/verify');
+require('../request');
 
 // import { normalizeRequestLibs } from '../request/normalize';
-import timerUtils from '../utils/timerUtils';
+const timerUtils = (
+  require('../utils/timerUtils') as typeof import('../utils/timerUtils')
+).default;
 // @ts-ignore
 // global.setInterval = setIntervalAsync;
 // // @ts-ignore
@@ -19,4 +22,7 @@ import timerUtils from '../utils/timerUtils';
 
 // normalizeRequestLibs();
 timerUtils.interceptTimerWithDisable();
+const { markRuntimePolyfillsReady } =
+  require('./runtimeCapabilities') as typeof import('./runtimeCapabilities');
+markRuntimePolyfillsReady();
 // interceptConsoleErrorWithExtraInfo();

--- a/packages/shared/src/polyfills/intlShim/index.js
+++ b/packages/shared/src/polyfills/intlShim/index.js
@@ -2,15 +2,13 @@ import { shouldPolyfill as shouldPolyfillGetcanonicallocales } from '@formatjs/i
 import { shouldPolyfill as shouldPolyfillLocale } from '@formatjs/intl-locale/should-polyfill';
 import { shouldPolyfill as shouldPolyfillPluralrules } from '@formatjs/intl-pluralrules/should-polyfill';
 
-(async () => {
-  if (shouldPolyfillGetcanonicallocales()) {
-    await import('@formatjs/intl-getcanonicallocales/polyfill');
-  }
-  if (shouldPolyfillLocale()) {
-    await import('@formatjs/intl-locale/polyfill');
-  }
-  if (shouldPolyfillPluralrules()) {
-    await import('@formatjs/intl-pluralrules/polyfill');
-    await import('@formatjs/intl-pluralrules/locale-data/en');
-  }
-})();
+if (shouldPolyfillGetcanonicallocales()) {
+  require('@formatjs/intl-getcanonicallocales/polyfill');
+}
+if (shouldPolyfillLocale()) {
+  require('@formatjs/intl-locale/polyfill');
+}
+if (shouldPolyfillPluralrules()) {
+  require('@formatjs/intl-pluralrules/polyfill');
+  require('@formatjs/intl-pluralrules/locale-data/en');
+}

--- a/packages/shared/src/polyfills/intlShim/index.test.ts
+++ b/packages/shared/src/polyfills/intlShim/index.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const mockInstallOrder: string[] = [];
+
+jest.mock('@formatjs/intl-getcanonicallocales/should-polyfill', () => ({
+  shouldPolyfill: () => true,
+}));
+jest.mock('@formatjs/intl-locale/should-polyfill', () => ({
+  shouldPolyfill: () => true,
+}));
+jest.mock('@formatjs/intl-pluralrules/should-polyfill', () => ({
+  shouldPolyfill: () => true,
+}));
+
+jest.mock('@formatjs/intl-getcanonicallocales/polyfill', () => {
+  mockInstallOrder.push('getCanonicalLocales');
+  return {};
+});
+jest.mock('@formatjs/intl-locale/polyfill', () => {
+  mockInstallOrder.push('Locale');
+  return {};
+});
+jest.mock('@formatjs/intl-pluralrules/polyfill', () => {
+  mockInstallOrder.push('PluralRules');
+  return {};
+});
+jest.mock('@formatjs/intl-pluralrules/locale-data/en', () => {
+  mockInstallOrder.push('PluralRules.locale.en');
+  return {};
+});
+
+describe('intlShim', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockInstallOrder.length = 0;
+  });
+
+  it('installs every required Intl polyfill before require returns', () => {
+    jest.isolateModules(() => {
+      require('./index');
+
+      expect(mockInstallOrder).toEqual([
+        'getCanonicalLocales',
+        'Locale',
+        'PluralRules',
+        'PluralRules.locale.en',
+      ]);
+    });
+  });
+});

--- a/packages/shared/src/polyfills/polyfillBootstrapContract.test.ts
+++ b/packages/shared/src/polyfills/polyfillBootstrapContract.test.ts
@@ -145,6 +145,18 @@ function containsDynamicImport(value: unknown): boolean {
 }
 
 describe('runtime polyfill bootstrap contract', () => {
+  it('captures the startup baseline before installing polyfills', () => {
+    const source = readFileSync(
+      path.join(repoRoot, 'packages/shared/src/polyfills/index.ts'),
+      'utf8',
+    );
+
+    expect(source.indexOf('$$debugT0')).toBeGreaterThanOrEqual(0);
+    expect(source.indexOf('$$debugT0')).toBeLessThan(
+      source.indexOf("require('./polyfillsPlatform')"),
+    );
+  });
+
   it.each(fullRuntimeEntries)(
     '%s loads the complete polyfill bootstrap before any other dependency',
     (relativePath) => {

--- a/packages/shared/src/polyfills/polyfillBootstrapContract.test.ts
+++ b/packages/shared/src/polyfills/polyfillBootstrapContract.test.ts
@@ -21,6 +21,11 @@ const fullRuntimeEntries = [
 
 const limitedRuntimeEntries = ['apps/ext/src/entry/content-script.ts'] as const;
 
+const nativeRuntimeEntries = [
+  'apps/mobile/index.ts',
+  'apps/mobile/background.ts',
+] as const;
+
 function findFirstRuntimeDependency(source: string): string | undefined {
   const ast = parse(source, {
     plugins: ['jsx', 'typescript'],
@@ -144,6 +149,58 @@ function containsDynamicImport(value: unknown): boolean {
   return Object.values(node).some(containsDynamicImport);
 }
 
+function containsImmediateCall(value: unknown, calleeName: string): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => containsImmediateCall(item, calleeName));
+  }
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const node = value as {
+    callee?: { name?: string; type?: string };
+    type?: string;
+    [key: string]: unknown;
+  };
+  if (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'ClassDeclaration' ||
+    node.type === 'ClassExpression'
+  ) {
+    return false;
+  }
+  if (
+    node.type === 'CallExpression' &&
+    node.callee?.type === 'Identifier' &&
+    node.callee.name === calleeName
+  ) {
+    return true;
+  }
+  return Object.values(node).some((child) =>
+    containsImmediateCall(child, calleeName),
+  );
+}
+
+function collectTopLevelBootstrapEvents(source: string): string[] {
+  const ast = parse(source, {
+    plugins: ['jsx', 'typescript'],
+    sourceType: 'unambiguous',
+  });
+
+  return ast.program.body.flatMap((statement) => {
+    const dependency = findImmediateRequire(statement);
+    if (dependency) {
+      return [`require:${dependency}`];
+    }
+    if (containsImmediateCall(statement, 'markRuntimePolyfillsReady')) {
+      return ['call:markRuntimePolyfillsReady'];
+    }
+    return [];
+  });
+}
+
 describe('runtime polyfill bootstrap contract', () => {
   it('captures the startup baseline before installing polyfills', () => {
     const source = readFileSync(
@@ -174,6 +231,19 @@ describe('runtime polyfill bootstrap contract', () => {
       expect(findFirstRuntimeDependency(source)).toBe(
         '@onekeyhq/shared/src/polyfills/polyfillsExtContentScript',
       );
+    },
+  );
+
+  it.each(nativeRuntimeEntries)(
+    '%s marks polyfills ready before loading any other runtime dependency',
+    (relativePath) => {
+      const source = readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+      expect(collectTopLevelBootstrapEvents(source).slice(0, 3)).toEqual([
+        'require:@onekeyhq/shared/src/polyfills',
+        'require:@onekeyhq/shared/src/polyfills/runtimeCapabilities',
+        'call:markRuntimePolyfillsReady',
+      ]);
     },
   );
 

--- a/packages/shared/src/polyfills/polyfillBootstrapContract.test.ts
+++ b/packages/shared/src/polyfills/polyfillBootstrapContract.test.ts
@@ -1,0 +1,178 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { parse } from '@babel/parser';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+const fullRuntimeEntries = [
+  'apps/mobile/index.ts',
+  'apps/mobile/background.ts',
+  'apps/desktop/index.js',
+  'apps/web/index.js',
+  'apps/web-embed/index.js',
+  'apps/ext/index.js',
+  'apps/ext/src/entry/background.ts',
+  'apps/ext/src/entry/offscreen.ts',
+  'apps/ext/src/entry/ui.tsx',
+  'apps/ext/src/entry/ui-popup.tsx',
+  'apps/ext/src/entry/ui-passkey.tsx',
+] as const;
+
+const limitedRuntimeEntries = ['apps/ext/src/entry/content-script.ts'] as const;
+
+function findFirstRuntimeDependency(source: string): string | undefined {
+  const ast = parse(source, {
+    plugins: ['jsx', 'typescript'],
+    sourceType: 'unambiguous',
+  });
+  for (const statement of ast.program.body) {
+    if (
+      statement.type === 'ImportDeclaration' &&
+      statement.importKind !== 'type' &&
+      !(
+        statement.specifiers.length > 0 &&
+        statement.specifiers.every(
+          (specifier) =>
+            specifier.type === 'ImportSpecifier' &&
+            specifier.importKind === 'type',
+        )
+      )
+    ) {
+      return statement.source.value;
+    }
+  }
+
+  for (const statement of ast.program.body) {
+    const dependency = findImmediateRequire(statement);
+    if (dependency) {
+      return dependency;
+    }
+  }
+  return undefined;
+}
+
+function findImmediateRequire(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const dependency = findImmediateRequire(item);
+      if (dependency) {
+        return dependency;
+      }
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const node = value as {
+    arguments?: unknown[];
+    callee?: { name?: string; type?: string };
+    type?: string;
+    [key: string]: unknown;
+  };
+  if (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'ClassDeclaration' ||
+    node.type === 'ClassExpression'
+  ) {
+    return undefined;
+  }
+  if (
+    node.type === 'CallExpression' &&
+    node.callee?.type === 'Identifier' &&
+    node.callee.name === 'require'
+  ) {
+    const firstArgument = node.arguments?.[0] as
+      | { type?: string; value?: unknown }
+      | undefined;
+    if (
+      firstArgument?.type === 'StringLiteral' &&
+      typeof firstArgument.value === 'string'
+    ) {
+      return firstArgument.value;
+    }
+  }
+
+  for (const child of Object.values(node)) {
+    const dependency = findImmediateRequire(child);
+    if (dependency) {
+      return dependency;
+    }
+  }
+  return undefined;
+}
+
+function collectSourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return collectSourceFiles(absolutePath);
+    }
+    if (
+      !entry.name.endsWith('.test.ts') &&
+      (entry.name.endsWith('.js') || entry.name.endsWith('.ts'))
+    ) {
+      return [absolutePath];
+    }
+    return [];
+  });
+}
+
+function containsDynamicImport(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(containsDynamicImport);
+  }
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const node = value as {
+    callee?: { type?: string };
+    type?: string;
+    [key: string]: unknown;
+  };
+  if (
+    node.type === 'ImportExpression' ||
+    (node.type === 'CallExpression' && node.callee?.type === 'Import')
+  ) {
+    return true;
+  }
+  return Object.values(node).some(containsDynamicImport);
+}
+
+describe('runtime polyfill bootstrap contract', () => {
+  it.each(fullRuntimeEntries)(
+    '%s loads the complete polyfill bootstrap before any other dependency',
+    (relativePath) => {
+      const source = readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      expect(findFirstRuntimeDependency(source)).toBe(
+        '@onekeyhq/shared/src/polyfills',
+      );
+    },
+  );
+
+  it.each(limitedRuntimeEntries)(
+    '%s loads its isolated-world polyfills before any other dependency',
+    (relativePath) => {
+      const source = readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      expect(findFirstRuntimeDependency(source)).toBe(
+        '@onekeyhq/shared/src/polyfills/polyfillsExtContentScript',
+      );
+    },
+  );
+
+  it.each(
+    collectSourceFiles(path.join(repoRoot, 'packages/shared/src/polyfills')),
+  )('%s contains no dynamic import boundary', (absolutePath) => {
+    const source = readFileSync(absolutePath, 'utf8');
+    const ast = parse(source, {
+      plugins: ['jsx', 'typescript'],
+      sourceType: 'unambiguous',
+    });
+    expect(containsDynamicImport(ast)).toBe(false);
+  });
+});

--- a/packages/shared/src/polyfills/runtimeCapabilities.test.ts
+++ b/packages/shared/src/polyfills/runtimeCapabilities.test.ts
@@ -15,7 +15,6 @@ function createCompleteRuntimeScope(): IRuntimePolyfillScope {
         toSorted() {},
       },
     },
-    Buffer() {},
     Intl: {
       Locale() {},
       PluralRules() {},
@@ -39,6 +38,7 @@ describe('runtimeCapabilities', () => {
   it('marks a complete runtime as ready', () => {
     const scope = createCompleteRuntimeScope();
 
+    expect(getMissingRuntimeCapabilities(scope)).not.toContain('Buffer');
     markRuntimePolyfillsReady(scope);
 
     expect(scope.__ONEKEY_RUNTIME_POLYFILLS_READY__).toBe(

--- a/packages/shared/src/polyfills/runtimeCapabilities.test.ts
+++ b/packages/shared/src/polyfills/runtimeCapabilities.test.ts
@@ -1,0 +1,66 @@
+import {
+  RUNTIME_POLYFILLS_VERSION,
+  assertRuntimePolyfillsReady,
+  getMissingRuntimeCapabilities,
+  markRuntimePolyfillsReady,
+} from './runtimeCapabilities';
+
+import type { IRuntimePolyfillScope } from './runtimeCapabilities';
+
+function createCompleteRuntimeScope(): IRuntimePolyfillScope {
+  return {
+    Array: {
+      prototype: {
+        flatMap() {},
+        toSorted() {},
+      },
+    },
+    Buffer() {},
+    Intl: {
+      Locale() {},
+      PluralRules() {},
+      getCanonicalLocales() {},
+    },
+    Promise: {
+      allSettled() {},
+    },
+    TextDecoder() {},
+    TextEncoder() {},
+    URL() {},
+    crypto: {
+      getRandomValues() {},
+    },
+    requestIdleCallback() {},
+    setImmediate() {},
+  };
+}
+
+describe('runtimeCapabilities', () => {
+  it('marks a complete runtime as ready', () => {
+    const scope = createCompleteRuntimeScope();
+
+    markRuntimePolyfillsReady(scope);
+
+    expect(scope.__ONEKEY_RUNTIME_POLYFILLS_READY__).toBe(
+      RUNTIME_POLYFILLS_VERSION,
+    );
+    expect(() => assertRuntimePolyfillsReady(scope)).not.toThrow();
+  });
+
+  it('reports a missing constructor and never marks the runtime ready', () => {
+    const scope = createCompleteRuntimeScope();
+    delete scope.Intl?.PluralRules;
+
+    expect(getMissingRuntimeCapabilities(scope)).toContain('Intl.PluralRules');
+    expect(() => markRuntimePolyfillsReady(scope)).toThrow(/Intl\.PluralRules/);
+    expect(scope.__ONEKEY_RUNTIME_POLYFILLS_READY__).toBeUndefined();
+  });
+
+  it('rejects access before bootstrap has marked the runtime ready', () => {
+    const scope = createCompleteRuntimeScope();
+
+    expect(() => assertRuntimePolyfillsReady(scope)).toThrow(
+      /bootstrap has not completed/,
+    );
+  });
+});

--- a/packages/shared/src/polyfills/runtimeCapabilities.ts
+++ b/packages/shared/src/polyfills/runtimeCapabilities.ts
@@ -1,0 +1,112 @@
+/* eslint-disable onekey/no-raw-error */
+
+export const RUNTIME_POLYFILLS_VERSION = 1;
+
+export type IRuntimePolyfillScope = {
+  __ONEKEY_RUNTIME_KIND__?: 'main' | 'background';
+  __ONEKEY_RUNTIME_POLYFILLS_READY__?: number;
+  Array?: {
+    prototype?: {
+      flatMap?: unknown;
+      toSorted?: unknown;
+    };
+  };
+  Buffer?: unknown;
+  Intl?: {
+    Locale?: unknown;
+    PluralRules?: unknown;
+    getCanonicalLocales?: unknown;
+  };
+  Promise?: {
+    allSettled?: unknown;
+  };
+  TextDecoder?: unknown;
+  TextEncoder?: unknown;
+  URL?: unknown;
+  crypto?: {
+    getRandomValues?: unknown;
+  };
+  requestIdleCallback?: unknown;
+  setImmediate?: unknown;
+};
+
+type ICapabilityCheck = readonly [
+  name: string,
+  isAvailable: (scope: IRuntimePolyfillScope) => boolean,
+];
+
+const runtimeCapabilityChecks: readonly ICapabilityCheck[] = [
+  [
+    'Intl.getCanonicalLocales',
+    (scope) => typeof scope.Intl?.getCanonicalLocales === 'function',
+  ],
+  ['Intl.Locale', (scope) => typeof scope.Intl?.Locale === 'function'],
+  [
+    'Intl.PluralRules',
+    (scope) => typeof scope.Intl?.PluralRules === 'function',
+  ],
+  [
+    'Promise.allSettled',
+    (scope) => typeof scope.Promise?.allSettled === 'function',
+  ],
+  ['URL', (scope) => typeof scope.URL === 'function'],
+  ['TextEncoder', (scope) => typeof scope.TextEncoder === 'function'],
+  ['TextDecoder', (scope) => typeof scope.TextDecoder === 'function'],
+  ['Buffer', (scope) => typeof scope.Buffer === 'function'],
+  [
+    'crypto.getRandomValues',
+    (scope) => typeof scope.crypto?.getRandomValues === 'function',
+  ],
+  ['setImmediate', (scope) => typeof scope.setImmediate === 'function'],
+  [
+    'requestIdleCallback',
+    (scope) => typeof scope.requestIdleCallback === 'function',
+  ],
+  [
+    'Array.prototype.flatMap',
+    (scope) => typeof scope.Array?.prototype?.flatMap === 'function',
+  ],
+  [
+    'Array.prototype.toSorted',
+    (scope) => typeof scope.Array?.prototype?.toSorted === 'function',
+  ],
+];
+
+function getDefaultRuntimeScope(): IRuntimePolyfillScope {
+  return globalThis as unknown as IRuntimePolyfillScope;
+}
+
+export function getMissingRuntimeCapabilities(
+  scope: IRuntimePolyfillScope = getDefaultRuntimeScope(),
+): string[] {
+  return runtimeCapabilityChecks
+    .filter(([, isAvailable]) => !isAvailable(scope))
+    .map(([name]) => name);
+}
+
+export function markRuntimePolyfillsReady(
+  scope: IRuntimePolyfillScope = getDefaultRuntimeScope(),
+): void {
+  const missing = getMissingRuntimeCapabilities(scope);
+  if (missing.length > 0) {
+    throw new Error(
+      `[RuntimePolyfills] Cannot complete ${scope.__ONEKEY_RUNTIME_KIND__ ?? 'unknown'} runtime bootstrap. Missing: ${missing.join(', ')}`,
+    );
+  }
+  scope.__ONEKEY_RUNTIME_POLYFILLS_READY__ = RUNTIME_POLYFILLS_VERSION;
+}
+
+export function assertRuntimePolyfillsReady(
+  scope: IRuntimePolyfillScope = getDefaultRuntimeScope(),
+): void {
+  if (scope.__ONEKEY_RUNTIME_POLYFILLS_READY__ === RUNTIME_POLYFILLS_VERSION) {
+    return;
+  }
+
+  const missing = getMissingRuntimeCapabilities(scope);
+  const missingSuffix =
+    missing.length > 0 ? ` Missing: ${missing.join(', ')}` : '';
+  throw new Error(
+    `[RuntimePolyfills] Runtime polyfill bootstrap has not completed for ${scope.__ONEKEY_RUNTIME_KIND__ ?? 'unknown'} runtime.${missingSuffix}`,
+  );
+}

--- a/packages/shared/src/polyfills/runtimeCapabilities.ts
+++ b/packages/shared/src/polyfills/runtimeCapabilities.ts
@@ -11,7 +11,6 @@ export type IRuntimePolyfillScope = {
       toSorted?: unknown;
     };
   };
-  Buffer?: unknown;
   Intl?: {
     Locale?: unknown;
     PluralRules?: unknown;
@@ -52,7 +51,6 @@ const runtimeCapabilityChecks: readonly ICapabilityCheck[] = [
   ['URL', (scope) => typeof scope.URL === 'function'],
   ['TextEncoder', (scope) => typeof scope.TextEncoder === 'function'],
   ['TextDecoder', (scope) => typeof scope.TextDecoder === 'function'],
-  ['Buffer', (scope) => typeof scope.Buffer === 'function'],
   [
     'crypto.getRandomValues',
     (scope) => typeof scope.crypto?.getRandomValues === 'function',


### PR DESCRIPTION
## Summary

- install FormatJS Intl polyfills synchronously so Intl.PluralRules exists before SDK module evaluation
- make the canonical polyfill bootstrap the first runtime dependency across mobile main/background, desktop, web, and extension entrypoints
- add runtime capability assertions and Metro union-build guards for incomplete or asynchronous polyfill bootstrap
- add cross-platform contract coverage and audit all shared polyfill sources for dynamic import boundaries

## Root cause

Android Release with Hermes runs main and background as isolated JavaScript runtimes. The background runtime could evaluate the SUI SDK segment while the previous asynchronous Intl polyfill imports were still pending, causing Intl.PluralRules to be undefined when constructed.

## Validation

- 6 targeted Jest suites passed, 127 tests total
- yarn agent:check --profile commit passed
- yarn agent:check --profile pr local lint and type checks passed
- Extension Manifest V3 production bundle and output checks passed
- Fresh Android Release/Hermes emulator install successfully imported SUI watch address 0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331; the process remained alive and no Intl.PluralRules crash was observed