### PR TITLE
fix: round perps share previews(OK-61562)

### DIFF
--- a/packages/kit/src/views/Perp/components/PositionShare/ShareView.native.tsx
+++ b/packages/kit/src/views/Perp/components/PositionShare/ShareView.native.tsx
@@ -35,7 +35,8 @@ export function ShareView({
     <Stack
       width={displaySize}
       height={displaySize}
-      borderRadius="$3"
+      borderRadius="$6"
+      borderCurve={platformEnv.isNativeIOS ? 'continuous' : undefined}
       borderWidth={1}
       borderColor="$borderSubdued"
       overflow="hidden"

--- a/packages/kit/src/views/Perp/components/PositionShare/ShareView.tsx
+++ b/packages/kit/src/views/Perp/components/PositionShare/ShareView.tsx
@@ -121,7 +121,7 @@ export function ShareView({
     <Stack
       width={displaySize}
       height={displaySize}
-      borderRadius="$3"
+      borderRadius="$6"
       overflow="hidden"
       borderWidth={1}
       borderColor="$borderSubdued"


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61562](https://onekeyhq.atlassian.net/browse/OK-61562)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- use a 24px radius for Perps share previews on native, web, desktop, and extension
- use the iOS continuous corner curve while keeping the shared radius on Android

## Testing
- yarn agent:check --profile commit
- yarn agent:check --profile pr
- verified the Share Position preview on an iOS simulator

[OK-61562]: https://onekeyhq.atlassian.net/browse/OK-61562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ