### PR TITLE
fix: normalize token search networkId and filter All Networks receive search for Others accounts (OK-61630)

### DIFF
--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -30,6 +30,7 @@ import {
   filterAccountTokenListByLimit,
   getEmptyTokenData,
   getMergedTokenData,
+  normalizeTokenSearchResults,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import type {
@@ -872,14 +873,10 @@ class ServiceToken extends ServiceBase {
     const buildSearchTokenKey = (info: IToken) =>
       `${info.networkId ?? ''}_${info.uniqueKey ?? info.address}`;
 
-    // Defense-in-depth (OK-60860): the backend search index may still return
-    // tokens on delisted networks (dropped from getAllNetworks via status
-    // TRASH) or on networks this app version does not know at all. Such rows
-    // render without a resolvable network and cannot receive funds, so drop
-    // them here. Tokens without their own networkId belong to the request's
-    // scoped networkId and pass through. The catalog lookup itself is
-    // best-effort: a transient catalog failure must not discard the token
-    // queries that already succeeded, so fail open and skip the filter.
+    // Catalog for the delisted-network filter inside
+    // normalizeTokenSearchResults (OK-60860). The lookup is best-effort: a
+    // transient catalog failure must not discard the token queries that
+    // already succeeded, so fail open and skip the filter.
     let availableNetworkIds: Set<string> | undefined;
     try {
       const { networks: availableNetworks } =
@@ -891,15 +888,15 @@ class ServiceToken extends ServiceBase {
       availableNetworkIds = undefined;
     }
 
+    // Normalize before deduping so the key sees the stamped networkId: a hit
+    // that omits it under a scoped request would otherwise collide across
+    // networks and, on press, fall back to the selector's own network.
     return uniqBy(
-      fulfilledResponses
-        .flatMap((resp) => resp.data.data)
-        .filter(
-          (item) =>
-            !item.info.networkId ||
-            !availableNetworkIds ||
-            availableNetworkIds.has(item.info.networkId),
-        ),
+      normalizeTokenSearchResults({
+        items: fulfilledResponses.flatMap((resp) => resp.data.data),
+        requestNetworkId: networkId,
+        availableNetworkIds,
+      }),
       (item) => buildSearchTokenKey(item.info),
     ).map((item) => ({
       ...item.info,

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -462,11 +462,13 @@ function TokenSelector() {
   const allNetworksCrossSearchEnabled =
     !!searchAll && isSelectorAllNetworks && !showLpTokensOnly;
   // Others (imported / watch-only / external) accounts hold one credential on
-  // one impl, so cross-network results must be narrowed to the networks that
-  // credential can actually derive an address on. HD/HW accounts are unfiltered
-  // — they can create an account on any network.
+  // one impl, so cross-network results — single-network cross mode and the
+  // onekeyall search in All Networks alike — must be narrowed to the networks
+  // that credential can actually derive an address on. Same rule as the
+  // All-Networks account fan-out, so every row left is selectable. HD/HW
+  // accounts are unfiltered — they can create an account on any network.
   const othersAccountForNetworkFilter =
-    crossNetworkSearchEnabled &&
+    (crossNetworkSearchEnabled || allNetworksCrossSearchEnabled) &&
     account &&
     accountId &&
     accountUtils.isOthersAccount({ accountId })

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -13,12 +13,14 @@ import {
   getFilteredTokenBySearchKey,
   mergeDeriveTokenListMap,
   nestAggregateTokensMap,
+  normalizeTokenSearchResults,
 } from './tokenUtils';
 
 import type {
   IAccountToken,
   IAggregateToken,
   IFetchAccountTokensResp,
+  IFetchTokenDetailItem,
   ITokenFiat,
 } from '../../types/token';
 
@@ -1373,5 +1375,104 @@ describe('buildSelectorTokenListFromResponses — token selector self-fetch merg
     });
 
     expect(merged.aggregateTokenFiatMap).toEqual({});
+  });
+});
+
+describe('normalizeTokenSearchResults — networkId normalization and catalog filter', () => {
+  const buildSearchHit = ({
+    networkId,
+    address,
+    uniqueKey,
+  }: {
+    networkId?: string;
+    address: string;
+    uniqueKey?: string;
+  }): IFetchTokenDetailItem => ({
+    info: {
+      decimals: 6,
+      name: 'Tether USD',
+      symbol: 'USDT',
+      address,
+      isNative: false,
+      networkId,
+      uniqueKey,
+    },
+    balance: '0',
+    balanceParsed: '0',
+    fiatValue: '0',
+    price: 1,
+  });
+
+  test('stamps the request network onto hits that omit networkId under a scoped request', () => {
+    const result = normalizeTokenSearchResults({
+      items: [
+        buildSearchHit({ address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' }),
+      ],
+      requestNetworkId: 'tron--0x2b6653dc',
+      availableNetworkIds: new Set(['tron--0x2b6653dc']),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].info.networkId).toBe('tron--0x2b6653dc');
+  });
+
+  test("keeps a hit's own networkId under a scoped request", () => {
+    const result = normalizeTokenSearchResults({
+      items: [buildSearchHit({ networkId: 'evm--1', address: '0xdac17f' })],
+      requestNetworkId: 'evm--56',
+      availableNetworkIds: new Set(['evm--1', 'evm--56']),
+    });
+
+    expect(result[0].info.networkId).toBe('evm--1');
+  });
+
+  test('drops hits that omit networkId under an all-networks request', () => {
+    const result = normalizeTokenSearchResults({
+      items: [
+        buildSearchHit({ address: '0xdac17f' }),
+        buildSearchHit({ networkId: 'evm--1', address: '0xdac17f' }),
+      ],
+      requestNetworkId: 'onekeyall--0',
+      availableNetworkIds: new Set(['evm--1']),
+    });
+
+    expect(result.map((item) => item.info.networkId)).toEqual(['evm--1']);
+  });
+
+  test('drops hits on networks missing from the catalog', () => {
+    const result = normalizeTokenSearchResults({
+      items: [
+        buildSearchHit({ networkId: 'evm--1', address: '0xdac17f' }),
+        buildSearchHit({ networkId: 'evm--999999', address: '0xdead' }),
+      ],
+      requestNetworkId: 'onekeyall--0',
+      availableNetworkIds: new Set(['evm--1']),
+    });
+
+    expect(result.map((item) => item.info.networkId)).toEqual(['evm--1']);
+  });
+
+  test('fails open when the catalog is unavailable', () => {
+    const result = normalizeTokenSearchResults({
+      items: [
+        buildSearchHit({ networkId: 'evm--1', address: '0xdac17f' }),
+        buildSearchHit({ networkId: 'evm--999999', address: '0xdead' }),
+      ],
+      requestNetworkId: 'onekeyall--0',
+      availableNetworkIds: undefined,
+    });
+
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns the same object for hits that need no normalization', () => {
+    const hit = buildSearchHit({ networkId: 'evm--1', address: '0xdac17f' });
+    const result = normalizeTokenSearchResults({
+      items: [hit],
+      requestNetworkId: 'evm--1',
+      availableNetworkIds: new Set(['evm--1']),
+    });
+
+    expect(result[0]).toBe(hit);
   });
 });

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -27,6 +27,7 @@ import type {
   IAccountToken,
   IAggregateToken,
   IFetchAccountTokensResp,
+  IFetchTokenDetailItem,
   IToken,
   ITokenData,
   ITokenFiat,
@@ -169,6 +170,49 @@ export function buildTokenSearchKeywordQueries(keywords?: string): string[] {
   });
 
   return Array.from(queries);
+}
+
+/**
+ * Normalize raw token search hits before they are deduped:
+ * - A hit that omits `info.networkId` belongs to the request's scoped network,
+ *   so stamp it there. Under an all-networks request it cannot be resolved to
+ *   a concrete network (it could never open a receive address), so drop it.
+ * - Defense-in-depth (OK-60860): the backend index may still return tokens on
+ *   delisted networks (dropped from the catalog via status TRASH) or on
+ *   networks this app version does not know at all; drop those too. The
+ *   catalog is optional so a transient lookup failure fails open.
+ */
+export function normalizeTokenSearchResults({
+  items,
+  requestNetworkId,
+  availableNetworkIds,
+}: {
+  items: IFetchTokenDetailItem[];
+  requestNetworkId: string;
+  availableNetworkIds?: Set<string>;
+}): IFetchTokenDetailItem[] {
+  const isAllNetworkRequest = networkUtils.isAllNetwork({
+    networkId: requestNetworkId,
+  });
+  const result: IFetchTokenDetailItem[] = [];
+  items.forEach((item) => {
+    let { networkId } = item.info;
+    if (!networkId) {
+      if (isAllNetworkRequest) {
+        return;
+      }
+      networkId = requestNetworkId;
+    }
+    if (availableNetworkIds && !availableNetworkIds.has(networkId)) {
+      return;
+    }
+    result.push(
+      networkId === item.info.networkId
+        ? item
+        : { ...item, info: { ...item.info, networkId } },
+    );
+  });
+  return result;
 }
 
 enum ESearchStrength {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61630](https://onekeyhq.atlassian.net/browse/OK-61630)

----------

<!-- github-pr-monitor:jira-links:end -->


[OK-61630](https://onekeyhq.atlassian.net/browse/OK-61630)

## Summary

Forward-port of the two review follow-ups landed on #13112 (`release/v6.5.2`). Both code paths are identical on `x`, so the commits cherry-pick cleanly.

- **Normalize token search hit `networkId` before dedupe** (`ServiceToken.searchTokens` → new `normalizeTokenSearchResults` in shared `tokenUtils`): a hit without `info.networkId` gets the scoped request network stamped; under an `onekeyall` request it is dropped. The delisted-network catalog filter (OK-60860) moves into the same pure helper and gains unit tests. Closes the Devin P1 / auto-review P1 raised on #13112. Production `/wallet/v1/account/token/search` responses currently always carry `networkId` (13 probes: scoped tron / evm / sol / tbtc plus `onekeyall`, with symbol, name and contract-address keywords), so this closes a gap the type allows rather than an observed failure.
- **Apply the Others-account compatibility filter to the All Networks receive search**: the filter only ran in single-network cross mode, so the `onekeyall` search still listed tokens on chains an imported / watch-only / external credential cannot use; pressing such a row fell into `createAddress`, which rejects non-HD/HW wallets, leaving a dead row. Same `isAccountCompatibleWithNetwork` rule the All-Networks account fan-out uses, so every remaining row is selectable.

Not changed, by design: auto-review P2 on #13112 (network-catalog failure blocking the search fallback). `serviceNetwork.getAllNetworks` is a memoized local read (presets + simpleDb-cached server networks + custom networks; `getServerNetworks` swallows its own errors) with no remote failure mode to fall back from.

## Verification

- `yarn agent:check --profile commit` green on this branch (full tsgo type check)
- Type-aware oxlint on the 4 changed files: clean
- Jest: `tokenUtils` (6 new cases for `normalizeTokenSearchResults`), `tokenSelectorAccountCompatibility`, `tokenSelectorCrossNetworkUtils` — 89/89
- Device QA: the OK-61630 self-test on 6.5.2 covers the search flows; the All Networks + imported-account search case is new and should be added to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1n6Fx23wzn79FbSkdPSBn


[OK-61630]: https://onekeyhq.atlassian.net/browse/OK-61630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ