### PR TITLE
fix: toggle TradingView auto price scale OK-61446

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -269,10 +269,11 @@ export const TradingViewNativeChart = memo(
         measuredPriceAxisFont.measureText(widestPriceLabel);
       const widestChartComponentPriceLabelBounds =
         measuredPriceAxisFont.measureText(widestChartComponentPriceLabel);
+      const priceRange = chartRuntime.value.pinnedPriceRange ?? autoPriceRange;
       const scaledPriceLabelBounds = measuredPriceAxisFont.measureText(
-        autoPriceRange
+        priceRange
           ? getTradingViewNativeScaledPriceAxisLabel({
-              autoPriceRange,
+              autoPriceRange: priceRange,
               baseLabel: widestPriceLabel,
               priceRangeScale: chartRuntime.value.priceRangeScale,
               priceScaleMode: chartRuntime.value.priceScaleMode,
@@ -338,6 +339,7 @@ export const TradingViewNativeChart = memo(
         height: runtime.size.height,
         candleLabels,
         indicatorSeries: runtime.indicatorSeries,
+        pinnedPriceRange: runtime.pinnedPriceRange,
         points: runtime.points,
         priceAxisWidth: priceAxisWidth.value,
         priceAxisTickCount,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartRuntime.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartRuntime.ts
@@ -14,6 +14,7 @@ import type {
   ITradingViewNativePriceScaleMode,
 } from '../types';
 import type { ITradingViewNativeIndicatorSeries } from '../utils/chartIndicators';
+import type { ITradingViewNativePriceRange } from '../utils/chartViewport';
 import type { ITradingViewNativeSubIndicatorRenderPane } from '../utils/subIndicatorRender';
 
 export interface ITradingViewNativeChartSize {
@@ -41,6 +42,7 @@ export interface ITradingViewNativeChartRuntime extends ITradingViewNativeChartR
     startOffset: number;
     startZoomScale: number;
   };
+  pinnedPriceRange: ITradingViewNativePriceRange | null;
   priceAxisScaleGesture: {
     chartHeight: number;
     startScale: number;
@@ -105,6 +107,7 @@ export function createTradingViewNativeChartRuntime({
       startOffset: 0,
       startZoomScale: TRADING_VIEW_NATIVE_DEFAULT_ZOOM_SCALE,
     },
+    pinnedPriceRange: null,
     priceAxisScaleGesture: {
       chartHeight: 0,
       startScale: 1,

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/chartSkiaRenderer.test.ts
@@ -178,6 +178,7 @@ function createScene(
   overrides: Partial<ITradingViewNativeChartScene> = {},
 ): ITradingViewNativeChartScene {
   return {
+    autoPriceRange: null,
     commands: [],
     crosshairPointIndex: null,
     customPaintStyles: {},

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.test.ts
@@ -78,10 +78,14 @@ describe('useTradingViewNativePriceScale', () => {
       currentPriceLabel: '',
       hasVolume: false,
       indicatorSeries: [],
-      points: [],
+      points: [
+        { c: 12, h: 15, l: 10, o: 11, t: 1, v: 1 },
+        { c: 18, h: 20, l: 14, o: 15, t: 2, v: 1 },
+      ],
       subIndicatorPanes: [],
     });
     runtime.crosshair = { visible: true, x: 10, y: 20 };
+    runtime.priceRangeScale = 2;
     runtime.size = { height: 300, width: 360 };
     const chartRuntime = createMockSharedValue(runtime);
     const { result } = renderHook(() =>
@@ -104,14 +108,18 @@ describe('useTradingViewNativePriceScale', () => {
       result.current.handleAutoScalePress();
     });
     expect(result.current.isAutoScale).toBe(false);
-    expect(chartRuntime.value.priceRangeScale).toBe(1);
+    expect(chartRuntime.value.pinnedPriceRange).toEqual({
+      maxPrice: 20,
+      minPrice: 10,
+    });
+    expect(chartRuntime.value.priceRangeScale).toBe(2);
     expect(chartRuntime.value.crosshair.visible).toBe(false);
 
-    chartRuntime.value.priceRangeScale = 2;
     act(() => {
       result.current.handleAutoScalePress();
     });
     expect(result.current.isAutoScale).toBe(true);
+    expect(chartRuntime.value.pinnedPriceRange).toBeNull();
     expect(chartRuntime.value.priceRangeScale).toBe(1);
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { createTradingViewNativeChartSettings } from '@onekeyhq/shared/types/tradingViewNative';
+
+import { createTradingViewNativeChartRuntime } from './chartRuntime';
+import { useTradingViewNativePriceScale } from './useTradingViewNativePriceScale';
+
+import type { SharedValue } from 'react-native-reanimated';
+
+type IMockGestureHandler = (...args: unknown[]) => void;
+
+function createMockSharedValue<T>(value: T): SharedValue<T> {
+  const sharedValue: SharedValue<T> = {
+    value,
+    addListener: jest.fn(),
+    get: () => sharedValue.value,
+    modify: jest.fn(),
+    removeListener: jest.fn(),
+    set: jest.fn(),
+  };
+  return sharedValue;
+}
+
+function mockCreateGestureBuilder() {
+  const builder: Record<string, jest.Mock> = {};
+  const methods = [
+    'activeOffsetY',
+    'enabled',
+    'maxDistance',
+    'maxPointers',
+    'numberOfTaps',
+    'onEnd',
+    'onStart',
+    'onTouchesDown',
+    'onUpdate',
+  ];
+  methods.forEach((method) => {
+    builder[method] = jest.fn(() => builder);
+  });
+  return builder;
+}
+
+jest.mock('react-native-gesture-handler', () => ({
+  Gesture: {
+    Pan: jest.fn(() => mockCreateGestureBuilder()),
+    Tap: jest.fn(() => mockCreateGestureBuilder()),
+  },
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  cancelAnimation: jest.fn(),
+}));
+
+jest.mock('react-native-worklets', () => ({
+  scheduleOnRN: jest.fn((callback: IMockGestureHandler, ...args: unknown[]) =>
+    callback(...args),
+  ),
+  scheduleOnUI: jest.fn((callback: IMockGestureHandler, ...args: unknown[]) =>
+    callback(...args),
+  ),
+}));
+
+jest.mock('../utils/subIndicatorRender', () => ({
+  getTradingViewNativeVisibleSubIndicatorPaneCount: jest.fn(() => 0),
+}));
+
+describe('useTradingViewNativePriceScale', () => {
+  it('toggles Auto and resets the range only when Auto is re-enabled', () => {
+    const runtime = createTradingViewNativeChartRuntime({
+      candleIntervalSeconds: 60,
+      chartComponents: [],
+      chartSettings: createTradingViewNativeChartSettings(),
+      chartType: 'candlestick',
+      currentPriceLabel: '',
+      hasVolume: false,
+      indicatorSeries: [],
+      points: [],
+      subIndicatorPanes: [],
+    });
+    runtime.crosshair = { visible: true, x: 10, y: 20 };
+    runtime.size = { height: 300, width: 360 };
+    const chartRuntime = createMockSharedValue(runtime);
+    const { result } = renderHook(() =>
+      useTradingViewNativePriceScale({
+        chartRuntime,
+        chartSize: { height: 300, width: 360 },
+        chartWidth: 300,
+        decayOffset: createMockSharedValue(0),
+        isEnabled: true,
+        isLogScaleAvailable: true,
+        priceAxisWidth: createMockSharedValue(52),
+        subIndicatorPanes: [],
+        timeAxisHeight: 20,
+      }),
+    );
+
+    expect(result.current.isAutoScale).toBe(true);
+
+    act(() => {
+      result.current.handleAutoScalePress();
+    });
+    expect(result.current.isAutoScale).toBe(false);
+    expect(chartRuntime.value.priceRangeScale).toBe(1);
+    expect(chartRuntime.value.crosshair.visible).toBe(false);
+
+    chartRuntime.value.priceRangeScale = 2;
+    act(() => {
+      result.current.handleAutoScalePress();
+    });
+    expect(result.current.isAutoScale).toBe(true);
+    expect(chartRuntime.value.priceRangeScale).toBe(1);
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.ts
@@ -142,18 +142,21 @@ export function useTradingViewNativePriceScale({
     if (isTouchVisible) {
       showForTouch();
     }
-    setIsAutoScale(true);
+    const nextIsAutoScale = !isAutoScale;
+    setIsAutoScale(nextIsAutoScale);
     scheduleOnUI(() => {
       'worklet';
 
       cancelAnimation(decayOffset);
       const runtime = getRuntimeWithCrosshairHidden(chartRuntime.value);
-      chartRuntime.value = {
-        ...runtime,
-        priceRangeScale: 1,
-      };
+      chartRuntime.value = nextIsAutoScale
+        ? {
+            ...runtime,
+            priceRangeScale: 1,
+          }
+        : runtime;
     });
-  }, [chartRuntime, decayOffset, isTouchVisible, showForTouch]);
+  }, [chartRuntime, decayOffset, isAutoScale, isTouchVisible, showForTouch]);
 
   const handleLogScalePress = useCallback(() => {
     if (!isLogScaleAvailable) {

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/useTradingViewNativePriceScale.ts
@@ -5,7 +5,10 @@ import { cancelAnimation } from 'react-native-reanimated';
 import { scheduleOnRN, scheduleOnUI } from 'react-native-worklets';
 
 import { TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING } from '../chartConstants';
+import { getTradingViewNativeChartWidth } from '../utils/chartLayout';
 import { reduceTradingViewNativeChartRuntime } from '../utils/chartRuntime';
+import { getTradingViewNativeVisiblePointRange } from '../utils/chartViewport';
+import { getTradingViewNativeMainPriceRange } from '../utils/mainPriceRange';
 import {
   getTradingViewNativeMainPriceAxisLayout,
   getTradingViewNativePriceRangeScaleAfterDrag,
@@ -59,6 +62,30 @@ function getRuntimeWithCrosshairHidden(
       type: 'crosshairHidden',
     }),
   };
+}
+
+function getTradingViewNativeRuntimeAutoPriceRange({
+  chartWidth,
+  runtime,
+}: {
+  chartWidth: number;
+  runtime: ITradingViewNativeChartRuntime;
+}) {
+  'worklet';
+
+  const visiblePointRange = getTradingViewNativeVisiblePointRange({
+    chartWidth,
+    initialRightOffset: runtime.viewport.initialRightOffset,
+    offset: runtime.viewport.offset,
+    pointCount: runtime.points.length,
+    zoomScale: runtime.viewport.zoomScale,
+  });
+  return getTradingViewNativeMainPriceRange({
+    chartType: runtime.chartType,
+    indicatorSeries: runtime.indicatorSeries,
+    points: runtime.points,
+    ...visiblePointRange,
+  });
 }
 
 export function useTradingViewNativePriceScale({
@@ -143,20 +170,45 @@ export function useTradingViewNativePriceScale({
       showForTouch();
     }
     const nextIsAutoScale = !isAutoScale;
-    setIsAutoScale(nextIsAutoScale);
     scheduleOnUI(() => {
       'worklet';
 
       cancelAnimation(decayOffset);
       const runtime = getRuntimeWithCrosshairHidden(chartRuntime.value);
-      chartRuntime.value = nextIsAutoScale
-        ? {
-            ...runtime,
-            priceRangeScale: 1,
-          }
-        : runtime;
+      if (nextIsAutoScale) {
+        chartRuntime.value = {
+          ...runtime,
+          pinnedPriceRange: null,
+          priceRangeScale: 1,
+        };
+        scheduleOnRN(handleAutoScaleStateChange, true);
+        return;
+      }
+      const pinnedPriceRange = getTradingViewNativeRuntimeAutoPriceRange({
+        chartWidth: getTradingViewNativeChartWidth(
+          runtime.size.width,
+          priceAxisWidth.value,
+        ),
+        runtime,
+      });
+      if (!pinnedPriceRange) {
+        return;
+      }
+      chartRuntime.value = {
+        ...runtime,
+        pinnedPriceRange,
+      };
+      scheduleOnRN(handleAutoScaleStateChange, false);
     });
-  }, [chartRuntime, decayOffset, isAutoScale, isTouchVisible, showForTouch]);
+  }, [
+    chartRuntime,
+    decayOffset,
+    handleAutoScaleStateChange,
+    isAutoScale,
+    isTouchVisible,
+    priceAxisWidth,
+    showForTouch,
+  ]);
 
   const handleLogScalePress = useCallback(() => {
     if (!isLogScaleAvailable) {
@@ -227,6 +279,7 @@ export function useTradingViewNativePriceScale({
         const runtime = getRuntimeWithCrosshairHidden(chartRuntime.value);
         chartRuntime.value = {
           ...runtime,
+          pinnedPriceRange: null,
           priceRangeScale: 1,
         };
         scheduleOnRN(handleAutoScaleStateChange, true);
@@ -248,10 +301,23 @@ export function useTradingViewNativePriceScale({
         'worklet';
 
         cancelAnimation(decayOffset);
-        scheduleOnRN(handleAutoScaleStateChange, false);
         const runtime = getRuntimeWithCrosshairHidden(chartRuntime.value);
+        const pinnedPriceRange =
+          runtime.pinnedPriceRange ??
+          getTradingViewNativeRuntimeAutoPriceRange({
+            chartWidth: getTradingViewNativeChartWidth(
+              runtime.size.width,
+              priceAxisWidth.value,
+            ),
+            runtime,
+          });
+        if (!pinnedPriceRange) {
+          return;
+        }
+        scheduleOnRN(handleAutoScaleStateChange, false);
         chartRuntime.value = {
           ...runtime,
+          pinnedPriceRange,
           priceAxisScaleGesture: {
             chartHeight: getTradingViewNativeMainPriceAxisLayoutForPanes({
               height: runtime.size.height,
@@ -267,6 +333,9 @@ export function useTradingViewNativePriceScale({
         'worklet';
 
         const runtime = chartRuntime.value;
+        if (!runtime.pinnedPriceRange) {
+          return;
+        }
         chartRuntime.value = {
           ...runtime,
           priceRangeScale: getTradingViewNativePriceRangeScaleAfterDrag({

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLayout.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLayout.test.ts
@@ -432,6 +432,39 @@ describe('TradingViewNative chart layout', () => {
     });
   });
 
+  it('keeps a pinned price range when the visible data changes', () => {
+    const points = buildPoints({
+      count: 2,
+      startTimestamp: getLocalTimestamp(2025, 0, 15),
+      stepSeconds: SECONDS_PER_HOUR,
+    }).map((point) => ({
+      ...point,
+      c: 200,
+      h: 250,
+      l: 150,
+      o: 180,
+    }));
+    const layout = getTradingViewNativeChartLayout({
+      candleIntervalSeconds: SECONDS_PER_HOUR,
+      hasVolume: false,
+      height: 300,
+      minimumTimeTickIndexSpacing: 1,
+      pinnedPriceRange: { maxPrice: 20, minPrice: 10 },
+      points,
+      priceAxisWidth: 44,
+      priceRangeScale: 2,
+      visiblePointRange: { endIndex: points.length, startIndex: 0 },
+      width: 402,
+    });
+
+    expect(layout).toMatchObject({
+      autoPriceRange: { maxPrice: 250, minPrice: 150 },
+      maxPrice: 25,
+      minPrice: 5,
+      priceRange: 20,
+    });
+  });
+
   it('maps logarithmic prices by equal percentage distance', () => {
     const points = buildPoints({
       count: 2,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLayout.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLayout.ts
@@ -87,6 +87,7 @@ export interface ITradingViewNativeWatermarkLayout {
 }
 
 export interface ITradingViewNativeChartLayout {
+  autoPriceRange: ITradingViewNativePriceRange;
   mainChartBottom: number;
   maxPrice: number;
   maxVolume: number;
@@ -929,6 +930,7 @@ export function getTradingViewNativeChartLayout({
   height,
   minimumTimeTickIndexSpacing,
   points,
+  pinnedPriceRange,
   priceAxisWidth,
   priceAxisTickCount,
   timeAxisHeight,
@@ -948,6 +950,7 @@ export function getTradingViewNativeChartLayout({
   height: number;
   minimumTimeTickIndexSpacing: number;
   points: IMarketTokenKLineDataPoint[];
+  pinnedPriceRange?: ITradingViewNativePriceRange | null;
   priceAxisWidth: number;
   priceAxisTickCount?: number;
   timeAxisHeight?: number;
@@ -1001,7 +1004,7 @@ export function getTradingViewNativeChartLayout({
     minPrice,
     mode: resolvedPriceScaleMode,
   } = resolveTradingViewNativePriceRange({
-    autoPriceRange,
+    autoPriceRange: pinnedPriceRange ?? autoPriceRange,
     rangeScale: priceRangeScale,
     requestedMode: priceScaleMode,
   });
@@ -1089,6 +1092,7 @@ export function getTradingViewNativeChartLayout({
   }).ticks;
 
   return {
+    autoPriceRange,
     mainChartBottom,
     maxPrice,
     maxVolume,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
@@ -67,6 +67,7 @@ describe('TradingViewNative shared chart scene', () => {
       endIndex: POINTS.length,
       startIndex: 0,
     });
+    expect(scene.autoPriceRange).toEqual({ maxPrice: 105, minPrice: 97 });
     expect(scene.crosshairPointIndex).toBe(POINTS.length - 1);
     expect(scene.commands[0]).toMatchObject({
       height: 240,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
@@ -74,6 +74,7 @@ import {
 import { isTradingViewNativePriceUp } from './chartStyle';
 import { getTradingViewNativePrimarySeriesModel } from './chartType';
 import {
+  type ITradingViewNativePriceRange,
   type ITradingViewNativeVisiblePointRange,
   clampTradingViewNativePanOffset,
   clampTradingViewNativeZoomScale,
@@ -248,6 +249,7 @@ export interface IBuildTradingViewNativeChartSceneOptions {
   candleLabels: ITradingViewNativeCandleLabels;
   currentPriceLabel?: string;
   points: IMarketTokenKLineDataPoint[];
+  pinnedPriceRange?: ITradingViewNativePriceRange | null;
   priceAxisFontSize?: number;
   priceAxisWidth?: number;
   priceAxisTickCount?: number;
@@ -276,6 +278,7 @@ const LATEST_PRICE_LABEL_PAINT_IDS = {
 const BACKGROUND_PAINT_ID = 'chart.background';
 
 export interface ITradingViewNativeChartScene {
+  autoPriceRange: ITradingViewNativePriceRange | null;
   commands: ITradingViewNativeChartSceneCommand[];
   crosshairPointIndex: number | null;
   customPaintStyles: Record<string, ITradingViewNativeChartScenePaintStyle>;
@@ -551,6 +554,7 @@ export function buildTradingViewNativeChartScene({
   candleLabels,
   currentPriceLabel,
   points,
+  pinnedPriceRange,
   priceAxisFontSize = AXIS_FONT_SIZE,
   priceAxisWidth,
   priceAxisTickCount,
@@ -729,6 +733,7 @@ export function buildTradingViewNativeChartScene({
     zoomScale,
   };
   const emptyScene = {
+    autoPriceRange: null,
     commands,
     crosshairPointIndex: null,
     customPaintStyles,
@@ -756,6 +761,7 @@ export function buildTradingViewNativeChartScene({
         TRADING_VIEW_NATIVE_CANDLE_STEP * zoomScale,
       ),
     points,
+    pinnedPriceRange,
     priceAxisWidth: resolvedPriceAxisWidth,
     priceAxisTickCount,
     timeAxisHeight,
@@ -1302,6 +1308,7 @@ export function buildTradingViewNativeChartScene({
     });
 
   return {
+    autoPriceRange: layout.autoPriceRange,
     commands,
     crosshairPointIndex,
     customPaintStyles,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
@@ -308,6 +308,7 @@ export const TradingViewNativeChart = memo(
           candleLabels,
           currentPriceLabel,
           indicatorSeries,
+          pinnedPriceRange: priceScaleModelRef.current.pinnedPriceRange,
           points,
           priceAxisFontSize,
           priceAxisWidth,
@@ -325,6 +326,8 @@ export const TradingViewNativeChart = memo(
         });
         subIndicatorLegendHitRegionsRef.current =
           scene?.subIndicatorLegendHitRegions ?? [];
+        priceScaleModelRef.current.autoPriceRange =
+          scene?.autoPriceRange ?? null;
         const nextChartWidth = getTradingViewNativeChartWidth(
           canvas.getBoundingClientRect().width,
           priceAxisWidth,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartCanvasLayout.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartCanvasLayout.ts
@@ -16,6 +16,7 @@ import type { ITradingViewNativePriceRange } from '../utils/chartViewport';
 
 export interface ITradingViewNativeCanvasPriceScale {
   mode: ITradingViewNativePriceScaleMode;
+  pinnedPriceRange?: ITradingViewNativePriceRange | null;
   rangeScale: number;
 }
 
@@ -50,9 +51,10 @@ export function getTradingViewNativeCanvasPriceAxisWidth(
     });
   }
   context.font = getTradingViewNativeCanvasFont('priceAxis', priceAxisFontSize);
-  const scaledPriceLabel = labels.autoPriceRange
+  const priceRange = priceScale.pinnedPriceRange ?? labels.autoPriceRange;
+  const scaledPriceLabel = priceRange
     ? getTradingViewNativeScaledPriceAxisLabel({
-        autoPriceRange: labels.autoPriceRange,
+        autoPriceRange: priceRange,
         baseLabel: labels.widestPrice,
         priceRangeScale: priceScale.rangeScale,
         priceScaleMode: priceScale.mode,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/drawTradingViewNativeCanvasChart.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/drawTradingViewNativeCanvasChart.ts
@@ -19,6 +19,7 @@ import type {
 } from '../types';
 import type { ITradingViewNativeIndicatorSeries } from '../utils/chartIndicators';
 import type { ITradingViewNativeChartRuntimeState } from '../utils/chartRuntime';
+import type { ITradingViewNativePriceRange } from '../utils/chartViewport';
 import type { ITradingViewNativeSubIndicatorRenderPane } from '../utils/subIndicatorRender';
 
 interface IDrawTradingViewNativeCanvasChartOptions {
@@ -34,6 +35,7 @@ interface IDrawTradingViewNativeCanvasChartOptions {
   currentPriceLabel: string;
   indicatorSeries: ITradingViewNativeIndicatorSeries[];
   points: IMarketTokenKLineDataPoint[];
+  pinnedPriceRange: ITradingViewNativePriceRange | null;
   priceAxisFontSize: number;
   priceAxisWidth: number;
   priceAxisTickCount?: number;
@@ -62,6 +64,7 @@ export function drawTradingViewNativeCanvasChart({
   currentPriceLabel,
   indicatorSeries,
   points,
+  pinnedPriceRange,
   priceAxisFontSize,
   priceAxisWidth,
   priceAxisTickCount,
@@ -116,6 +119,7 @@ export function drawTradingViewNativeCanvasChart({
     candleLabels,
     currentPriceLabel,
     points,
+    pinnedPriceRange,
     priceAxisFontSize,
     priceAxisWidth,
     priceAxisTickCount,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.test.ts
@@ -56,6 +56,35 @@ function createPointerEvent({
 }
 
 describe('useTradingViewNativePriceScale', () => {
+  it('toggles Auto and resets the range only when Auto is re-enabled', () => {
+    const modelRef = { current: createTradingViewNativeWebPriceScaleModel() };
+    const renderWithCrosshairHidden = jest.fn();
+    const { result } = renderHook(() =>
+      useTradingViewNativePriceScale({
+        isLogScaleAvailable: true,
+        modelRef,
+        renderCurrentChart: jest.fn(),
+        renderWithCrosshairHidden,
+      }),
+    );
+
+    expect(result.current.isAutoScale).toBe(true);
+
+    act(() => {
+      result.current.handleAutoScalePress();
+    });
+    expect(result.current.isAutoScale).toBe(false);
+    expect(modelRef.current.rangeScale).toBe(1);
+
+    modelRef.current.rangeScale = 2;
+    act(() => {
+      result.current.handleAutoScalePress();
+    });
+    expect(result.current.isAutoScale).toBe(true);
+    expect(modelRef.current.rangeScale).toBe(1);
+    expect(renderWithCrosshairHidden).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps Auto enabled for a click and disables it only after a drag', () => {
     const modelRef = { current: createTradingViewNativeWebPriceScaleModel() };
     const renderCurrentChart = jest.fn();

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.test.ts
@@ -58,6 +58,8 @@ function createPointerEvent({
 describe('useTradingViewNativePriceScale', () => {
   it('toggles Auto and resets the range only when Auto is re-enabled', () => {
     const modelRef = { current: createTradingViewNativeWebPriceScaleModel() };
+    modelRef.current.autoPriceRange = { maxPrice: 20, minPrice: 10 };
+    modelRef.current.rangeScale = 2;
     const renderWithCrosshairHidden = jest.fn();
     const { result } = renderHook(() =>
       useTradingViewNativePriceScale({
@@ -74,19 +76,25 @@ describe('useTradingViewNativePriceScale', () => {
       result.current.handleAutoScalePress();
     });
     expect(result.current.isAutoScale).toBe(false);
-    expect(modelRef.current.rangeScale).toBe(1);
+    expect(modelRef.current.pinnedPriceRange).toEqual({
+      maxPrice: 20,
+      minPrice: 10,
+    });
+    expect(modelRef.current.rangeScale).toBe(2);
 
-    modelRef.current.rangeScale = 2;
+    modelRef.current.autoPriceRange = { maxPrice: 200, minPrice: 100 };
     act(() => {
       result.current.handleAutoScalePress();
     });
     expect(result.current.isAutoScale).toBe(true);
+    expect(modelRef.current.pinnedPriceRange).toBeNull();
     expect(modelRef.current.rangeScale).toBe(1);
     expect(renderWithCrosshairHidden).toHaveBeenCalledTimes(2);
   });
 
   it('keeps Auto enabled for a click and disables it only after a drag', () => {
     const modelRef = { current: createTradingViewNativeWebPriceScaleModel() };
+    modelRef.current.autoPriceRange = { maxPrice: 20, minPrice: 10 };
     const renderCurrentChart = jest.fn();
     const renderWithCrosshairHidden = jest.fn();
     const { result } = renderHook(() =>
@@ -126,6 +134,10 @@ describe('useTradingViewNativePriceScale', () => {
       );
     });
     expect(result.current.isAutoScale).toBe(false);
+    expect(modelRef.current.pinnedPriceRange).toEqual({
+      maxPrice: 20,
+      minPrice: 10,
+    });
     expect(modelRef.current.rangeScale).not.toBe(1);
     expect(renderCurrentChart).toHaveBeenCalledTimes(1);
   });

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.ts
@@ -70,10 +70,13 @@ export function useTradingViewNativePriceScale({
   }, [isLogScaleAvailable, modelRef, renderWithCrosshairHidden]);
 
   const handleAutoScalePress = useCallback(() => {
-    modelRef.current.rangeScale = 1;
-    setIsAutoScale(true);
+    const nextIsAutoScale = !isAutoScale;
+    if (nextIsAutoScale) {
+      modelRef.current.rangeScale = 1;
+    }
+    setIsAutoScale(nextIsAutoScale);
     renderWithCrosshairHidden();
-  }, [modelRef, renderWithCrosshairHidden]);
+  }, [isAutoScale, modelRef, renderWithCrosshairHidden]);
 
   const handleLogScalePress = useCallback(() => {
     if (!isLogScaleAvailable) {

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/useTradingViewNativePriceScale.ts
@@ -10,11 +10,14 @@ import { getTradingViewNativePriceRangeScaleAfterDrag } from '../utils/priceAxis
 import { getTradingViewNativeWheelPriceRangeScale } from './chartWheel';
 
 import type { ITradingViewNativePriceScaleMode } from '../types';
+import type { ITradingViewNativePriceRange } from '../utils/chartViewport';
 
 const PRICE_AXIS_DRAG_ACTIVATION_DISTANCE = 4;
 
 export interface ITradingViewNativeWebPriceScaleModel {
+  autoPriceRange: ITradingViewNativePriceRange | null;
   mode: ITradingViewNativePriceScaleMode;
+  pinnedPriceRange: ITradingViewNativePriceRange | null;
   rangeScale: number;
 }
 
@@ -28,9 +31,20 @@ interface IPriceAxisPointerDragState {
 
 export function createTradingViewNativeWebPriceScaleModel(): ITradingViewNativeWebPriceScaleModel {
   return {
+    autoPriceRange: null,
     mode: 'linear',
+    pinnedPriceRange: null,
     rangeScale: 1,
   };
+}
+
+function pinTradingViewNativeWebPriceRange(
+  model: ITradingViewNativeWebPriceScaleModel,
+) {
+  if (!model.pinnedPriceRange && model.autoPriceRange) {
+    model.pinnedPriceRange = { ...model.autoPriceRange };
+  }
+  return Boolean(model.pinnedPriceRange);
 }
 
 export function useTradingViewNativePriceScale({
@@ -72,7 +86,10 @@ export function useTradingViewNativePriceScale({
   const handleAutoScalePress = useCallback(() => {
     const nextIsAutoScale = !isAutoScale;
     if (nextIsAutoScale) {
+      modelRef.current.pinnedPriceRange = null;
       modelRef.current.rangeScale = 1;
+    } else if (!pinTradingViewNativeWebPriceRange(modelRef.current)) {
+      return;
     }
     setIsAutoScale(nextIsAutoScale);
     renderWithCrosshairHidden();
@@ -131,6 +148,9 @@ export function useTradingViewNativePriceScale({
         return;
       }
       if (!dragState.isActive) {
+        if (!pinTradingViewNativeWebPriceRange(modelRef.current)) {
+          return;
+        }
         dragState.isActive = true;
         setIsAutoScale(false);
       }
@@ -169,6 +189,7 @@ export function useTradingViewNativePriceScale({
   const handleDoubleClick = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
       event.preventDefault();
+      modelRef.current.pinnedPriceRange = null;
       modelRef.current.rangeScale = 1;
       setIsAutoScale(true);
       updateHovered(true);
@@ -180,6 +201,9 @@ export function useTradingViewNativePriceScale({
   const handleWheel = useCallback(
     (deltaY: number) => {
       if (deltaY === 0) {
+        return;
+      }
+      if (!pinTradingViewNativeWebPriceRange(modelRef.current)) {
         return;
       }
       modelRef.current.rangeScale = getTradingViewNativeWheelPriceRangeScale({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61446](https://onekeyhq.atlassian.net/browse/OK-61446)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- allow the TradingView price-axis Auto control to toggle off and on
- pin the current visible candle and main-indicator price range while Auto is disabled
- keep Native/Skia and Web/Canvas behavior aligned, including drag, wheel, pan, resize, and data updates
- clear the pinned range and reset scaling when Auto is re-enabled

## Verification

- `yarn agent:check --profile commit`
- 5 targeted Jest suites, 89 tests
- GitHub CI: 24 passed, 0 failed, 0 pending
- localhost Market detail Pro chart: Auto `true -> false -> true`; after panning, ticks stayed fixed while Auto was off and recalculated when re-enabled

## Issue

- OK-61446


[OK-61446]: https://onekeyhq.atlassian.net/browse/OK-61446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ