### PR TITLE
fix: use popover for perps desktop settings OK-61897

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpSettingsButton.test.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsButton.test.tsx
@@ -7,6 +7,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { PerpSettingsButton } from './PerpSettingsButton';
 
 const mockShowPerpSettingsDialog = jest.fn();
+const mockPerpSettingsPopover = jest.fn();
 const mockSettingsTourVisited = jest.fn();
 let mockMedia = { gtMd: false, gtXl: false };
 let mockSettingsIsFirstVisit = true;
@@ -47,7 +48,10 @@ jest.mock('./PerpsActivityCenterAction', () => ({
 }));
 
 jest.mock('./PerpSettingsDialog', () => ({
-  PerpSettingsPopover: () => null,
+  PerpSettingsPopover: (props: { renderTrigger: ReactNode }) => {
+    mockPerpSettingsPopover(props);
+    return props.renderTrigger;
+  },
   showPerpSettingsDialog: (options: unknown) => {
     mockShowPerpSettingsDialog(options);
   },
@@ -56,6 +60,7 @@ jest.mock('./PerpSettingsDialog', () => ({
 describe('PerpSettingsButton', () => {
   beforeEach(() => {
     mockShowPerpSettingsDialog.mockReset();
+    mockPerpSettingsPopover.mockReset();
     mockSettingsTourVisited.mockReset();
     mockSettingsIsFirstVisit = true;
     mockMedia = { gtMd: false, gtXl: false };
@@ -83,27 +88,25 @@ describe('PerpSettingsButton', () => {
     expect(mockSettingsTourVisited).not.toHaveBeenCalled();
   });
 
-  it('hides layout settings in the medium desktop menu', () => {
+  it('uses a popover and hides layout settings in the medium desktop menu', () => {
     mockMedia = { gtMd: true, gtXl: false };
     const view = render(<PerpSettingsButton />);
 
-    fireEvent.click(view.getByRole('button', { name: 'settings' }));
-
-    expect(mockShowPerpSettingsDialog).toHaveBeenCalledWith(
+    expect(mockPerpSettingsPopover).toHaveBeenCalledWith(
       expect.objectContaining({ showChartPositionSetting: false }),
     );
+    expect(mockShowPerpSettingsDialog).not.toHaveBeenCalled();
     expect(view.queryByTestId('perp-mobile-settings-feature-dot')).toBeNull();
     expect(mockSettingsTourVisited).not.toHaveBeenCalled();
   });
 
   it('keeps an explicitly requested layout setting visible', () => {
     mockMedia = { gtMd: true, gtXl: false };
-    const view = render(<PerpSettingsButton showChartPositionSetting />);
+    render(<PerpSettingsButton showChartPositionSetting />);
 
-    fireEvent.click(view.getByRole('button', { name: 'settings' }));
-
-    expect(mockShowPerpSettingsDialog).toHaveBeenCalledWith(
+    expect(mockPerpSettingsPopover).toHaveBeenCalledWith(
       expect.objectContaining({ showChartPositionSetting: true }),
     );
+    expect(mockShowPerpSettingsDialog).not.toHaveBeenCalled();
   });
 });

--- a/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
@@ -40,7 +40,7 @@ export function PerpSettingsButton({
   showGuideEntry?: boolean;
 }) {
   const intl = useIntl();
-  const { gtMd, gtXl } = useMedia();
+  const { gtMd } = useMedia();
   const isMobileLayout = platformEnv.isNative || !gtMd;
   const shouldShowChartPositionSetting =
     showChartPositionSetting || isMobileLayout;
@@ -48,7 +48,7 @@ export function PerpSettingsButton({
     isFirstVisit: isSettingsFeatureFirstVisit,
     tourVisited: markSettingsFeatureVisited,
   } = useSpotlight(ESpotlightTour.perpLayoutSettingsMenu);
-  const { showGuide } = useShowGuide({ forceModal: !gtXl });
+  const { showGuide } = useShowGuide({ forceModal: isMobileLayout });
   const [isActivityCenterOpen, setIsActivityCenterOpen] = useState(false);
   const handleOpenActivityCenter = useCallback(() => {
     setIsActivityCenterOpen(true);
@@ -79,7 +79,7 @@ export function PerpSettingsButton({
     showGuideEntry,
   ]);
 
-  if (!gtXl) {
+  if (isMobileLayout) {
     return (
       <DebugRenderTracker name="PerpSettingsButton">
         <>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61897](https://onekeyhq.atlassian.net/browse/OK-61897)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- use the desktop layout breakpoint for the Perps settings presentation
- keep Native and compact layouts on Dialog, while Desktop and Web Wallet use the anchored Popover
- update the existing breakpoint tests without changing animation behavior

## Test plan
- yarn jest packages/kit/src/views/Perp/components/PerpSettingsButton.test.tsx --runInBand
- yarn agent:check --profile commit
- yarn agent:check --profile pr

Issue: https://onekeyhq.atlassian.net/browse/OK-61897

[OK-61897]: https://onekeyhq.atlassian.net/browse/OK-61897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ