### PR TITLE
fix: restore dev-vendor common HBC for iOS device Debug builds

### DIFF
--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -135,14 +135,17 @@ private enum InitialBundleKind {
 }
 
 #if DEBUG
-/// Debug-only common HBC configuration. `sessionId` is set for the iOS
-/// Simulator DevSession shell and nil for Xcode device builds that embed the
-/// artifacts directly (see `resolveDevVendorBundleInfo`).
+/// Debug-only common HBC configuration shared by the iOS Simulator DevSession
+/// shell and Xcode builds that embed the artifacts directly (see
+/// `resolveDevVendorBundleInfo`). DevSession identifiers stay inside the
+/// dev-shell gate so non-shell builds never carry them.
 private struct DevVendorBundleInfo {
   let commonBundleURL: URL
   let fingerprint: String
   let metroBaseURL: URL
-  let sessionId: String?
+#if ONEKEY_DEV_SHELL && targetEnvironment(simulator)
+  let sessionId: String
+#endif
 }
 #endif
 
@@ -602,8 +605,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
       return DevVendorBundleInfo(
         commonBundleURL: commonURL,
         fingerprint: fingerprint,
-        metroBaseURL: metroBaseURL,
-        sessionId: nil
+        metroBaseURL: metroBaseURL
       )
     } catch {
       fatalError("Unable to validate embedded dev-vendor iOS artifacts: \(error)")
@@ -714,11 +716,13 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
       "resolver.runtimeTarget": runtimeTarget,
       "unstable_transformProfile": "hermes-stable",
     ]
-    if let sessionId = devVendorBundleInfo.sessionId {
-      values["resolver.devSessionId"] = sessionId
-    } else {
-      values["resolver.devVendorEmbedded"] = "true"
-    }
+#if ONEKEY_DEV_SHELL && targetEnvironment(simulator)
+    values["resolver.devSessionId"] = devVendorBundleInfo.sessionId
+#else
+    // Embedded Xcode builds have no DevSession; Metro serves them only when it
+    // is not bound to one either (see plugins/devVendor.js).
+    values["resolver.devVendorEmbedded"] = "true"
+#endif
     if runtimeTarget == "background", isDevBackgroundHMREnabled(fingerprint: fingerprint) {
       values["resolver.devVendorBackgroundHMR"] = "true"
     }

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -1,4 +1,4 @@
-#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)
+#if DEBUG
 internal import CryptoKit
 #endif
 internal import Expo
@@ -81,7 +81,7 @@ private enum BackgroundThreadBridge {
     cls.perform(selector, with: host, with: entryURL)
   }
 
-#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)
+#if DEBUG
   static func installSharedBridgeInMainRuntime(
     _ host: AnyObject,
     thenStartBackgroundRunnerWithDevVendorConfig config: [String: String]
@@ -128,18 +128,21 @@ private func isStartupProfileEnabled() -> Bool {
 private enum InitialBundleKind {
   case none
   case common
-#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)
+#if DEBUG
   case devVendorCommon
 #endif
   case main
 }
 
-#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)
+#if DEBUG
+/// Debug-only common HBC configuration. `sessionId` is set for the iOS
+/// Simulator DevSession shell and nil for Xcode device builds that embed the
+/// artifacts directly (see `resolveDevVendorBundleInfo`).
 private struct DevVendorBundleInfo {
   let commonBundleURL: URL
   let fingerprint: String
   let metroBaseURL: URL
-  let sessionId: String
+  let sessionId: String?
 }
 #endif
 
@@ -355,7 +358,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
     return url
   }
 
-#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)
+#if DEBUG
   private lazy var devVendorBundleInfo = resolveDevVendorBundleInfo()
 
   private func explicitDevBackgroundHMRValue() -> Bool? {
@@ -380,6 +383,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   }
 
   private func resolveDevVendorBundleInfo() -> DevVendorBundleInfo? {
+#if ONEKEY_DEV_SHELL && targetEnvironment(simulator)
     guard
       let nativeContractKey = Bundle.main.object(
         forInfoDictionaryKey: "ONEKEY_NATIVE_CONTRACT_KEY"
@@ -516,6 +520,95 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
         "Run the dev-shell command again for this exact simulator. Error: \(error)"
       )
     }
+#else
+    // Xcode Debug builds (physical devices and non-shell simulators): the
+    // "Bundle React Native code and images" phase embeds the validated
+    // out-dir-bundle/dev-vendor common HBC + manifest when
+    // ONEKEY_DEV_VENDOR=true. There is no DevSession; Metro is the plain
+    // `yarn app:native-bundle` server reached through the packager URL, and the
+    // delta requests identify themselves with resolver.devVendorEmbedded=true.
+    let commonURL = Bundle.main.url(
+      forResource: "onekey-dev-vendor-common",
+      withExtension: "hbc"
+    )
+    let manifestURL = Bundle.main.url(
+      forResource: "onekey-dev-vendor-manifest",
+      withExtension: "json"
+    )
+    if commonURL == nil && manifestURL == nil {
+      return nil
+    }
+    guard let commonURL, let manifestURL else {
+      fatalError("Dev-vendor common HBC and manifest must be embedded together")
+    }
+    guard
+      let packagerURL = RCTBundleURLProvider.sharedSettings().jsBundleURL(
+        forBundleRoot: ".expo/.virtual-metro-entry"
+      ),
+      var baseComponents = URLComponents(url: packagerURL, resolvingAgainstBaseURL: false)
+    else {
+      // Without a reachable packager the plain Metro path fails the same way
+      // (RN "could not connect" screen) instead of loading two full bundles.
+      NitroModuleBridge.logInfo(
+        "DevVendor",
+        "embedded common HBC found but no Metro packager URL is available; using the plain Metro bundle path"
+      )
+      return nil
+    }
+    baseComponents.path = ""
+    baseComponents.query = nil
+    baseComponents.fragment = nil
+    guard
+      let metroBaseURLValue = baseComponents.url?.absoluteString,
+      let metroBaseURL = validatedMetroBaseURL(metroBaseURLValue)
+    else {
+      fatalError("Dev-vendor Metro packager URL is invalid: \(packagerURL.absoluteString)")
+    }
+    do {
+      let manifest = try readDevSessionJSON(from: manifestURL, maxBytes: 8 * 1024 * 1024)
+      guard
+        manifest["platform"] as? String == "ios",
+        let fingerprint = manifest["fingerprint"] as? String,
+        fingerprint.range(
+          of: "^[0-9a-f]{64}$",
+          options: .regularExpression
+        ) != nil,
+        let common = manifest["common"] as? [String: Any],
+        let bytecode = common["bytecode"] as? [String: Any],
+        bytecode["file"] as? String == "common.hbc",
+        let expectedBytes = bytecode["bytes"] as? NSNumber,
+        let expectedSha256 = bytecode["sha256"] as? String,
+        expectedSha256.range(
+          of: "^[0-9a-f]{64}$",
+          options: .regularExpression
+        ) != nil,
+        expectedBytes.int64Value > 0,
+        expectedBytes.int64Value <= 512 * 1024 * 1024
+      else {
+        fatalError("Dev-vendor embedded iOS manifest is invalid")
+      }
+      let commonAttributes = try FileManager.default.attributesOfItem(atPath: commonURL.path)
+      guard
+        let commonSize = commonAttributes[.size] as? NSNumber,
+        commonSize.int64Value == expectedBytes.int64Value,
+        (try sha256File(commonURL)) == expectedSha256
+      else {
+        fatalError("Dev-vendor embedded common.hbc integrity mismatch")
+      }
+      NitroModuleBridge.logInfo(
+        "DevVendor",
+        "configured embedded iOS dev vendor fingerprint=\(fingerprint) metro=\(metroBaseURL.absoluteString)"
+      )
+      return DevVendorBundleInfo(
+        commonBundleURL: commonURL,
+        fingerprint: fingerprint,
+        metroBaseURL: metroBaseURL,
+        sessionId: nil
+      )
+    } catch {
+      fatalError("Unable to validate embedded dev-vendor iOS artifacts: \(error)")
+    }
+#endif
   }
 
   private func bundleInteger(forInfoDictionaryKey key: String) -> Int? {
@@ -618,10 +711,14 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
       "resolver.devVendor": "true",
       "resolver.devVendorNative": "true",
       "resolver.devVendorFingerprint": fingerprint,
-      "resolver.devSessionId": devVendorBundleInfo.sessionId,
       "resolver.runtimeTarget": runtimeTarget,
       "unstable_transformProfile": "hermes-stable",
     ]
+    if let sessionId = devVendorBundleInfo.sessionId {
+      values["resolver.devSessionId"] = sessionId
+    } else {
+      values["resolver.devVendorEmbedded"] = "true"
+    }
     if runtimeTarget == "background", isDevBackgroundHMREnabled(fingerprint: fingerprint) {
       values["resolver.devVendorBackgroundHMR"] = "true"
     }
@@ -727,7 +824,6 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 
   override func bundleURL() -> URL? {
 #if DEBUG
-#if ONEKEY_DEV_SHELL && targetEnvironment(simulator)
     if let devVendorBundleInfo {
       initialBundleKind = .devVendorCommon
       NitroModuleBridge.logInfo(
@@ -736,7 +832,6 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
       )
       return devVendorBundleInfo.commonBundleURL
     }
-#endif
     let metroURL = canonicalDevMetroURL(
       RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
     )
@@ -842,7 +937,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 
     (UIApplication.shared.delegate as? AppDelegate)?.reactHost = host
 
-#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)
+#if DEBUG
     if initialBundleKind == .devVendorCommon {
       guard
         let devVendorBundleInfo,

--- a/apps/mobile/plugins/__tests__/devVendor.test.js
+++ b/apps/mobile/plugins/__tests__/devVendor.test.js
@@ -1429,6 +1429,62 @@ describe('devVendor', () => {
     ).toThrow('no valid ONEKEY_DEV_SESSION_ID');
   });
 
+  it('serves embedded native requests only from a session-less Metro server', () => {
+    const manifest = { fingerprint: 'fingerprint-ios' };
+    const sessionId = 'wk-111111111111-dev-222222222222-3333333333333333';
+    const embeddedRequest = {
+      devVendor: 'true',
+      devVendorNative: 'true',
+      devVendorEmbedded: 'true',
+      devVendorFingerprint: 'fingerprint-ios',
+      runtimeTarget: 'background',
+    };
+
+    expect(() =>
+      assertNativeDevVendorResolverContract({
+        customResolverOptions: embeddedRequest,
+        env: {},
+        manifest,
+        platform: 'ios',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertNativeDevVendorResolverContract({
+        customResolverOptions: {
+          ...embeddedRequest,
+          devVendorFingerprint: 'stale',
+        },
+        env: {},
+        manifest,
+        platform: 'ios',
+      }),
+    ).toThrow('cache fingerprint mismatch');
+    expect(() =>
+      assertNativeDevVendorResolverContract({
+        customResolverOptions: { ...embeddedRequest, runtimeTarget: 'worker' },
+        env: {},
+        manifest,
+        platform: 'ios',
+      }),
+    ).toThrow('invalid runtime target');
+    expect(() =>
+      assertNativeDevVendorResolverContract({
+        customResolverOptions: { ...embeddedRequest, devSessionId: sessionId },
+        env: {},
+        manifest,
+        platform: 'ios',
+      }),
+    ).toThrow('must not carry a dev session ID');
+    expect(() =>
+      assertNativeDevVendorResolverContract({
+        customResolverOptions: embeddedRequest,
+        env: { ONEKEY_DEV_SESSION_ID: sessionId },
+        manifest,
+        platform: 'ios',
+      }),
+    ).toThrow('reached a DevSession Metro server');
+  });
+
   it('keeps non-native dev-vendor requests backward compatible', () => {
     expect(() =>
       assertNativeDevVendorResolverContract({

--- a/apps/mobile/plugins/devVendor.js
+++ b/apps/mobile/plugins/devVendor.js
@@ -1255,6 +1255,24 @@ function assertNativeDevVendorResolverContract({
     );
   }
   const requestedSessionId = customResolverOptions.devSessionId;
+  const serverSessionId = env.ONEKEY_DEV_SESSION_ID;
+  if (customResolverOptions.devVendorEmbedded === 'true') {
+    // Xcode/Gradle Debug builds embed the validated common HBC + manifest and
+    // run against a plain `yarn app:native-bundle` Metro. They have no
+    // DevSession, so they may only be served by a Metro server that is not
+    // bound to a DevSession either; DevSession isolation stays intact.
+    if (requestedSessionId !== undefined) {
+      throw new Error(
+        `[devVendor] Native ${platform} embedded request must not carry a dev session ID.`,
+      );
+    }
+    if (typeof serverSessionId === 'string' && serverSessionId.length > 0) {
+      throw new Error(
+        `[devVendor] Native ${platform} embedded request reached a DevSession Metro server.`,
+      );
+    }
+    return;
+  }
   if (
     typeof requestedSessionId !== 'string' ||
     !DEV_SESSION_ID_PATTERN.test(requestedSessionId)
@@ -1263,7 +1281,6 @@ function assertNativeDevVendorResolverContract({
       `[devVendor] Native ${platform} request has an invalid dev session ID.`,
     );
   }
-  const serverSessionId = env.ONEKEY_DEV_SESSION_ID;
   if (
     typeof serverSessionId !== 'string' ||
     !DEV_SESSION_ID_PATTERN.test(serverSessionId)

--- a/apps/mobile/scripts/__tests__/native-dev-shell.test.js
+++ b/apps/mobile/scripts/__tests__/native-dev-shell.test.js
@@ -60,19 +60,34 @@ function createDevSession({
   };
 }
 
+// Source a build without ONEKEY_DEV_SHELL compiles: dev-shell `#if` branches
+// are dropped, their `#else` branches are kept because that is exactly what a
+// production (non dev-shell) variant, including Xcode device Debug builds, gets.
 function stripSwiftDevShellBlocks(source) {
   const output = [];
-  let excludedDepth = 0;
+  const stack = [];
+  const isExcluded = () =>
+    stack.some((frame) => frame.devShell && !frame.inElse);
   for (const line of source.split('\n')) {
     if (/^\s*#if\b/u.test(line)) {
-      if (excludedDepth > 0 || line.includes('ONEKEY_DEV_SHELL')) {
-        excludedDepth += 1;
-      } else {
+      const devShell = line.includes('ONEKEY_DEV_SHELL');
+      const wasExcluded = isExcluded();
+      stack.push({ devShell, inElse: false });
+      if (!wasExcluded && !devShell) {
         output.push(line);
       }
-    } else if (/^\s*#endif\b/u.test(line) && excludedDepth > 0) {
-      excludedDepth -= 1;
-    } else if (excludedDepth === 0) {
+    } else if (/^\s*#else\b/u.test(line) && stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      frame.inElse = true;
+      if (!frame.devShell && !isExcluded()) {
+        output.push(line);
+      }
+    } else if (/^\s*#endif\b/u.test(line) && stack.length > 0) {
+      const frame = stack.pop();
+      if (!frame.devShell && !isExcluded()) {
+        output.push(line);
+      }
+    } else if (!isExcluded()) {
       output.push(line);
     }
   }
@@ -1847,8 +1862,19 @@ describe('native-dev-shell', () => {
     expect(androidDebug).toContain('resolver.devSessionId');
     expect(androidReleaseConfig).not.toContain('ONEKEY_DEV_SHELL');
     expect(iosSource).toContain(
-      '#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)',
+      '#if ONEKEY_DEV_SHELL && targetEnvironment(simulator)',
     );
+    // Xcode Debug builds outside the Simulator dev shell must keep the embedded
+    // common HBC path (no DevSession) or physical devices fall back to two full
+    // Metro bundles and hit the per-process memory limit.
+    expect(iosProductionSource).toContain('#if DEBUG');
+    expect(iosProductionSource).toContain(
+      'forResource: "onekey-dev-vendor-common"',
+    );
+    expect(iosProductionSource).toContain(
+      'values["resolver.devVendorEmbedded"] = "true"',
+    );
+    expect(iosProductionSource).not.toContain('devVendorBundleInfo.sessionId');
 
     expect(androidDebug).toContain(
       'buildDevVendorEntryUrl(metroBaseUrl, sessionId, "main", fingerprint)',


### PR DESCRIPTION
## Summary

Physical-device iOS Debug builds started dying again about 30 s after launch with the 3.3 GB per-process Jetsam kill that #13054 had fixed. Every launch logged `bundleURL(DEBUG): metroURL=…/.expo/.virtual-metro-entry.bundle` plus `background.bundle?…modulesOnly=false`, no `[DevVendor]` line at all, and `[PerfStats] Memory warning received (critical), RSS=2700 MB` at +30 s, even though the "Bundle React Native code and images" phase still embedded `onekey-dev-vendor-common.hbc` into the `.app`.

## Root cause

#13115 wrapped the whole dev-vendor path in `AppDelegate.swift` (`DevVendorBundleInfo`, `resolveDevVendorBundleInfo`, the common HBC branch of `bundleURL()`, and the dev-vendor branch of `hostDidStart`) in `#if ONEKEY_DEV_SHELL && DEBUG && targetEnvironment(simulator)` and moved the manifest lookup to the Simulator DevSession directory. `ONEKEY_DEV_SHELL` is only injected by the Simulator-only dev-shell build, so on a device the code is compiled out and both Hermes V1 runtimes load the full source bundles again. The Metro side also gained a `resolver.devSessionId` check that a plain `yarn app:native-bundle` server cannot satisfy, so restoring the Swift branch alone was not enough. Android devices go through the DevSession launcher and were not affected.

## Changes

- `apps/mobile/ios/AppDelegate.swift`: the shared dev-vendor pieces are gated on `#if DEBUG` again. `resolveDevVendorBundleInfo()` keeps the DevSession resolver under `ONEKEY_DEV_SHELL && targetEnvironment(simulator)` and adds an embedded-artifact resolver for every other Debug build: it reads `onekey-dev-vendor-common.hbc` + `onekey-dev-vendor-manifest.json` from the app bundle, validates size + sha256 against the manifest, derives the Metro base URL from the packager URL, and tags delta requests with `resolver.devVendorEmbedded=true`. `DevVendorBundleInfo.sessionId` is optional; DevSession shells still send `resolver.devSessionId`.
- `apps/mobile/plugins/devVendor.js`: `assertNativeDevVendorResolverContract` accepts an embedded native request only when it carries no dev session ID and the Metro server itself has no `ONEKEY_DEV_SESSION_ID`. DevSession-bound servers keep rejecting foreign requests, so worktree/session isolation is unchanged. The fingerprint and runtime-target checks still apply.
- Test: `serves embedded native requests only from a session-less Metro server`.
- `apps/mobile/scripts/__tests__/native-dev-shell.test.js`: `stripSwiftDevShellBlocks` keeps the `#else` branch of a dev-shell block (that is what a non-shell build compiles), the guard assertion matches the current `#if ONEKEY_DEV_SHELL && targetEnvironment(simulator)`, and the production source must keep the embedded common HBC path so physical devices cannot silently regress to two full Metro bundles again. DevSession identifiers (`resolver.devSessionId`, `sessionId`) stay inside the dev-shell gate.

## Validation

- `npx jest apps/mobile/scripts/__tests__/native-dev-shell.test.js apps/mobile/plugins/__tests__/devVendor.test.js` → 83 passed (on the `x` base)
- `yarn agent:check --profile commit` → all local checks PASS
- iPhone 15 Pro / iOS 26.6, Xcode Debug + `yarn app:native-bundle` (no `ONEKEY_DEV_SESSION_ID`):

| | before | after |
|---|---|---|
| main bundle | full Metro bundle | `[DevVendor] main common.hbc + Metro delta ready (72.4 MB)` at +7 s |
| background | full 102 MB `background.bundle` | embedded common.hbc + 45.5 MB delta, host setup 6.6 s |
| RSS | 2.7 GB warning at +30 s, killed at 3.36 GB | 1.97 GB → plateau 2.23–2.25 GB, no critical warning |
| physFootprint (sysmon) | 3.19 GB before kill | 2.34 GB at +90 s / +150 s |
| lifetime | 1–2 min | still foreground after 4 min |

Metro accepted the embedded requests (`[devVendor] serialize … runtime=main deltaModules=9992`, `runtime=background deltaModules=5975`).

## Notes

- `AppDelegate.swift` is part of `nativeContractFiles`, so this change (like any edit there) rotates the dev-vendor fingerprint: restart `yarn app:native-bundle` and rebuild the app together, otherwise the bundle phase fails its `--check`.
- Background HMR on device still follows `ONEKEY_DEV_BG_HMR` from the launch environment / Info.plist, as after #13115; the old per-fingerprint persistence is not restored here.
