### PR TITLE
fix: recover Market list after request failure

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -12,23 +12,6 @@ import { fetchMarketTokenListForPlatform } from './marketTokenListPlatformApi';
 import { useMarketTokenList } from './useMarketTokenList';
 
 const mockTrackNetworkLoading = jest.fn();
-type IUsePromiseResult =
-  typeof import('@onekeyhq/kit/src/hooks/usePromiseResult').usePromiseResult;
-let mockUsePromiseResultOverride: IUsePromiseResult | undefined;
-
-jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
-  const actual = jest.requireActual<
-    typeof import('@onekeyhq/kit/src/hooks/usePromiseResult')
-  >('@onekeyhq/kit/src/hooks/usePromiseResult');
-
-  return {
-    ...actual,
-    usePromiseResult: (...args: Parameters<IUsePromiseResult>) =>
-      mockUsePromiseResultOverride
-        ? mockUsePromiseResultOverride(...args)
-        : actual.usePromiseResult(...args),
-  };
-});
 
 jest.mock('@onekeyhq/components', () => ({
   getCurrentVisibilityState: () => true,
@@ -113,10 +96,12 @@ jest.mock('./marketTokenListPlatformApi', () => ({
 
 function createDeferred<T>() {
   let resolve: (value: T) => void = () => undefined;
-  const promise = new Promise<T>((promiseResolve) => {
+  let reject: (reason: Error) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
     resolve = promiseResolve;
+    reject = promiseReject;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function createResponse(
@@ -142,7 +127,6 @@ describe('useMarketTokenList initial data', () => {
   const mockFetchMarketTokenList = jest.mocked(fetchMarketTokenListForPlatform);
 
   beforeEach(() => {
-    mockUsePromiseResultOverride = undefined;
     swrCacheUtils.clearAll();
     swrCacheUtils.flushNow();
     mockFetchMarketTokenList.mockReset();
@@ -150,41 +134,97 @@ describe('useMarketTokenList initial data', () => {
   });
 
   afterEach(() => {
-    mockUsePromiseResultOverride = undefined;
     swrCacheUtils.clearAll();
     swrCacheUtils.flushNow();
   });
 
-  it('stops reporting a network switch after an empty request settles', async () => {
-    let settleRequest: () => void = () => undefined;
+  it('keeps the switching skeleton until a successful response is transformed', async () => {
+    const remoteResponse = createResponse('0xremote', 'Remote Token', 'REMOTE');
+    const remoteRequest = createDeferred<IMarketTokenListResponse>();
+    const renderedStates: Array<{
+      data: string[];
+      isLoading: boolean | undefined;
+      isNetworkSwitching: boolean;
+    }> = [];
 
-    mockUsePromiseResultOverride = ((_method, _deps, options) => {
-      settleRequest = () => options?.onIsLoadingChange?.(false);
-      return {
-        result: undefined,
-        setResult: jest.fn(),
-        isLoading: false,
-        run: jest.fn(async () => undefined),
-        setStopPolling: jest.fn(() => false),
-      };
-    }) as IUsePromiseResult;
+    mockFetchMarketTokenList.mockReturnValueOnce(remoteRequest.promise);
 
-    const { result } = renderHook(() =>
-      useMarketTokenList({
+    function Probe() {
+      const result = useMarketTokenList({
         networkId: 'evm--1',
         pollingInterval: 0,
         type: 'trending',
-      }),
-    );
+      });
+      renderedStates.push({
+        data: result.data.map((item) => item.id),
+        isLoading: result.isLoading,
+        isNetworkSwitching: result.isNetworkSwitching,
+      });
+      return null;
+    }
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(mockFetchMarketTokenList).toHaveBeenCalledTimes(1);
+    });
     await act(async () => {
-      settleRequest();
-      await Promise.resolve();
+      remoteRequest.resolve(remoteResponse);
+      await remoteRequest.promise;
     });
 
-    expect(result.current).toMatchObject({
-      data: [],
-      isLoading: false,
-      isNetworkSwitching: false,
+    await waitFor(() => {
+      expect(renderedStates.at(-1)).toMatchObject({
+        data: ['0xremote'],
+        isNetworkSwitching: false,
+      });
+    });
+    expect(
+      renderedStates.some(
+        (state) =>
+          state.isLoading === false &&
+          !state.isNetworkSwitching &&
+          state.data.length === 0,
+      ),
+    ).toBe(false);
+  });
+
+  it('clears stale rows when a network switch request fails', async () => {
+    const failedRequest = createDeferred<IMarketTokenListResponse>();
+    mockFetchMarketTokenList
+      .mockResolvedValueOnce(createResponse('0xold', 'Old Token', 'OLD'))
+      .mockReturnValueOnce(failedRequest.promise);
+
+    const { result, rerender } = renderHook(
+      ({ networkId }) =>
+        useMarketTokenList({
+          networkId,
+          pollingInterval: 0,
+          type: 'trending',
+        }),
+      { initialProps: { networkId: 'evm--1' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data.map((item) => item.id)).toEqual(['0xold']);
+    });
+
+    rerender({ networkId: 'evm--137' });
+    await waitFor(() => {
+      expect(result.current.isNetworkSwitching).toBe(true);
+    });
+
+    await act(async () => {
+      failedRequest.reject(new Error('request failed'));
+      await failedRequest.promise.catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        data: [],
+        isLoading: false,
+        isNetworkSwitching: false,
+      });
     });
   });
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 
 import {
   swrCacheUtils,
@@ -12,6 +12,23 @@ import { fetchMarketTokenListForPlatform } from './marketTokenListPlatformApi';
 import { useMarketTokenList } from './useMarketTokenList';
 
 const mockTrackNetworkLoading = jest.fn();
+type IUsePromiseResult =
+  typeof import('@onekeyhq/kit/src/hooks/usePromiseResult').usePromiseResult;
+let mockUsePromiseResultOverride: IUsePromiseResult | undefined;
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
+  const actual = jest.requireActual<
+    typeof import('@onekeyhq/kit/src/hooks/usePromiseResult')
+  >('@onekeyhq/kit/src/hooks/usePromiseResult');
+
+  return {
+    ...actual,
+    usePromiseResult: (...args: Parameters<IUsePromiseResult>) =>
+      mockUsePromiseResultOverride
+        ? mockUsePromiseResultOverride(...args)
+        : actual.usePromiseResult(...args),
+  };
+});
 
 jest.mock('@onekeyhq/components', () => ({
   getCurrentVisibilityState: () => true,
@@ -125,6 +142,7 @@ describe('useMarketTokenList initial data', () => {
   const mockFetchMarketTokenList = jest.mocked(fetchMarketTokenListForPlatform);
 
   beforeEach(() => {
+    mockUsePromiseResultOverride = undefined;
     swrCacheUtils.clearAll();
     swrCacheUtils.flushNow();
     mockFetchMarketTokenList.mockReset();
@@ -132,8 +150,42 @@ describe('useMarketTokenList initial data', () => {
   });
 
   afterEach(() => {
+    mockUsePromiseResultOverride = undefined;
     swrCacheUtils.clearAll();
     swrCacheUtils.flushNow();
+  });
+
+  it('stops reporting a network switch after an empty request settles', async () => {
+    let settleRequest: () => void = () => undefined;
+
+    mockUsePromiseResultOverride = ((_method, _deps, options) => {
+      settleRequest = () => options?.onIsLoadingChange?.(false);
+      return {
+        result: undefined,
+        setResult: jest.fn(),
+        isLoading: false,
+        run: jest.fn(async () => undefined),
+        setStopPolling: jest.fn(() => false),
+      };
+    }) as IUsePromiseResult;
+
+    const { result } = renderHook(() =>
+      useMarketTokenList({
+        networkId: 'evm--1',
+        pollingInterval: 0,
+        type: 'trending',
+      }),
+    );
+    await act(async () => {
+      settleRequest();
+      await Promise.resolve();
+    });
+
+    expect(result.current).toMatchObject({
+      data: [],
+      isLoading: false,
+      isNetworkSwitching: false,
+    });
   });
 
   it('renders SWR rows on the first frame, then replaces and caches the remote page', async () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -213,6 +213,7 @@ describe('useMarketTokenList initial data', () => {
     await waitFor(() => {
       expect(result.current.isNetworkSwitching).toBe(true);
     });
+    expect(result.current.data.map((item) => item.id)).toEqual(['0xold']);
 
     await act(async () => {
       failedRequest.reject(new Error('request failed'));
@@ -226,6 +227,79 @@ describe('useMarketTokenList initial data', () => {
         isNetworkSwitching: false,
       });
     });
+  });
+
+  it('keeps the switching skeleton until a retry response is transformed', async () => {
+    const failedRequest = createDeferred<IMarketTokenListResponse>();
+    const recoveredRequest = createDeferred<IMarketTokenListResponse>();
+    const renderedStates: Array<{
+      data: string[];
+      isLoading: boolean | undefined;
+      isNetworkSwitching: boolean;
+    }> = [];
+    mockFetchMarketTokenList
+      .mockReturnValueOnce(failedRequest.promise)
+      .mockReturnValueOnce(recoveredRequest.promise);
+
+    const { result } = renderHook(() => {
+      const value = useMarketTokenList({
+        networkId: 'evm--1',
+        pollingInterval: 0,
+        type: 'trending',
+      });
+      renderedStates.push({
+        data: value.data.map((item) => item.id),
+        isLoading: value.isLoading,
+        isNetworkSwitching: value.isNetworkSwitching,
+      });
+      return value;
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+    await act(async () => {
+      failedRequest.reject(new Error('request failed'));
+      await failedRequest.promise.catch(() => undefined);
+    });
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        data: [],
+        isLoading: false,
+        isNetworkSwitching: false,
+      });
+    });
+
+    const retryRenderStart = renderedStates.length;
+    let retryPromise: Promise<void> | undefined;
+    act(() => {
+      retryPromise = result.current.refetch();
+    });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+    await act(async () => {
+      recoveredRequest.resolve(
+        createResponse('0xrecovered', 'Recovered Token', 'RECOVERED'),
+      );
+      await retryPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.data.map((item) => item.id)).toEqual([
+        '0xrecovered',
+      ]);
+    });
+    expect(
+      renderedStates
+        .slice(retryRenderStart)
+        .some(
+          (state) =>
+            state.isLoading === false &&
+            !state.isNetworkSwitching &&
+            state.data.length === 0,
+        ),
+    ).toBe(false);
   });
 
   it('renders SWR rows on the first frame, then replaces and caches the remote page', async () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -461,11 +461,7 @@ export function useMarketTokenList({
     {
       checkIsFocused: !platformEnv.isWeb,
       watchLoading: hasNetworkId,
-      onIsLoadingChange: (nextIsLoading) => {
-        if (!nextIsLoading) {
-          setIsNetworkSwitching(false);
-        }
-      },
+      undefinedResultIfError: true,
       pollingInterval,
       revalidateOnFocus: true,
       revalidateOnReconnect: true,
@@ -492,6 +488,15 @@ export function useMarketTokenList({
       timeRange: timeRangeRef.current,
     }),
   );
+
+  useEffect(() => {
+    // Successful results keep the switching skeleton until the transform effect
+    // commits their rows. A settled error must instead drop the previous scope.
+    if (hasNetworkId && isLoading === false && apiResult === undefined) {
+      setTransformedData([]);
+      setIsNetworkSwitching(false);
+    }
+  }, [apiResult, hasNetworkId, isLoading]);
 
   const effectiveIsLoading = hasNetworkId ? isLoading : false;
   const isSeedResult = Boolean(apiResult?.__fromSeed);

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -461,6 +461,11 @@ export function useMarketTokenList({
     {
       checkIsFocused: !platformEnv.isWeb,
       watchLoading: hasNetworkId,
+      onIsLoadingChange: (nextIsLoading) => {
+        if (!nextIsLoading) {
+          setIsNetworkSwitching(false);
+        }
+      },
       pollingInterval,
       revalidateOnFocus: true,
       revalidateOnReconnect: true,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -488,15 +488,29 @@ export function useMarketTokenList({
       timeRange: timeRangeRef.current,
     }),
   );
+  const previousIsLoadingRef = useRef(isLoading);
 
   useEffect(() => {
+    const wasLoading = previousIsLoadingRef.current;
+    previousIsLoadingRef.current = isLoading;
+
+    if (isLoading === true && transformedData.length === 0) {
+      setIsNetworkSwitching(true);
+      return;
+    }
+
     // Successful results keep the switching skeleton until the transform effect
     // commits their rows. A settled error must instead drop the previous scope.
-    if (hasNetworkId && isLoading === false && apiResult === undefined) {
+    if (
+      hasNetworkId &&
+      wasLoading === true &&
+      isLoading === false &&
+      apiResult === undefined
+    ) {
       setTransformedData([]);
       setIsNetworkSwitching(false);
     }
-  }, [apiResult, hasNetworkId, isLoading]);
+  }, [apiResult, hasNetworkId, isLoading, transformedData.length]);
 
   const effectiveIsLoading = hasNetworkId ? isLoading : false;
   const isSeedResult = Boolean(apiResult?.__fromSeed);


### PR DESCRIPTION
## Summary

- Keep the Market network-switch skeleton active until a successful token-list response has been transformed and committed.
- Reset failed latest requests, clear rows from the previous scope, and then release the switching state so the page cannot remain on its skeleton indefinitely or expose stale tokens.
- Add real-hook regression coverage for both the successful transition and a failed network switch.

## Reproduction

1. Launch Desktop with a fresh profile.
2. Fail the first `/utility/v2/market/token/list` request.
3. Before this change, the Market page remains on the skeleton after the request has settled and network access is restored.

## Verification

- Full Electron build and isolated-profile runtime test.
- Successful cold request: no settled empty-state frame before transformed rows render.
- Injected Robinhood token-list failure after Hot data loaded: empty state renders without exposing the previous rows.
- Restored requests: Robinhood rows render without restarting the App.
- `yarn tsc:only`
- `yarn tsc:staged`
- 4 focused Jest suites, 34 tests passed.
- Type-aware Oxlint: 0 warnings, 0 errors.
- Prettier and `git diff --check` passed.

## Environment note

`yarn agent:check --profile commit` cannot spawn its Windows child processes in this environment (`exitCode: null` with no code diagnostics). The underlying type, lint, format, and focused test commands were run directly and passed. The repository `lint:staged` shell pipeline also requires Unix `xargs`/`grep`, which are unavailable in this PowerShell environment.

