### PR TITLE
fix: polish perps trading UI (OK-62018)

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -293,6 +293,10 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     fontWeight: '500',
   },
+  nativeMobileHorizontalTabularText: {
+    fontFamily: 'Roobert-Regular',
+    fontWeight: '400',
+  },
   interactiveRow: {
     height: rowHeight,
     position: 'relative',
@@ -1153,6 +1157,10 @@ export function OrderBook({
   const textColor = useTextColor();
   const spreadColor = useSpreadColor();
   const isInteractive = Boolean(onSelectLevel);
+  const mobileHorizontalTabularTextStyle =
+    platformEnv.isNative && variant === 'mobileHorizontal'
+      ? styles.nativeMobileHorizontalTabularText
+      : undefined;
 
   const hoverSummary = useMemo(() => {
     if (
@@ -1421,6 +1429,7 @@ export function OrderBook({
                           <PerpBookText
                             style={[
                               styles.tabularText,
+                              mobileHorizontalTabularTextStyle,
                               { color: textColor.textSubdued },
                             ]}
                           >
@@ -1429,6 +1438,7 @@ export function OrderBook({
                           <PerpBookText
                             style={[
                               styles.tabularText,
+                              mobileHorizontalTabularTextStyle,
                               { color: textColor.green },
                             ]}
                           >
@@ -1455,6 +1465,7 @@ export function OrderBook({
                           <PerpBookText
                             style={[
                               styles.tabularText,
+                              mobileHorizontalTabularTextStyle,
                               { color: textColor.red },
                             ]}
                           >
@@ -1463,6 +1474,7 @@ export function OrderBook({
                           <PerpBookText
                             style={[
                               styles.tabularText,
+                              mobileHorizontalTabularTextStyle,
                               { color: textColor.textSubdued },
                             ]}
                           >

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -10,6 +10,7 @@ import {
 import type { ReactElement, ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
+import { type LayoutChangeEvent, StyleSheet } from 'react-native';
 
 import {
   Button,
@@ -40,6 +41,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { markPerpsColdStartPerfOnce } from '@onekeyhq/shared/src/performance/perpsColdStartPerf';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { getPerpsOrderBookTickOptionWithCache } from '@onekeyhq/shared/src/utils/perpsOrderBookTickOptionsCache';
 import {
@@ -87,7 +89,6 @@ import { useTickOptions } from './OrderBook/useTickOptions';
 import { PerpOrderBookMobileVerticalShell } from './PerpOrderBookMobileVerticalShell';
 
 import type { ITickParam } from './OrderBook/tickSizeUtils';
-import type { LayoutChangeEvent } from 'react-native';
 
 const FUNDING_DIALOG_CLOSE_DURATION_MS = 100;
 
@@ -229,7 +230,7 @@ function FundingDialogContent({
           </XStack>
         </YStack>
       </YStack>
-      <Divider />
+      <FundingDialogDivider />
 
       <YStack gap="$2">
         <SizableText size="$bodyMd" color="$textSubdued">
@@ -272,7 +273,7 @@ function FundingDialogContent({
         )}
       </YStack>
 
-      <Divider />
+      <FundingDialogDivider />
       <YStack gap="$2">
         <SizableText size="$bodyMd" color="$textSubdued">
           {intl.formatMessage({
@@ -302,6 +303,24 @@ function FundingDialogContent({
         })}
       </Button>
     </YStack>
+  );
+}
+
+function FundingDialogDivider() {
+  if (!platformEnv.isNative) {
+    return <Divider />;
+  }
+
+  return (
+    <Divider
+      bg="$borderSubdued"
+      borderBottomWidth={0}
+      flex={0}
+      h={StyleSheet.hairlineWidth}
+      maxHeight={StyleSheet.hairlineWidth}
+      w="100%"
+      y={0}
+    />
   );
 }
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -15,7 +15,6 @@ import {
   Select,
   SizableText,
   Skeleton,
-  Stack,
   Tooltip,
   XStack,
   YStack,
@@ -2586,28 +2585,22 @@ function PerpTradingForm({
                 height={checkboxSizeVal}
                 {...(isMobile && { p: '$0', borderWidth: 1.5 })}
               />
-              <Tooltip
-                placement="top"
-                triggerAsChild="except-style"
-                renderContent={intl.formatMessage({
+              <DashText
+                size={isMobile ? '$bodySm' : '$bodyMdMedium'}
+                color="$text"
+                dashColor="$textDisabled"
+                dashThickness={0.5}
+                tooltip={intl.formatMessage({
                   id: ETranslations.perp_twap_randomize__desc,
                 })}
-                renderTrigger={
-                  <Stack display="inline-flex" alignSelf="flex-start">
-                    <DashText
-                      size={isMobile ? '$bodySm' : '$bodyMdMedium'}
-                      color="$text"
-                      dashColor="$textDisabled"
-                      dashThickness={0.5}
-                      cursor="help"
-                    >
-                      {intl.formatMessage({
-                        id: ETranslations.perp_twap_randomize__title,
-                      })}
-                    </DashText>
-                  </Stack>
-                }
-              />
+                tooltipTitle={intl.formatMessage({
+                  id: ETranslations.perp_twap_randomize__title,
+                })}
+              >
+                {intl.formatMessage({
+                  id: ETranslations.perp_twap_randomize__title,
+                })}
+              </DashText>
             </XStack>
             {twapEstimatedSliceNotionalDisplay ? (
               <XStack


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-62018](https://onekeyhq.atlassian.net/browse/OK-62018)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- use regular weight for Native horizontal order book values
- render stable Native hairline dividers in the funding dialog
- align the TWAP randomize tooltip with the shared DashText pattern

## Validation
- yarn agent:check --profile commit
- yarn agent:check --profile pr

## Issue
- https://onekeyhq.atlassian.net/browse/OK-62018

[OK-62018]: https://onekeyhq.atlassian.net/browse/OK-62018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ