### PR TITLE
feat: Robinhood network defaults and stale wallet config refresh on v6.5.2(OK-62300 OK-58112)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1569,3 +1569,5 @@ tnum
 cctp
 hypercore
 robinhood
+usdg
+USDG

--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1571,3 +1571,4 @@ hypercore
 robinhood
 usdg
 USDG
+cyeth

--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1568,3 +1568,4 @@ tnum
 # Circle Cross-Chain Transfer Protocol, and Hyperliquid's L1
 cctp
 hypercore
+robinhood

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
@@ -35,6 +35,12 @@ export interface ISimpleDBAggregateToken {
     }
   >;
   allAggregateTokens?: IAccountToken[];
+  // Tracks the last successful wallet-config sync so stale caches written by
+  // older app versions (with a different preset network list) get refreshed.
+  configSyncMeta?: {
+    appVersion: string;
+    syncedAt: number;
+  };
   tokenDetails?: Record<
     string, // all networks accountId
     Record<
@@ -186,6 +192,7 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     homeDefaultTokenMap,
     allAggregateTokenMap,
     allAggregateTokens,
+    configSyncMeta,
     merge = false,
   }: {
     allAggregateTokenMap: Record<string, { tokens: IAccountToken[] }>;
@@ -193,10 +200,15 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     aggregateTokenConfigMap: Record<string, IAggregateToken>;
     aggregateTokenSymbolMap: Record<string, boolean>;
     homeDefaultTokenMap: Record<string, IHomeDefaultToken>;
+    configSyncMeta?: {
+      appVersion: string;
+      syncedAt: number;
+    };
     merge?: boolean;
   }) {
     await this.setRawData((rawData) => ({
       ...rawData,
+      configSyncMeta: configSyncMeta ?? rawData?.configSyncMeta,
       aggregateTokenSymbolMap: merge
         ? { ...rawData?.aggregateTokenSymbolMap, ...aggregateTokenSymbolMap }
         : aggregateTokenSymbolMap,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
@@ -236,6 +236,17 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     }));
   }
 
+  // Drops the sync marker so the next syncWalletConfigIfNeeded re-fetches the
+  // wallet config. Used when the server-network set changes, because the
+  // cached aggregate-token maps were gated on the previous set.
+  @backgroundMethod()
+  async clearConfigSyncMeta() {
+    await this.setRawData((rawData) => ({
+      ...rawData,
+      configSyncMeta: undefined,
+    }));
+  }
+
   @backgroundMethod()
   async updateLastActiveTabNameInTokenDetails({
     accountId,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
@@ -36,9 +36,12 @@ export interface ISimpleDBAggregateToken {
   >;
   allAggregateTokens?: IAccountToken[];
   // Tracks the last successful wallet-config sync so stale caches written by
-  // older app versions (with a different preset network list) get refreshed.
+  // older builds (with a different preset network list) get refreshed. Hot
+  // updates keep appVersion but change bundleVersion, so both are tracked.
   configSyncMeta?: {
     appVersion: string;
+    // Absent on caches written before bundle tracking was added.
+    bundleVersion?: string;
     syncedAt: number;
   };
   tokenDetails?: Record<
@@ -202,6 +205,7 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     homeDefaultTokenMap: Record<string, IHomeDefaultToken>;
     configSyncMeta?: {
       appVersion: string;
+      bundleVersion?: string;
       syncedAt: number;
     };
     merge?: boolean;

--- a/packages/kit-bg/src/services/ServiceCustomRpc.serverNetworks.test.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.serverNetworks.test.ts
@@ -1,0 +1,153 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: any) => target,
+  backgroundMethod: () => (_t: any, _k: string, desc: any) => desc,
+  backgroundMethodForDev: () => (_t: any, _k: string, desc: any) => desc,
+  toastIfError: () => (_t: any, _k: string, desc: any) => desc,
+  checkDevOnlyPassword: jest.fn(),
+}));
+
+jest.mock('./ServiceBase', () => ({
+  __esModule: true,
+  default: class ServiceBase {
+    backgroundApi: any;
+
+    constructor({ backgroundApi }: { backgroundApi: any }) {
+      this.backgroundApi = backgroundApi;
+    }
+
+    // Replaced per test via jest.spyOn.
+    async getClient(): Promise<any> {
+      return undefined;
+    }
+  },
+}));
+
+jest.mock('../vaults/factory', () => ({ vaultFactory: {} }));
+
+// eslint-disable-next-line import-js/order, import/first
+import { ENetworkStatus, type IServerNetwork } from '@onekeyhq/shared/types';
+
+// eslint-disable-next-line import-js/order, import/first
+import ServiceCustomRpc from './ServiceCustomRpc';
+
+// Server-delivered network that is not part of presetNetworks.
+const robinhood = {
+  id: 'evm--4663',
+  status: ENetworkStatus.LISTED,
+} as IServerNetwork;
+
+function buildService({
+  cachedNetworks,
+  lastFetchTime,
+  serverNetworks,
+}: {
+  cachedNetworks: IServerNetwork[];
+  lastFetchTime: number | undefined;
+  serverNetworks: IServerNetwork[];
+}) {
+  const clearConfigSyncMeta = jest.fn(async () => undefined);
+  const upsertServerNetworks = jest.fn(async () => undefined);
+  const service = new ServiceCustomRpc({
+    backgroundApi: {
+      simpleDb: {
+        serverNetwork: {
+          getAllServerNetworks: jest.fn(async () => ({
+            networks: cachedNetworks,
+            lastFetchTime,
+          })),
+          upsertServerNetworks,
+        },
+        customNetwork: {
+          getAllCustomNetworks: jest.fn(async () => []),
+        },
+        aggregateToken: { clearConfigSyncMeta },
+      },
+      serviceNetwork: {
+        clearAllNetworksCache: jest.fn(async () => undefined),
+      },
+    },
+  } as any);
+  const get = jest.fn(async () => ({ data: { data: serverNetworks } }));
+  jest
+    .spyOn(service as any, 'getClient')
+    .mockImplementation(async () => ({ get }));
+  return { service, get, clearConfigSyncMeta, upsertServerNetworks };
+}
+
+describe('ServiceCustomRpc server networks', () => {
+  it('ensureServerNetworksFetched fetches when the cache was never filled', async () => {
+    const { service, get, upsertServerNetworks } = buildService({
+      cachedNetworks: [],
+      lastFetchTime: undefined,
+      serverNetworks: [robinhood],
+    });
+
+    await service.ensureServerNetworksFetched();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(upsertServerNetworks).toHaveBeenCalledWith({
+      networkInfos: [robinhood],
+    });
+  });
+
+  it('ensureServerNetworksFetched skips the request once the cache is filled', async () => {
+    const { service, get } = buildService({
+      cachedNetworks: [robinhood],
+      lastFetchTime: Date.now(),
+      serverNetworks: [robinhood],
+    });
+
+    await service.ensureServerNetworksFetched();
+
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('ensureServerNetworksFetched swallows fetch failures', async () => {
+    const { service, get } = buildService({
+      cachedNetworks: [],
+      lastFetchTime: undefined,
+      serverNetworks: [],
+    });
+    get.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(
+      service.ensureServerNetworksFetched(),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fetchNetworkFromServer shares one in-flight request', async () => {
+    const { service, get } = buildService({
+      cachedNetworks: [],
+      lastFetchTime: undefined,
+      serverNetworks: [robinhood],
+    });
+
+    await Promise.all([
+      service.fetchNetworkFromServer(),
+      service.fetchNetworkFromServer(),
+    ]);
+    await service.fetchNetworkFromServer();
+
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates the wallet config only when the server-network set changed', async () => {
+    const changed = buildService({
+      cachedNetworks: [],
+      lastFetchTime: undefined,
+      serverNetworks: [robinhood],
+    });
+    await changed.service.fetchNetworkFromServer();
+    expect(changed.clearConfigSyncMeta).toHaveBeenCalledTimes(1);
+
+    const unchanged = buildService({
+      cachedNetworks: [robinhood],
+      lastFetchTime: Date.now(),
+      serverNetworks: [robinhood],
+    });
+    await unchanged.service.fetchNetworkFromServer();
+    expect(unchanged.clearConfigSyncMeta).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -524,8 +524,44 @@ class ServiceCustomRpc extends ServiceBase {
     });
   }
 
+  // Resolves once the server-network cache has been filled at least once.
+  // Callers that gate on server-delivered networks (e.g. wallet-config
+  // aggregate members) use this instead of getServerNetworks, which returns
+  // the possibly empty cache and only refreshes it in the background.
+  // Fetch failures are swallowed: the caller proceeds with the cache it has
+  // and the hourly refresh in getServerNetworks retries later.
+  @backgroundMethod()
+  public async ensureServerNetworksFetched(): Promise<void> {
+    try {
+      const { lastFetchTime } =
+        await this.backgroundApi.simpleDb.serverNetwork.getAllServerNetworks();
+      if (lastFetchTime) {
+        return;
+      }
+      await this.fetchNetworkFromServer();
+    } catch (error) {
+      defaultLogger.account.wallet.getServerNetworksError(error);
+    }
+  }
+
+  private _fetchNetworkFromServerPromise: Promise<IServerNetwork[]> | undefined;
+
+  // Single-flight: getServerNetworks fires a background refresh from every
+  // stale read, so concurrent callers share one in-flight request instead of
+  // each issuing their own.
   @backgroundMethod()
   public async fetchNetworkFromServer(): Promise<IServerNetwork[]> {
+    if (this._fetchNetworkFromServerPromise) {
+      return this._fetchNetworkFromServerPromise;
+    }
+    this._fetchNetworkFromServerPromise =
+      this._fetchNetworkFromServer().finally(() => {
+        this._fetchNetworkFromServerPromise = undefined;
+      });
+    return this._fetchNetworkFromServerPromise;
+  }
+
+  private async _fetchNetworkFromServer(): Promise<IServerNetwork[]> {
     // await timerUtils.wait(3000 * 10);
     defaultLogger.account.wallet.fetchNetworkFromServer();
     // Request /wallet/v1/network/list to get all evm networks
@@ -592,6 +628,10 @@ class ServiceCustomRpc extends ServiceBase {
     // signal every network selector already listens to.
     if (serverNetworkListChanged) {
       appEventBus.emit(EAppEventBusNames.AddedCustomNetwork, undefined);
+      // The cached aggregate-token maps were gated on the previous
+      // server-network set, so let the next syncWalletConfigIfNeeded rebuild
+      // them instead of waiting for the config TTL.
+      await this.backgroundApi.simpleDb.aggregateToken.clearConfigSyncMeta();
     }
 
     defaultLogger.account.wallet.insertServerNetwork(usedNetworks);

--- a/packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts
+++ b/packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts
@@ -16,6 +16,7 @@ import {
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
+  ROBINHOOD_NETWORK_ID,
   dangerAggregateTokenNetworkRepresent,
   getPresetNetworks,
   presetNetworksMap,
@@ -69,6 +70,8 @@ import type {
 } from '../../vaults/types';
 
 const defaultPinnedNetworkIds = [
+  // Robinhood sits above Bitcoin in the single-network selector (OK-62300).
+  ROBINHOOD_NETWORK_ID,
   getNetworkIdsMap().btc,
   getNetworkIdsMap().lightning,
   getNetworkIdsMap().eth,

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts
@@ -40,7 +40,13 @@ function buildMember(networkId: string): IAggregateToken {
   return { networkId, address: '', decimals: 18 } as IAggregateToken;
 }
 
-function buildService({ networks }: { networks: IServerNetwork[] }) {
+function buildService({
+  networks,
+  ensureServerNetworksFetched = jest.fn(async () => undefined),
+}: {
+  networks: IServerNetwork[] | (() => IServerNetwork[]);
+  ensureServerNetworksFetched?: jest.Mock<Promise<void>, []>;
+}) {
   const updateAllAggregateInfo = jest.fn(
     async (_params: IUpdateAllAggregateInfoParams) => undefined,
   );
@@ -53,7 +59,12 @@ function buildService({ networks }: { networks: IServerNetwork[] }) {
         },
       },
       serviceNetwork: {
-        getAllNetworks: jest.fn(async () => ({ networks })),
+        getAllNetworks: jest.fn(async () => ({
+          networks: typeof networks === 'function' ? networks() : networks,
+        })),
+      },
+      serviceCustomRpc: {
+        ensureServerNetworksFetched,
       },
     },
   });
@@ -131,5 +142,31 @@ describe('ServiceSetting.syncWalletConfig', () => {
 
     // Only one eligible member is left, so ETH is not an aggregate token.
     expect(Object.keys(configMap)).toEqual([]);
+  });
+
+  it('waits for the server-network cache before gating members', async () => {
+    // Fresh install: the merged registry only knows presets until the first
+    // server-network fetch lands, which is what ensureServerNetworksFetched
+    // awaits.
+    let cachedNetworks = [ethereum];
+    const ensureServerNetworksFetched = jest.fn(async () => {
+      cachedNetworks = [ethereum, robinhood];
+    });
+    const { service } = buildService({
+      networks: () => cachedNetworks,
+      ensureServerNetworksFetched,
+    });
+
+    const configMap = await sync(service);
+
+    expect(ensureServerNetworksFetched).toHaveBeenCalledTimes(1);
+    expect(
+      configMap[
+        buildAggregateTokenMapKeyForAggregateConfig({
+          networkId: 'evm--4663',
+          tokenAddress: '',
+        })
+      ],
+    ).toBeDefined();
   });
 });

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  buildAggregateTokenListMapKeyForTokenList,
+  buildAggregateTokenMapKeyForAggregateConfig,
+} from '@onekeyhq/shared/src/utils/tokenUtils';
+import { ENetworkStatus, type IServerNetwork } from '@onekeyhq/shared/types';
+import type { IFetchWalletConfigResp } from '@onekeyhq/shared/types/setting';
+import type { IAggregateToken } from '@onekeyhq/shared/types/token';
+
+import ServiceSetting from './ServiceSetting';
+
+import type { SimpleDbEntityAggregateToken } from '../dbs/simple/entity/SimpleDbEntityAggregateToken';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: any) => target,
+  backgroundMethod: () => (_t: any, _k: string, desc: any) => desc,
+  backgroundMethodForDev: () => (_t: any, _k: string, desc: any) => desc,
+  toastIfError: () => (_t: any, _k: string, desc: any) => desc,
+  checkDevOnlyPassword: jest.fn(),
+}));
+
+// Preset network.
+const ethereum = {
+  id: 'evm--1',
+  status: ENetworkStatus.LISTED,
+} as IServerNetwork;
+// Server-delivered network that is not part of presetNetworks.
+const robinhood = {
+  id: 'evm--4663',
+  status: ENetworkStatus.LISTED,
+} as IServerNetwork;
+
+type IUpdateAllAggregateInfoParams = Parameters<
+  SimpleDbEntityAggregateToken['updateAllAggregateInfo']
+>[0];
+
+function buildMember(networkId: string): IAggregateToken {
+  return { networkId, address: '', decimals: 18 } as IAggregateToken;
+}
+
+function buildService({ networks }: { networks: IServerNetwork[] }) {
+  const updateAllAggregateInfo = jest.fn(
+    async (_params: IUpdateAllAggregateInfoParams) => undefined,
+  );
+  const service = new ServiceSetting({
+    backgroundApi: {
+      simpleDb: {
+        aggregateToken: { updateAllAggregateInfo },
+        approval: {
+          updateApprovalResurfaceDaysConfig: jest.fn(async () => undefined),
+        },
+      },
+      serviceNetwork: {
+        getAllNetworks: jest.fn(async () => ({ networks })),
+      },
+    },
+  });
+  const config: IFetchWalletConfigResp['data'] = {
+    meta: {
+      homeDefaults: [],
+      approvalResurfaceDays: 14,
+      approvalAlertResurfaceDays: 30,
+    },
+    tokens: {
+      ETH: {
+        logoURI: 'eth.png',
+        name: 'Ethereum',
+        data: [
+          buildMember('evm--1'),
+          buildMember('evm--4663'),
+          // Unknown to the client: must never reach the aggregate maps.
+          buildMember('evm--999999'),
+        ],
+      },
+    },
+  };
+  jest.spyOn(service, 'fetchWalletConfig').mockResolvedValue(config);
+  return { service, updateAllAggregateInfo };
+}
+
+async function sync(service: ServiceSetting) {
+  const configMap = await service.syncWalletConfig();
+  if (!configMap) {
+    throw new OneKeyLocalError('syncWalletConfig returned no config map');
+  }
+  return configMap;
+}
+
+describe('ServiceSetting.syncWalletConfig', () => {
+  it('keeps aggregate members on server-delivered networks that are not presets', async () => {
+    const { service, updateAllAggregateInfo } = buildService({
+      networks: [ethereum, robinhood],
+    });
+
+    const configMap = await sync(service);
+
+    expect(
+      configMap[
+        buildAggregateTokenMapKeyForAggregateConfig({
+          networkId: 'evm--4663',
+          tokenAddress: '',
+        })
+      ],
+    ).toBeDefined();
+    expect(
+      configMap[
+        buildAggregateTokenMapKeyForAggregateConfig({
+          networkId: 'evm--999999',
+          tokenAddress: '',
+        })
+      ],
+    ).toBeUndefined();
+
+    const { allAggregateTokenMap } = updateAllAggregateInfo.mock.calls[0][0];
+    const ethGroup =
+      allAggregateTokenMap[
+        buildAggregateTokenListMapKeyForTokenList({ commonSymbol: 'ETH' })
+      ];
+    expect(ethGroup.tokens.map((token) => token.networkId)).toEqual([
+      'evm--1',
+      'evm--4663',
+    ]);
+  });
+
+  it('drops members whose network is missing from the merged registry', async () => {
+    const { service } = buildService({ networks: [ethereum] });
+
+    const configMap = await sync(service);
+
+    // Only one eligible member is left, so ETH is not an aggregate token.
+    expect(Object.keys(configMap)).toEqual([]);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts
@@ -31,21 +31,37 @@ const robinhood = {
   id: 'evm--4663',
   status: ENetworkStatus.LISTED,
 } as IServerNetwork;
+const base = {
+  id: 'evm--8453',
+  status: ENetworkStatus.LISTED,
+} as IServerNetwork;
 
 type IUpdateAllAggregateInfoParams = Parameters<
   SimpleDbEntityAggregateToken['updateAllAggregateInfo']
 >[0];
 
-function buildMember(networkId: string): IAggregateToken {
-  return { networkId, address: '', decimals: 18 } as IAggregateToken;
+function buildMember(networkId: string, order?: number): IAggregateToken {
+  return {
+    networkId,
+    address: '',
+    decimals: 18,
+    ...(order === undefined ? {} : { order }),
+  } as IAggregateToken;
 }
 
 function buildService({
   networks,
   ensureServerNetworksFetched = jest.fn(async () => undefined),
+  ethMembers = [
+    buildMember('evm--1'),
+    buildMember('evm--4663'),
+    // Unknown to the client: must never reach the aggregate maps.
+    buildMember('evm--999999'),
+  ],
 }: {
   networks: IServerNetwork[] | (() => IServerNetwork[]);
   ensureServerNetworksFetched?: jest.Mock<Promise<void>, []>;
+  ethMembers?: IAggregateToken[];
 }) {
   const updateAllAggregateInfo = jest.fn(
     async (_params: IUpdateAllAggregateInfoParams) => undefined,
@@ -78,12 +94,7 @@ function buildService({
       ETH: {
         logoURI: 'eth.png',
         name: 'Ethereum',
-        data: [
-          buildMember('evm--1'),
-          buildMember('evm--4663'),
-          // Unknown to the client: must never reach the aggregate maps.
-          buildMember('evm--999999'),
-        ],
+        data: ethMembers,
       },
     },
   };
@@ -168,5 +179,43 @@ describe('ServiceSetting.syncWalletConfig', () => {
         })
       ],
     ).toBeDefined();
+  });
+
+  it('sorts aggregate members by server order, members without order last', async () => {
+    // The server array is not guaranteed to follow `order` (prod USDG arrives
+    // as Ethereum, Robinhood, X Layer, Solana with orders 3, 1, 2, 4), and
+    // consumers that flatten members keep array order.
+    const { service, updateAllAggregateInfo } = buildService({
+      networks: [ethereum, robinhood, base],
+      ethMembers: [
+        buildMember('evm--1', 3),
+        buildMember('evm--8453'),
+        buildMember('evm--4663', 1),
+      ],
+    });
+
+    await sync(service);
+
+    const { allAggregateTokenMap, allAggregateTokens } =
+      updateAllAggregateInfo.mock.calls[0][0];
+    const ethGroup =
+      allAggregateTokenMap[
+        buildAggregateTokenListMapKeyForTokenList({ commonSymbol: 'ETH' })
+      ];
+    expect(ethGroup.tokens.map((token) => token.networkId)).toEqual([
+      'evm--4663',
+      'evm--1',
+      'evm--8453',
+    ]);
+    // The common row only carries aggregate-wide fields, so the first member
+    // changing must not alter it.
+    expect(allAggregateTokens).toEqual([
+      expect.objectContaining({
+        isAggregateToken: true,
+        commonSymbol: 'ETH',
+        name: 'Ethereum',
+        logoURI: 'eth.png',
+      }),
+    ]);
   });
 });

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
+import ServiceSetting from './ServiceSetting';
+
+import type { ISimpleDBAggregateToken } from '../dbs/simple/entity/SimpleDbEntityAggregateToken';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: any) => target,
+  backgroundMethod: () => (_t: any, _k: string, desc: any) => desc,
+  backgroundMethodForDev: () => (_t: any, _k: string, desc: any) => desc,
+  toastIfError: () => (_t: any, _k: string, desc: any) => desc,
+  checkDevOnlyPassword: jest.fn(),
+}));
+
+const currentAppVersion = platformEnv.version ?? '';
+const oneDayMs = timerUtils.getTimeDurationMs({ day: 1 });
+
+function buildService(rawData: ISimpleDBAggregateToken | null) {
+  const service = new ServiceSetting({
+    backgroundApi: {
+      simpleDb: {
+        aggregateToken: {
+          getRawData: jest.fn(async () => rawData),
+        },
+      },
+    },
+  });
+  const syncSpy = jest
+    .spyOn(service, 'syncWalletConfig')
+    .mockResolvedValue({} as any);
+  return { service, syncSpy };
+}
+
+describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
+  it('syncs when the config has never been synced', async () => {
+    const { service, syncSpy } = buildService(null);
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the cached config has no sync meta', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the app version changed since the last sync', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: 'stale-app-version',
+        syncedAt: Date.now(),
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the cached config is older than the TTL', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: currentAppVersion,
+        syncedAt: Date.now() - oneDayMs - 1,
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips syncing when the cached config is fresh', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: currentAppVersion,
+        syncedAt: Date.now(),
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent calls into a single sync', async () => {
+    const { service, syncSpy } = buildService(null);
+
+    await Promise.all([
+      service.syncWalletConfigIfNeeded(),
+      service.syncWalletConfigIfNeeded(),
+    ]);
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
@@ -16,6 +16,7 @@ jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
 }));
 
 const currentAppVersion = platformEnv.version ?? '';
+const currentBundleVersion = platformEnv.bundleVersion ?? '';
 const oneDayMs = timerUtils.getTimeDurationMs({ day: 1 });
 
 function buildService(rawData: ISimpleDBAggregateToken | null) {
@@ -58,6 +59,7 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
       aggregateTokenConfigMap: {},
       configSyncMeta: {
         appVersion: 'stale-app-version',
+        bundleVersion: currentBundleVersion,
         syncedAt: Date.now(),
       },
     });
@@ -72,6 +74,7 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
       aggregateTokenConfigMap: {},
       configSyncMeta: {
         appVersion: currentAppVersion,
+        bundleVersion: currentBundleVersion,
         syncedAt: Date.now() - oneDayMs - 1,
       },
     });
@@ -86,6 +89,7 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
       aggregateTokenConfigMap: {},
       configSyncMeta: {
         appVersion: currentAppVersion,
+        bundleVersion: currentBundleVersion,
         syncedAt: Date.now(),
       },
     });
@@ -104,5 +108,49 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
     ]);
 
     expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the hot-update bundle version changed since the last sync', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: currentAppVersion,
+        bundleVersion: 'stale-bundle-version',
+        syncedAt: Date.now(),
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a cache without bundle version as stale only when the build has one', async () => {
+    const originalBundleVersion = platformEnv.bundleVersion;
+    try {
+      platformEnv.bundleVersion = 'hot-update-1';
+      const stale = buildService({
+        aggregateTokenConfigMap: {},
+        configSyncMeta: {
+          appVersion: currentAppVersion,
+          syncedAt: Date.now(),
+        },
+      });
+      await stale.service.syncWalletConfigIfNeeded();
+      expect(stale.syncSpy).toHaveBeenCalledTimes(1);
+
+      platformEnv.bundleVersion = undefined;
+      const fresh = buildService({
+        aggregateTokenConfigMap: {},
+        configSyncMeta: {
+          appVersion: currentAppVersion,
+          syncedAt: Date.now(),
+        },
+      });
+      await fresh.service.syncWalletConfigIfNeeded();
+      expect(fresh.syncSpy).not.toHaveBeenCalled();
+    } finally {
+      platformEnv.bundleVersion = originalBundleVersion;
+    }
   });
 });

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -43,6 +43,7 @@ import {
   buildAggregateTokenListMapKeyForTokenList,
   buildAggregateTokenMapKeyForAggregateConfig,
   buildHomeDefaultTokenMapKey,
+  sortTokensByOrder,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type {
   EHardwareTransportType,
@@ -991,6 +992,14 @@ class ServiceSetting extends ServiceBase {
         }
       },
     );
+
+    // The server array is not guaranteed to follow `order` (prod USDG arrives
+    // as Ethereum, Robinhood, X Layer, Solana with orders 3, 1, 2, 4) and the
+    // Receive search flatten keeps array order, so sort members once here.
+    // Members without `order` sink to the end.
+    Object.values(allAggregateTokenMap).forEach((group) => {
+      group.tokens = sortTokensByOrder({ tokens: group.tokens });
+    });
 
     const allAggregateTokens: IAccountToken[] = Object.keys(
       allAggregateTokenMap,

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -1008,6 +1008,10 @@ class ServiceSetting extends ServiceBase {
         homeDefaultTokenMap,
         allAggregateTokenMap,
         aggregateTokenSymbolMap,
+        configSyncMeta: {
+          appVersion: platformEnv.version ?? '',
+          syncedAt: Date.now(),
+        },
       }),
       this.backgroundApi.simpleDb.approval.updateApprovalResurfaceDaysConfig({
         approvalResurfaceDays,
@@ -1016,6 +1020,37 @@ class ServiceSetting extends ServiceBase {
     ]);
 
     return aggregateTokenConfigMap;
+  }
+
+  _syncWalletConfigIfNeededPromise: Promise<void> | undefined;
+
+  @backgroundMethod()
+  public async syncWalletConfigIfNeeded() {
+    if (this._syncWalletConfigIfNeededPromise) {
+      return this._syncWalletConfigIfNeededPromise;
+    }
+    this._syncWalletConfigIfNeededPromise = (async () => {
+      const rawData =
+        await this.backgroundApi.simpleDb.aggregateToken.getRawData();
+      const configSyncMeta = rawData?.configSyncMeta;
+      const appVersion = platformEnv.version ?? '';
+      // Re-sync when the config has never been synced, when the app version
+      // changed (the bundled preset network list may differ, leaving stale
+      // networks in the cached aggregate-token maps), or when the cache is
+      // older than the TTL.
+      const shouldSync =
+        !rawData?.aggregateTokenConfigMap ||
+        !configSyncMeta ||
+        configSyncMeta.appVersion !== appVersion ||
+        Date.now() - configSyncMeta.syncedAt >
+          timerUtils.getTimeDurationMs({ day: 1 });
+      if (shouldSync) {
+        await this.syncWalletConfig();
+      }
+    })().finally(() => {
+      this._syncWalletConfigIfNeededPromise = undefined;
+    });
+    return this._syncWalletConfigIfNeededPromise;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -1,5 +1,5 @@
 import { consts } from '@onekeyfe/cross-inpage-provider-core';
-import { flatten, groupBy, isEqual, uniqBy } from 'lodash';
+import { flatten, groupBy, isEqual, keyBy, uniqBy } from 'lodash';
 import semver from 'semver';
 
 import {
@@ -12,10 +12,7 @@ import {
   backgroundMethod,
   toastIfError,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
-import {
-  getListedNetworkMap,
-  getNetworkIdsMap,
-} from '@onekeyhq/shared/src/config/networkIds';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
   IMPL_BTC,
   IMPL_EVM,
@@ -900,7 +897,17 @@ class ServiceSetting extends ServiceBase {
     const aggregateTokenConfigMap: Record<string, IAggregateToken> = {};
     const homeDefaultTokenMap: Record<string, IHomeDefaultToken> = {};
     const aggregateTokenSymbolMap: Record<string, boolean> = {};
-    const listedNetworkMap = getListedNetworkMap();
+    // Aggregate members may live on server-delivered chains (e.g. Robinhood)
+    // that are not part of presetNetworks, so gate on the merged network
+    // registry instead of the preset-only listed map: presets keep their
+    // preset status, server networks their server status, delisted (TRASH)
+    // networks are already dropped and user custom RPC networks are excluded.
+    const { networks: eligibleNetworks } =
+      await this.backgroundApi.serviceNetwork.getAllNetworks({
+        excludeCustomNetwork: true,
+        excludeAllNetworkItem: true,
+      });
+    const eligibleNetworkMap = keyBy(eligibleNetworks, 'id');
     homeDefaults.forEach((homeDefault) => {
       homeDefaultTokenMap[
         buildHomeDefaultTokenMapKey({
@@ -912,7 +919,7 @@ class ServiceSetting extends ServiceBase {
     Object.entries(tokens).forEach(
       ([commonSymbol, { data, logoURI, name }]) => {
         const filteredData = uniqBy(
-          data.filter((token) => !!listedNetworkMap[token.networkId]),
+          data.filter((token) => !!eligibleNetworkMap[token.networkId]),
           (token) => token.networkId,
         );
 

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -1010,6 +1010,7 @@ class ServiceSetting extends ServiceBase {
         aggregateTokenSymbolMap,
         configSyncMeta: {
           appVersion: platformEnv.version ?? '',
+          bundleVersion: platformEnv.bundleVersion ?? '',
           syncedAt: Date.now(),
         },
       }),
@@ -1034,14 +1035,17 @@ class ServiceSetting extends ServiceBase {
         await this.backgroundApi.simpleDb.aggregateToken.getRawData();
       const configSyncMeta = rawData?.configSyncMeta;
       const appVersion = platformEnv.version ?? '';
-      // Re-sync when the config has never been synced, when the app version
-      // changed (the bundled preset network list may differ, leaving stale
-      // networks in the cached aggregate-token maps), or when the cache is
-      // older than the TTL.
+      const bundleVersion = platformEnv.bundleVersion ?? '';
+      // Re-sync when the config has never been synced, when the app or
+      // hot-update bundle version changed (the bundled preset network list may
+      // differ, leaving stale networks in the cached aggregate-token maps), or
+      // when the cache is older than the TTL. Hot updates keep
+      // platformEnv.version, so bundleVersion is what tells them apart.
       const shouldSync =
         !rawData?.aggregateTokenConfigMap ||
         !configSyncMeta ||
         configSyncMeta.appVersion !== appVersion ||
+        (configSyncMeta.bundleVersion ?? '') !== bundleVersion ||
         Date.now() - configSyncMeta.syncedAt >
           timerUtils.getTimeDurationMs({ day: 1 });
       if (shouldSync) {

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -874,7 +874,16 @@ class ServiceSetting extends ServiceBase {
   @backgroundMethod()
   public async syncWalletConfig() {
     await this.abortFetchWalletConfig();
-    const resp = await this.fetchWalletConfig();
+    // Aggregate members are gated on the merged network registry below, which
+    // includes server-delivered networks only once their cache has been filled.
+    // On a fresh install getServerNetworks returns an empty cache and refreshes
+    // it in the background, so without waiting here the first sync would drop
+    // every server-chain member and persist that incomplete map until the
+    // config TTL expires.
+    const [resp] = await Promise.all([
+      this.fetchWalletConfig(),
+      this.backgroundApi.serviceCustomRpc.ensureServerNetworksFetched(),
+    ]);
 
     if (!resp) {
       return;

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1293,10 +1293,10 @@ function TokenListBlock({
         a = await backgroundApiProxy.simpleDb.aggregateToken.getRawData();
       } else {
         // Refresh the cached wallet config in the background when it is stale
-        // (app version changed or TTL expired) so delisted networks get purged
-        // from the persisted aggregate-token maps. Not awaited: the current
-        // refresh renders with the cached data and the next one picks up the
-        // fresh config.
+        // (app/bundle version changed or TTL expired) so delisted networks get
+        // purged from the persisted aggregate-token maps. Not awaited: the
+        // current refresh renders with the cached data and the next one picks
+        // up the fresh config.
         backgroundApiProxy.serviceSetting
           .syncWalletConfigIfNeeded()
           .catch(() => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1291,6 +1291,18 @@ function TokenListBlock({
       if (!a?.aggregateTokenConfigMap) {
         await backgroundApiProxy.serviceSetting.syncWalletConfig();
         a = await backgroundApiProxy.simpleDb.aggregateToken.getRawData();
+      } else {
+        // Refresh the cached wallet config in the background when it is stale
+        // (app version changed or TTL expired) so delisted networks get purged
+        // from the persisted aggregate-token maps. Not awaited: the current
+        // refresh renders with the cached data and the next one picks up the
+        // fresh config.
+        backgroundApiProxy.serviceSetting
+          .syncWalletConfigIfNeeded()
+          .catch(() => {
+            // Background refresh failure is non-fatal; the stale cache heals on
+            // the next refresh attempt.
+          });
       }
 
       customTokensRawData.current = c ?? undefined;

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -2631,6 +2631,17 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => {
   return networks;
 });
 
+// Robinhood Chain is delivered via the server network list instead of
+// presetNetworks, so feature switches below reference it by network id.
+export const ROBINHOOD_NETWORK_ID = 'evm--4663';
+
+// Network ids enabled by default under All Networks. Extends the preset list
+// with server-delivered chains that cannot live in presetNetworks.
+export const getDefaultEnabledNetworkIdsInAllNetworks = memoFn((): string[] => [
+  ...getDefaultEnabledNetworksInAllNetworks().map((network) => network.id),
+  ROBINHOOD_NETWORK_ID,
+]);
+
 export const getNetworksSupportFilterScamHistory = memoFn(
   (): IServerNetwork[] => [
     eth,

--- a/packages/shared/src/utils/networkUtils.allNetworksDefaults.test.ts
+++ b/packages/shared/src/utils/networkUtils.allNetworksDefaults.test.ts
@@ -1,0 +1,74 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import {
+  ROBINHOOD_NETWORK_ID,
+  getDefaultEnabledNetworkIdsInAllNetworks,
+  getDefaultEnabledNetworksInAllNetworks,
+} from '@onekeyhq/shared/src/config/presetNetworks';
+
+import { isEnabledNetworksInAllNetworks } from './networkUtils';
+
+const emptyState = {
+  enabledNetworks: {},
+  disabledNetworks: {},
+};
+
+describe('All Networks default-enabled set', () => {
+  it('keeps every preset default and appends the server-delivered Robinhood chain', () => {
+    const ids = getDefaultEnabledNetworkIdsInAllNetworks();
+    const presetIds = getDefaultEnabledNetworksInAllNetworks().map(
+      (network) => network.id,
+    );
+
+    expect(ids.slice(0, presetIds.length)).toEqual(presetIds);
+    expect(ids).toContain(ROBINHOOD_NETWORK_ID);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('enables Robinhood without any persisted user choice', () => {
+    expect(
+      isEnabledNetworksInAllNetworks({
+        networkId: ROBINHOOD_NETWORK_ID,
+        ...emptyState,
+        isTestnet: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('respects an explicit Robinhood opt-out', () => {
+    expect(
+      isEnabledNetworksInAllNetworks({
+        networkId: ROBINHOOD_NETWORK_ID,
+        enabledNetworks: {},
+        disabledNetworks: { [ROBINHOOD_NETWORK_ID]: true },
+        isTestnet: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps preset defaults enabled and other mainnets opt-in', () => {
+    expect(
+      isEnabledNetworksInAllNetworks({
+        networkId: getNetworkIdsMap().btc,
+        ...emptyState,
+        isTestnet: false,
+      }),
+    ).toBe(true);
+    expect(
+      isEnabledNetworksInAllNetworks({
+        networkId: 'evm--999999',
+        ...emptyState,
+        isTestnet: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('never enables a testnet by default', () => {
+    expect(
+      isEnabledNetworksInAllNetworks({
+        networkId: 'evm--11155111',
+        ...emptyState,
+        isTestnet: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/networkUtils.ts
+++ b/packages/shared/src/utils/networkUtils.ts
@@ -6,7 +6,7 @@ import {
 } from '../../types/ProviderApis/ProviderApiBtc.type';
 import { getNetworkIdsMap } from '../config/networkIds';
 import {
-  getDefaultEnabledNetworksInAllNetworks,
+  getDefaultEnabledNetworkIdsInAllNetworks,
   getPresetNetworks,
 } from '../config/presetNetworks';
 import { AGGREGATE_TOKEN_MOCK_NETWORK_ID } from '../consts/networkConsts';
@@ -26,9 +26,8 @@ import numberUtils from './numberUtils';
 
 import type { IServerNetwork } from '../../types';
 
-const defaultEnabledNetworks = getDefaultEnabledNetworksInAllNetworks();
 const defaultEnabledNetworkIds = new Set(
-  defaultEnabledNetworks.map((n) => n.id),
+  getDefaultEnabledNetworkIdsInAllNetworks(),
 );
 
 function parseNetworkId({ networkId }: { networkId: string }) {

--- a/packages/shared/src/utils/tokenUtils.buildAggregateTokenListData.test.ts
+++ b/packages/shared/src/utils/tokenUtils.buildAggregateTokenListData.test.ts
@@ -1,0 +1,92 @@
+import type {
+  IAccountToken,
+  IAggregateToken,
+  ITokenFiat,
+} from '@onekeyhq/shared/types/token';
+
+import {
+  buildAggregateTokenListData,
+  buildAggregateTokenListMapKeyForTokenList,
+  buildAggregateTokenMapKeyForAggregateConfig,
+} from './tokenUtils';
+
+function buildConfigEntry(networkId: string, order: number): IAggregateToken {
+  return {
+    networkId,
+    address: '',
+    order,
+    commonSymbol: 'ETH',
+    logoURI: 'eth.png',
+    name: 'Ethereum',
+  } as IAggregateToken;
+}
+
+function buildMember(networkId: string): IAccountToken {
+  return {
+    $key: `${networkId}__`,
+    networkId,
+    address: '',
+    symbol: 'ETH',
+    name: 'Ether',
+    decimals: 18,
+    isNative: true,
+  } as IAccountToken;
+}
+
+const aggregateTokenConfigMapRawData: Record<string, IAggregateToken> = {
+  [buildAggregateTokenMapKeyForAggregateConfig({
+    networkId: 'evm--1',
+    tokenAddress: '',
+  })]: buildConfigEntry('evm--1', 1),
+  [buildAggregateTokenMapKeyForAggregateConfig({
+    networkId: 'evm--4663',
+    tokenAddress: '',
+  })]: buildConfigEntry('evm--4663', 2),
+};
+
+describe('buildAggregateTokenListData', () => {
+  it('stamps every member with the aggregate config order and metadata', () => {
+    // Fold two networks into ONE accumulated map, the way the token selector
+    // self-fetch does across responses.
+    let aggregateTokenListMap: Record<
+      string,
+      { commonToken: IAccountToken; tokens: IAccountToken[] }
+    > = {};
+    let aggregateTokenMap: Record<string, ITokenFiat> = {};
+    for (const [networkId, networkName] of [
+      ['evm--1', 'Ethereum'],
+      ['evm--4663', 'Robinhood'],
+    ] as const) {
+      const data = buildAggregateTokenListData({
+        networkId,
+        accountId: 'account-1',
+        token: buildMember(networkId),
+        tokenMap: {},
+        aggregateTokenListMap,
+        aggregateTokenMap,
+        aggregateTokenConfigMapRawData,
+        networkName,
+      });
+      aggregateTokenListMap = data.aggregateTokenListMap;
+      aggregateTokenMap = data.aggregateTokenMap;
+    }
+
+    const group =
+      aggregateTokenListMap[
+        buildAggregateTokenListMapKeyForTokenList({ commonSymbol: 'ETH' })
+      ];
+    expect(
+      group.tokens.map((token) => [
+        token.networkId,
+        token.order,
+        token.commonSymbol,
+        token.networkName,
+        token.logoURI,
+        token.accountId,
+      ]),
+    ).toEqual([
+      ['evm--1', 1, 'ETH', 'Ethereum', 'eth.png', 'account-1'],
+      ['evm--4663', 2, 'ETH', 'Robinhood', 'eth.png', 'account-1'],
+    ]);
+  });
+});

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -1562,3 +1562,194 @@ describe('getFilteredTokenBySearchKey — backend hits of aggregates without a r
     ]);
   });
 });
+
+describe('getFilteredTokenBySearchKey — exact symbol hits outrank network-only hits (Receive flatten)', () => {
+  const ethereum = buildTestNetwork({
+    id: 'evm--1',
+    name: 'Ethereum',
+    code: 'eth',
+    shortname: 'ETH',
+  });
+  const robinhood = buildTestNetwork({
+    id: 'evm--4663',
+    name: 'Robinhood',
+    code: 'robinhood',
+    shortname: 'Robinhood',
+  });
+  const networksMap = { 'evm--1': ethereum, 'evm--4663': robinhood };
+  const ethOnEthereum = buildTestToken({
+    $key: 'eth-native',
+    address: '',
+    networkId: 'evm--1',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    isNative: true,
+  });
+  const ethOnRobinhood = buildTestToken({
+    $key: 'robinhood-native',
+    address: '',
+    networkId: 'evm--4663',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    isNative: true,
+  });
+  // Held Ethereum token whose own fields do not contain "eth": it matches
+  // only through the network name.
+  const usdtOnEthereum = buildTestToken({
+    $key: 'eth-usdt',
+    address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    networkId: 'evm--1',
+    symbol: 'USDT',
+    name: 'Tether USD',
+  });
+  const tokenFiatMap = {
+    [ethOnEthereum.$key]: { fiatValue: '0.5' } as ITokenFiat,
+    [usdtOnEthereum.$key]: { fiatValue: '100' } as ITokenFiat,
+    [ethOnRobinhood.$key]: { fiatValue: '0' } as ITokenFiat,
+  };
+
+  test('"eth" lists ETH on every chain before other tokens that only hit the Ethereum network name', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [usdtOnEthereum, ethOnEthereum, ethOnRobinhood],
+        searchKey: 'eth',
+        networksMap,
+        enableNetworkSearch: true,
+        tokenFiatMap,
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([ethOnEthereum, ethOnRobinhood, usdtOnEthereum]);
+  });
+});
+
+describe('getFilteredTokenBySearchKey — zero-balance ranking keeps config order (Receive flatten)', () => {
+  const networksMap = {
+    'evm--1': buildTestNetwork({
+      id: 'evm--1',
+      name: 'Ethereum',
+      code: 'eth',
+      shortname: 'ETH',
+    }),
+    'evm--4663': buildTestNetwork({
+      id: 'evm--4663',
+      name: 'Robinhood',
+      code: 'robinhood',
+      shortname: 'Robinhood',
+    }),
+    'evm--8453': buildTestNetwork({
+      id: 'evm--8453',
+      name: 'Base',
+      code: 'base',
+      shortname: 'Base',
+    }),
+  };
+  const aggregateEth = buildTestToken({
+    $key: 'aggregate_ETH_',
+    address: 'aggregate_ETH_',
+    networkId: 'aggregate',
+    isAggregateToken: true,
+    symbol: 'ETH',
+    name: 'Ethereum',
+    commonSymbol: 'ETH',
+  });
+  const ethOnEthereum = buildTestToken({
+    $key: 'eth-evm--1',
+    address: '',
+    networkId: 'evm--1',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    order: 1,
+  });
+  // Disabled under All Networks: never fanned out, so it has NO fiat record.
+  const ethOnRobinhood = buildTestToken({
+    $key: 'eth-evm--4663',
+    address: '',
+    networkId: 'evm--4663',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    order: 2,
+  });
+  // Enabled but empty: the fan-out wrote a zero fiat record.
+  const ethOnBase = buildTestToken({
+    $key: 'eth-evm--8453',
+    address: '',
+    networkId: 'evm--8453',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    order: 3,
+  });
+
+  test('a member without a fiat record ranks as zero, not below the zero-record members', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateEth],
+        searchKey: 'eth',
+        aggregateTokenListMap: {
+          [aggregateEth.$key]: {
+            tokens: [ethOnEthereum, ethOnRobinhood, ethOnBase],
+          },
+        },
+        networksMap,
+        enableNetworkSearch: true,
+        tokenFiatMap: {
+          [ethOnEthereum.$key]: { fiatValue: '0.5' } as ITokenFiat,
+          [ethOnBase.$key]: { fiatValue: '0' } as ITokenFiat,
+        },
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([ethOnEthereum, ethOnRobinhood, ethOnBase]);
+  });
+
+  test('backend hits kept for an absent aggregate follow the member config order', () => {
+    const usdgEthereumMember = buildTestToken({
+      $key: 'usdg-evm--1',
+      address: '0xe343167631d89b6ffc58b88d6b7fb0228795491d',
+      networkId: 'evm--1',
+      symbol: 'USDG',
+      order: 3,
+    });
+    const usdgRobinhoodMember = buildTestToken({
+      $key: 'usdg-evm--4663',
+      address: '0x5fc5360d0400b1c8f9e8cd7d3b3a6a2f5fbb8d3e',
+      networkId: 'evm--4663',
+      symbol: 'USDG',
+      order: 1,
+    });
+    // Backend returns Ethereum first; Mantle is not a config member at all.
+    const hitEthereum = buildTestToken({
+      $key: 'evm--1_usdg',
+      address: usdgEthereumMember.address,
+      networkId: 'evm--1',
+      symbol: 'USDG',
+    });
+    const hitRobinhood = buildTestToken({
+      $key: 'evm--4663_usdg',
+      address: usdgRobinhoodMember.address,
+      networkId: 'evm--4663',
+      symbol: 'USDG',
+    });
+    const hitMantle = buildTestToken({
+      $key: 'evm--5000_usdg',
+      address: '0x063c1d1ef6e9f4c3a2b1d0e9f8a7b6c5d4e3f2a1',
+      networkId: 'evm--5000',
+      symbol: 'USDG',
+    });
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [],
+        searchKey: 'usdg',
+        searchAll: true,
+        searchTokenList: [hitEthereum, hitMantle, hitRobinhood],
+        aggregateTokenListMap: {
+          'aggregate_USDG_': {
+            tokens: [usdgRobinhoodMember, usdgEthereumMember],
+          },
+        },
+        networksMap,
+        enableNetworkSearch: true,
+        tokenFiatMap: {},
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([hitRobinhood, hitEthereum, hitMantle]);
+  });
+});

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -1448,3 +1448,117 @@ describe('normalizeTokenSearchResults — networkId normalization and catalog fi
     expect(result[0]).toBe(hit);
   });
 });
+
+describe('getFilteredTokenBySearchKey — backend hits of aggregates without a row (Receive All Networks)', () => {
+  const aggregateUsdg = buildTestToken({
+    $key: 'aggregate_USDG_',
+    address: 'aggregate_USDG_',
+    networkId: 'aggregate',
+    isAggregateToken: true,
+    symbol: 'USDG',
+    commonSymbol: 'USDG',
+  });
+  const memberUsdgEthereum = buildTestToken({
+    $key: 'member-usdg-evm--1',
+    address: '0xe343167631d89b6ffc58b88d6b7fb0228795491d',
+    networkId: 'evm--1',
+    symbol: 'USDG',
+  });
+  const memberUsdgRobinhood = buildTestToken({
+    $key: 'member-usdg-evm--4663',
+    address: '0x5fc5360d0400b1c8f9e8cd7d3b3a6a2f5fbb8d3e',
+    networkId: 'evm--4663',
+    symbol: 'USDG',
+  });
+  const memberUsdgSolana = buildTestToken({
+    $key: 'member-usdg-sol--101',
+    address: '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
+    networkId: 'sol--101',
+    symbol: 'USDG',
+  });
+  // Backend `token/search` hits carry their own `$key` shape.
+  const hitUsdgRobinhood = buildTestToken({
+    $key: 'evm--4663_0x5fc5360d0400b1c8f9e8cd7d3b3a6a2f5fbb8d3e',
+    address: memberUsdgRobinhood.address,
+    networkId: 'evm--4663',
+    symbol: 'USDG',
+  });
+  const hitUsdgEthereum = buildTestToken({
+    $key: 'evm--1_0xe343167631d89b6ffc58b88d6b7fb0228795491d',
+    address: memberUsdgEthereum.address,
+    networkId: 'evm--1',
+    symbol: 'USDG',
+  });
+  const hitSyrupUsdg = buildTestToken({
+    $key: 'evm--1_0x87b65c4aaffa5bd5aefa5fbd2fb0a9e7b4c3d2e1',
+    address: '0x87b65c4aaffa5bd5aefa5fbd2fb0a9e7b4c3d2e1',
+    networkId: 'evm--1',
+    symbol: 'syrupUSDG',
+    name: 'syrupUSDG',
+  });
+  const aggregateTokenListMap = {
+    [aggregateUsdg.$key]: {
+      tokens: [memberUsdgEthereum, memberUsdgRobinhood, memberUsdgSolana],
+    },
+  };
+  const networksMap = {
+    'evm--1': buildTestNetwork({
+      id: 'evm--1',
+      name: 'Ethereum',
+      code: 'eth',
+      shortname: 'ETH',
+    }),
+    'evm--4663': buildTestNetwork({
+      id: 'evm--4663',
+      name: 'Robinhood',
+      code: 'robinhood',
+      shortname: 'Robinhood',
+    }),
+    'sol--101': buildTestNetwork({
+      id: 'sol--101',
+      name: 'Solana',
+      code: 'sol',
+      shortname: 'SOL',
+    }),
+  };
+  const searchTokenList = [hitUsdgRobinhood, hitUsdgEthereum, hitSyrupUsdg];
+
+  test('keeps member hits as plain rows when the account holds none of the aggregate', () => {
+    // No USDG aggregate row: the account holds no USDG on any enabled network
+    // (e.g. Robinhood disabled). Nothing can flatten the config members, so
+    // the backend hits must survive instead of being deduped into nothing.
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [],
+        searchKey: 'usdg',
+        searchAll: true,
+        searchTokenList,
+        aggregateTokenListMap,
+        networksMap,
+        enableNetworkSearch: true,
+        tokenFiatMap: {},
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([hitUsdgRobinhood, hitUsdgEthereum, hitSyrupUsdg]);
+  });
+
+  test('still dedupes member hits against an aggregate that has a row', () => {
+    const result = getFilteredTokenBySearchKey({
+      tokens: [aggregateUsdg],
+      searchKey: 'usdg',
+      searchAll: true,
+      searchTokenList,
+      aggregateTokenListMap,
+      networksMap,
+      enableNetworkSearch: true,
+      tokenFiatMap: {},
+      flattenAggregateTokens: true,
+    });
+    expect(result.map((token) => token.$key)).toEqual([
+      memberUsdgEthereum.$key,
+      memberUsdgRobinhood.$key,
+      memberUsdgSolana.$key,
+      hitSyrupUsdg.$key,
+    ]);
+  });
+});

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -1753,3 +1753,66 @@ describe('getFilteredTokenBySearchKey — zero-balance ranking keeps config orde
     ).toEqual([hitRobinhood, hitEthereum, hitMantle]);
   });
 });
+
+describe('getFilteredTokenBySearchKey — substring chain-code hits are not network qualifiers', () => {
+  const networksMap = {
+    'evm--1': buildTestNetwork({
+      id: 'evm--1',
+      name: 'Ethereum',
+      code: 'eth',
+      shortname: 'ETH',
+    }),
+    // Cyber's code/shortname/shortcode are "cyeth": they CONTAIN "eth" but do
+    // not name the chain "eth".
+    'evm--7560': buildTestNetwork({
+      id: 'evm--7560',
+      name: 'Cyber',
+      code: 'cyeth',
+      shortname: 'cyeth',
+    }),
+    'evm--59144': buildTestNetwork({
+      id: 'evm--59144',
+      name: 'Linea',
+      code: 'linea',
+      shortname: 'Linea',
+    }),
+  };
+  const ethOnEthereum = buildTestToken({
+    $key: 'eth-evm--1',
+    address: '',
+    networkId: 'evm--1',
+    symbol: 'ETH',
+    name: 'Ethereum',
+  });
+  const ethOnCyber = buildTestToken({
+    $key: 'eth-evm--7560',
+    address: '',
+    networkId: 'evm--7560',
+    symbol: 'ETH',
+    name: 'Ethereum',
+  });
+  const ethOnLinea = buildTestToken({
+    $key: 'eth-evm--59144',
+    address: '',
+    networkId: 'evm--59144',
+    symbol: 'ETH',
+    name: 'Ethereum',
+  });
+
+  test('"eth" keeps Ethereum first (exact chain code) but ranks empty Cyber ETH below held Linea ETH', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [ethOnCyber, ethOnLinea, ethOnEthereum],
+        searchKey: 'eth',
+        networksMap,
+        enableNetworkSearch: true,
+        tokenFiatMap: {
+          [ethOnEthereum.$key]: { fiatValue: '0.51' } as ITokenFiat,
+          [ethOnLinea.$key]: { fiatValue: '3.30' } as ITokenFiat,
+          [ethOnCyber.$key]: { fiatValue: '0' } as ITokenFiat,
+        },
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([ethOnEthereum, ethOnLinea, ethOnCyber]);
+  });
+});

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -1551,7 +1551,19 @@ export function buildAggregateTokenListData(params: {
         ],
       };
     } else {
-      newAggregateTokenListMap[aggregateTokenListMapKey].tokens.push(token);
+      // Later members must carry the same config metadata as the first one:
+      // the token selector folds every network into one accumulated map, and
+      // `sortTokensByOrder` would otherwise leave members without `order` in
+      // response-arrival order.
+      newAggregateTokenListMap[aggregateTokenListMapKey].tokens.push({
+        ...token,
+        accountId,
+        networkId,
+        order: aggregateToken.order,
+        commonSymbol: aggregateToken.commonSymbol,
+        networkName,
+        logoURI: aggregateToken.logoURI,
+      });
     }
 
     newAggregateTokenMap[aggregateTokenListMapKey] = {

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -143,6 +143,25 @@ function networkFieldsContainKeyword(
   );
 }
 
+// TRUE only when the keyword names the network itself ("eth" → Ethereum's
+// code). Includes-hits (`networkFieldsContainKeyword`) are too loose to act as
+// a qualifier for a keyword that already hits the token: Cyber's code "cyeth"
+// contains "eth", but "eth" is a symbol search there, not a chain scope.
+function networkFieldsEqualKeyword(
+  network: IServerNetwork | undefined,
+  kw: string,
+): boolean {
+  if (!network) return false;
+  return (
+    network.name?.toLowerCase() === kw ||
+    network.code?.toLowerCase() === kw ||
+    network.shortname?.toLowerCase() === kw ||
+    network.shortcode?.toLowerCase() === kw ||
+    getTokenNetworkAliasMap()[network.id]?.some((alias) => alias === kw) ||
+    false
+  );
+}
+
 const tokenSearchKeywordAliasMap: Record<string, string[]> = {
   eth: ['ether'],
 };
@@ -261,7 +280,12 @@ function computeSearchStrength(
         hasPureNetworkKeyword: false,
       };
     if (hitToken) anyTokenHit = true;
-    if (hitNetwork) anyNetworkHit = true;
+    // A keyword that also hits the token only counts as a network qualifier
+    // when it names the network exactly; a substring hit on the chain code
+    // must not lift an empty ETH@Cyber above held ETH on other chains.
+    if (hitNetwork && (!hitToken || networkFieldsEqualKeyword(network, kw))) {
+      anyNetworkHit = true;
+    }
     if (hitNetwork && !hitToken) hasPureNetworkKeyword = true;
   }
 
@@ -355,7 +379,7 @@ export function getFilteredTokenBySearchKey({
           Number.MAX_SAFE_INTEGER,
       }))
       // Config-ordered member hits first, everything else keeps backend order.
-      .sort((a, b) => a.order - b.order || a.index - b.index)
+      .toSorted((a, b) => a.order - b.order || a.index - b.index)
       .map(({ token }) => token);
 
     mergedTokens = mergedTokens.concat(filteredSearchTokenList);

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -308,9 +308,19 @@ export function getFilteredTokenBySearchKey({
   let mergedTokens = tokens;
 
   if (searchAll && searchTokenList) {
-    const aggregateTokens = Object.values(aggregateTokenListMap ?? {}).flatMap(
-      (token) => token.tokens,
+    // Only an aggregate that has a row in `tokens` can stand in for its
+    // members (grouped row or flattened subs). The selector folds aggregate
+    // rows from the enabled-network fan-out alone, so a backend hit whose
+    // aggregate is absent — the account holds none of it on an enabled
+    // network — must stay as a plain row or it disappears from the results.
+    const presentAggregateKeys = new Set(
+      tokens
+        .filter((token) => token.isAggregateToken)
+        .map((token) => token.$key),
     );
+    const aggregateTokens = Object.entries(aggregateTokenListMap ?? {})
+      .filter(([aggregateKey]) => presentAggregateKeys.has(aggregateKey))
+      .flatMap(([, aggregate]) => aggregate.tokens);
 
     const filteredSearchTokenList = searchTokenList.filter(
       (token) =>

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -318,16 +318,45 @@ export function getFilteredTokenBySearchKey({
         .filter((token) => token.isAggregateToken)
         .map((token) => token.$key),
     );
-    const aggregateTokens = Object.entries(aggregateTokenListMap ?? {})
-      .filter(([aggregateKey]) => presentAggregateKeys.has(aggregateKey))
-      .flatMap(([, aggregate]) => aggregate.tokens);
-
-    const filteredSearchTokenList = searchTokenList.filter(
-      (token) =>
-        !aggregateTokens.find(
-          (t) => t.address === token.address && t.networkId === token.networkId,
-        ),
+    const aggregateTokens: IAccountToken[] = [];
+    // Members of ABSENT aggregates keep their backend hits as plain rows;
+    // remember their config `order` so those rows rank the way the server
+    // lists the members (Robinhood first for USDG) instead of backend order.
+    const buildMemberKey = (token: IAccountToken) =>
+      `${token.address}_${token.networkId ?? ''}`;
+    const absentMemberOrderByKey = new Map<string, number>();
+    Object.entries(aggregateTokenListMap ?? {}).forEach(
+      ([aggregateKey, aggregate]) => {
+        if (presentAggregateKeys.has(aggregateKey)) {
+          aggregateTokens.push(...aggregate.tokens);
+          return;
+        }
+        aggregate.tokens.forEach((member) => {
+          if (!isNil(member.order)) {
+            absentMemberOrderByKey.set(buildMemberKey(member), member.order);
+          }
+        });
+      },
     );
+
+    const filteredSearchTokenList = searchTokenList
+      .filter(
+        (token) =>
+          !aggregateTokens.find(
+            (t) =>
+              t.address === token.address && t.networkId === token.networkId,
+          ),
+      )
+      .map((token, index) => ({
+        token,
+        index,
+        order:
+          absentMemberOrderByKey.get(buildMemberKey(token)) ??
+          Number.MAX_SAFE_INTEGER,
+      }))
+      // Config-ordered member hits first, everything else keeps backend order.
+      .sort((a, b) => a.order - b.order || a.index - b.index)
+      .map(({ token }) => token);
 
     mergedTokens = mergedTokens.concat(filteredSearchTokenList);
     mergedTokens = uniqBy(
@@ -473,16 +502,23 @@ export function getFilteredTokenBySearchKey({
 
   if (tokenFiatMap) {
     results.sort((a, b) => {
-      if (a.strength !== b.strength) return a.strength - b.strength;
-      // Exact symbol hits ("usdt" → USDT) outrank includes hits (aUSDT) even
-      // when the includes hit carries more fiat value.
+      // An exact symbol hit ("eth" → ETH, "usdt" → USDT) is the token the
+      // user typed, so it outranks every includes hit (aUSDT) and every
+      // network-only hit regardless of match strength or fiat: otherwise
+      // "eth" buries ETH on other chains under every held token whose only
+      // match is the Ethereum network name.
       if (a.exactSymbolHit !== b.exactSymbolHit) {
         return a.exactSymbolHit ? -1 : 1;
       }
-      const fa = new BigNumber(tokenFiatMap[a.token.$key]?.fiatValue ?? -1);
-      const fb = new BigNumber(tokenFiatMap[b.token.$key]?.fiatValue ?? -1);
-      return (fb.isNaN() ? new BigNumber(-1) : fb).comparedTo(
-        fa.isNaN() ? new BigNumber(-1) : fa,
+      if (a.strength !== b.strength) return a.strength - b.strength;
+      // A row without a fiat record (network disabled under All Networks, or
+      // a backend hit) renders as zero, so it must rank as zero too — ranking
+      // it below the zero-record rows would push a disabled network's member
+      // behind every enabled one regardless of config order.
+      const fa = new BigNumber(tokenFiatMap[a.token.$key]?.fiatValue ?? 0);
+      const fb = new BigNumber(tokenFiatMap[b.token.$key]?.fiatValue ?? 0);
+      return (fb.isNaN() ? new BigNumber(0) : fb).comparedTo(
+        fa.isNaN() ? new BigNumber(0) : fa,
       );
     });
   }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-62300](https://onekeyhq.atlassian.net/browse/OK-62300) [OK-58112](https://onekeyhq.atlassian.net/browse/OK-58112)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- All Networks now enables the server-delivered Robinhood chain (`evm--4663`) by default, via a new id-based default-enabled helper.
- The single-network selector's default top list pins Robinhood above Bitcoin.
- Adds unit tests for the All Networks default-enabled set and the Robinhood opt-out.
- Aggregate-token config sync (`/wallet/v1/wallet/config`) now keeps members on server-delivered networks: the eligibility filter uses the merged network registry instead of the preset-only listed map, so Robinhood ETH/USDG show up inside the ETH/USDG aggregate tokens once the server config lists them.
- The token selector's aggregate network list (Receive → ETH → choose network) now orders zero-balance members by the server `order` like the aggregate detail page does: `buildAggregateTokenListData` stamps `order` / `commonSymbol` / `networkName` / `logoURI` on every folded member instead of only the first one.

- Backports the stale wallet-config refresh from #12533 (OK-58112) to this hot-update line and extends it: `/wallet/v1/wallet/config` is re-fetched when the cache is older than 1 day, when the app version changes, or when the hot-update bundle version changes (`platformEnv.bundleVersion`), via `configSyncMeta` on `simpleDb.aggregateToken` and a single-flight `serviceSetting.syncWalletConfigIfNeeded()` kicked off in the background from the home token list. Without it, existing 6.5.2 users would never pick up the Robinhood entries the aggregate fix above depends on.

## Intent & Context
Jira OK-62300 ("Robinhood 网络调整") asks for two product changes on the 6.5.2 hot-update line: (1) All Networks should include Robinhood by default, and (2) in single-network mode Robinhood should sit at the top of the default network list, above Bitcoin. The user asked for the work to be based on `release/v6.5.2`.

Before this change the client only default-enabled the static preset list in `getDefaultEnabledNetworksInAllNetworks()`, and the pinned top list was the hardcoded `defaultPinnedNetworkIds` in `ServiceNetwork`. Robinhood is not a preset network (it is delivered by `/wallet/v1/network/list`), so it could not participate in either list even though the server already reports `defaultEnabled: true` for it — the client never consumed that server flag.

Wallet config lifecycle: on `release/v6.5.2` the config was fetched exactly once (the home All Networks run, gated on the cache being absent) and never refreshed until an app reset, because the branch forked from `x` on 2026-07-13 before #12533 landed. Hot-update bundles all carry `VERSION=6.5.2`, so even #12533's app-version check would not fire across hot updates; only `BUNDLE_VERSION` changes.

## Design Decisions
- **Aggregate members are gated on `serviceNetwork.getAllNetworks({ excludeCustomNetwork, excludeAllNetworkItem })`, not `getListedNetworkMap()`.** The preset-only map silently dropped every non-preset member (`evm--4663`, and also 34443 / 48900 / 1101 / 7777777 on the test server), which is why the ETH aggregate never showed Robinhood even though the app's own client received it. The merged registry keeps preset status for presets, server status for server-delivered chains, already drops TRASH networks, and excludes user custom RPC networks; the server list refreshes hourly, which bounds the stale-cache window #12533 worried about. Note for the x sync: `ServiceToken.getAllAggregateTokenInfo` on `x` (#12533) applies the same preset-only filter at read time and needs the same change.
- **Reference Robinhood by id, do not promote it to `presetNetworks`.** `getAllNetworks` merges presets first and is first-wins, so a preset copy would permanently mask server-side flag updates such as `backendIndex`. This follows the pattern already used on `x` for the scam-history and approval switches (#12718).
- **New `getDefaultEnabledNetworkIdsInAllNetworks()` helper instead of consuming the server `defaultEnabled` flag.** `isEnabledNetworksInAllNetworks` is called from ~20 sites with only a network id; switching them to the server flag would be a much larger change and would also silently alter behavior for every other server network. The id helper keeps the existing preset list intact and appends Robinhood.
- **Opt-out semantics unchanged.** Robinhood behaves like the other default-enabled ids: `disabledNetworks['evm--4663']` still wins, so users who previously turned it off stay off.
- **`ROBINHOOD_NETWORK_ID` is exported and declared at the same position `x` uses for its private const.** The release→x sync will surface a visible merge conflict at that spot rather than a silent duplicate declaration; resolve by keeping a single exported constant.
- **Pinned list falls back gracefully.** The pinned ids resolve through `getNetworksByIds` → `getAllNetworks`, so on a cold install Robinhood appears at the top only once the server network list has been fetched; before that the list is simply the previous order.
- **Only the TTL/refresh slice of #12533 is backported.** #12533 also degraded stale aggregate-token groups in `TokenDetails` / `TokenSelector` / `ServiceToken.getAllAggregateTokenInfo` for delisted networks. Those hunks conflict with the 6.5.2 `TokenDetails` page and are a separate concern, so they are intentionally left out; `syncWalletConfig` on 6.5.2 already filters incoming tokens through `getListedNetworkMap()`, so a refreshed config is written clean.
- **Same semantics as `x`, plus bundle awareness.** Re-sync when `aggregateTokenConfigMap` is missing, when `configSyncMeta` is missing (existing 6.5.2 caches), when `appVersion` differs, when `bundleVersion` differs, or when `syncedAt` is more than 1 day old. Concurrent callers share one promise.
- **Why `bundleVersion`.** Hot-update bundles on this line are all built with `VERSION=6.5.2`; only `BUNDLE_VERSION` (`platformEnv.bundleVersion`) changes. Without it, a hot update that ships a changed preset network list would keep the stale config for up to 24 h. `x` has the same gap; a cache without `bundleVersion` is treated as stale only when the running build has one, so web/desktop builds without a bundle version do not refetch spuriously.
- **Non-blocking on the hot path.** The first fetch (no cache) still awaits so the home list renders with config; the stale-cache refresh is fire-and-forget and the next home refresh picks up the new data. A failed background refresh is swallowed and retried on the next run.
- **No schema migration needed.** `configSyncMeta` is an optional field on an existing simpleDb entity; caches without it are treated as stale and refreshed once.

## Changes Detail
- `packages/shared/src/utils/tokenUtils.ts`: `buildAggregateTokenListData` enriches later members of an aggregate group with the config metadata. The home path folds each network into a fresh map (every member was "first"), but the selector self-fetch (`buildSelectorTokenListFromResponses`) accumulates one map across responses, so only the first-arriving member carried `order` and `sortTokensByOrder` left the rest in response-arrival order — Robinhood, enabled last, landed last.
- `packages/shared/src/utils/tokenUtils.buildAggregateTokenListData.test.ts`: two networks folded into one map both carry order/commonSymbol/networkName/logoURI/accountId.
- `packages/shared/src/config/presetNetworks.ts`: export `ROBINHOOD_NETWORK_ID`; add `getDefaultEnabledNetworkIdsInAllNetworks()` (preset defaults + Robinhood).
- `packages/shared/src/utils/networkUtils.ts`: build `defaultEnabledNetworkIds` from the new id helper.
- `packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts`: prepend `ROBINHOOD_NETWORK_ID` to `defaultPinnedNetworkIds` (Robinhood → Bitcoin → Lightning → Ethereum → Tron → Solana → BNB Chain → Polygon → TON).
- `packages/shared/src/utils/networkUtils.allNetworksDefaults.test.ts`: new tests — helper composition, Robinhood default-enabled, explicit opt-out, non-default mainnets stay opt-in, testnets never default.
- `development/spellCheckerSkipWords.txt`: add `robinhood`.
- `packages/kit-bg/src/services/ServiceSetting.ts`: `syncWalletConfig` filters aggregate members through the merged network registry (`keyBy(getAllNetworks(...).networks, 'id')`).
- `packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts`: server-only member kept, unknown member dropped, single survivor is not an aggregate.
- `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts`: add `configSyncMeta { appVersion, bundleVersion?, syncedAt }` to the struct and to `updateAllAggregateInfo` (kept when not supplied).
- `packages/kit-bg/src/services/ServiceSetting.ts`: `syncWalletConfig` stamps `configSyncMeta` (app + bundle version); new `syncWalletConfigIfNeeded()` with the staleness rule and single-flight promise.
- `packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx`: when the cached config exists, kick off `syncWalletConfigIfNeeded()` in the background.
- `packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts`: never synced / no meta / app version changed / bundle version changed / meta without bundle version / TTL expired / fresh / concurrent dedupe.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**:
  - All Networks aggregation now includes one more EVM chain per EVM account (extra `evm--4663` requests in home balance/token/history fan-out). The server entry currently reports `backendIndex: true`, `status: LISTED`.
  - The single-network top section keeps its existing value-based override (`sortChainSelectorNetworksByValue`, >$1): for funded accounts the top section is sorted by value and Robinhood only appears there when it has value. The new default order applies to zero-value accounts (the case shown in the Jira screenshot).
  - Existing users who explicitly enabled Robinhood are unaffected; users who explicitly disabled it remain disabled.
  - One extra `/wallet/v1/wallet/config` request per install on the first All Networks home run after this hot update (existing caches have no `configSyncMeta`), then at most one per day / per new bundle. `syncWalletConfig` replaces the aggregate maps wholesale, the same write path used for the first fetch.
  - Production `wallet.onekeycn.com` does not list `evm--4663` in the wallet config yet (the test server does); the aggregate change is inert until the backend ships it. On a cold install where the server network list fails to load, that sync drops server-only members until the next config sync.

## Test plan
- [x] `yarn jest packages/shared/src/utils/networkUtils.allNetworksDefaults.test.ts` — 5/5 pass; `packages/shared/src/utils` + `ServiceNetwork` suites — 63 suites / 1328 tests pass.
- [x] `yarn agent:check --profile commit` — lint-worktree-ts / lint-staged / tsc-staged PASS.
- [x] Desktop dev over CDP: `serviceNetwork.getNetworkSelectorPinnedNetworks({ useDefaultPinnedNetworks: true })` returns `evm--4663:Robinhood` first, then `btc--0:Bitcoin`; `getChainSelectorNetworksCompatibleWithAccountId().frequentlyUsedItems` matches.
- [x] Desktop UI: All Networks tab shows Robinhood checked with an empty persisted state (19 selected = 18 presets + Robinhood); Single network tab for a zero-value HD account lists Robinhood above Bitcoin.
- [ ] Fresh install: after the server network list loads, Robinhood is the first item in the single-network top list; All Networks includes Robinhood without any user action.
- [ ] Turn Robinhood off in All Networks, restart the app: it stays off.
- [ ] Funded account: the single-network top section is still value-sorted; Robinhood appears there only with balance.
- [ ] Mobile (iOS/Android) and extension: same selector order and All Networks default.
- [x] `yarn jest packages/kit-bg/src/services/ServiceSetting.syncWalletConfig.test.ts` — 2/2 pass.
- [ ] Against the test endpoint: ETH aggregate token detail lists Robinhood as a member; with Robinhood enabled in All Networks its ETH balance is included.
- [x] Desktop dev, zero-balance account: Receive → 接收转账 → ETH → network list is Ethereum, Robinhood, Base, Arbitrum, … (server order), matching the aggregate detail page; funded account keeps value-first ordering.
- [x] `yarn jest packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts` — 8/8 pass.
- [x] Local desktop dev (working tree hot-reloaded onto this branch): first All Networks home run stamped `configSyncMeta` once (08:21), no further request on later reloads.
- [x] `yarn agent:check --profile commit` — lint-worktree-ts / lint-staged / tsc-staged PASS.
- [ ] Upgrade from a 6.5.2 build with a cached config: first All Networks home load issues one `/wallet/v1/wallet/config` request in the background, `simpleDb.aggregateToken.configSyncMeta` gets stamped.
- [ ] Reopen within 24 h: no additional config request; after 24 h, after a native upgrade, or after installing a new hot-update bundle: one request.
- [ ] Fresh install: first All Networks load still awaits the config before rendering aggregate tokens.

[OK-62300]: https://onekeyhq.atlassian.net/browse/OK-62300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OK-58112]: https://onekeyhq.atlassian.net/browse/OK-58112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ