### PR TITLE
fix: correct fullscreen chart settings behavior (OK-62135, OK-61428)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/showTradingViewChartSettingsDialog.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/showTradingViewChartSettingsDialog.test.tsx
@@ -38,4 +38,20 @@ describe('showTradingViewChartSettingsDialog', () => {
       mockShowDialog.mock.calls[0][0].renderContent.props.hiddenOptionIds,
     ).toEqual(['previousClose']);
   });
+
+  it('lets custom settings content close its own dialog', () => {
+    const renderContent = jest.fn((closeDialog: () => void) => (
+      <button onClick={closeDialog} type="button">
+        Close
+      </button>
+    ));
+
+    showTradingViewChartSettingsDialog({ renderContent });
+
+    expect(mockShowDialog.mock.calls[0][0].renderContent).toBe(
+      renderContent.mock.results[0].value,
+    );
+    renderContent.mock.calls[0][0]();
+    expect(mockCloseDialog).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/showTradingViewChartSettingsDialog.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/showTradingViewChartSettingsDialog.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Dialog } from '@onekeyhq/components';
 
 import {
@@ -12,7 +14,11 @@ const TRADING_VIEW_WEBVIEW_HIDDEN_OPTION_IDS = [
   ITradingViewChartSettingsProps['hiddenOptionIds']
 >;
 
-export function showTradingViewChartSettingsDialog() {
+export function showTradingViewChartSettingsDialog({
+  renderContent,
+}: {
+  renderContent?: (closeDialog: () => void) => ReactNode;
+} = {}) {
   const dialogInstanceRef: {
     current: ReturnType<typeof Dialog.show> | undefined;
   } = {
@@ -37,7 +43,9 @@ export function showTradingViewChartSettingsDialog() {
       outlineWidth: 0,
       bg: 'transparent',
     },
-    renderContent: (
+    renderContent: renderContent ? (
+      renderContent(closeDialog)
+    ) : (
       <TradingViewChartSettings
         hiddenOptionIds={TRADING_VIEW_WEBVIEW_HIDDEN_OPTION_IDS}
         onCancel={closeDialog}

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
@@ -28,6 +28,7 @@ type IMockDialogConfig = {
 };
 const mockTradingViewChartControls = jest.fn<null, [unknown]>(() => null);
 const mockPushModal = jest.fn();
+const mockShowMarketChartSettingsDialog = jest.fn<void, []>();
 const mockDialogShow = jest.fn<void, [IMockDialogConfig]>();
 const defaultIndicatorSettingsProps = {
   activeChartType: 'candlestick' as const,
@@ -60,6 +61,13 @@ jest.mock(
 jest.mock('@onekeyhq/kit/src/hooks/useAppNavigation', () => () => ({
   pushModal: mockPushModal,
 }));
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal',
+  () => ({
+    showMarketChartSettingsDialog: () => mockShowMarketChartSettingsDialog(),
+  }),
+);
 
 describe('TradingViewNative chart controls', () => {
   beforeEach(() => {
@@ -242,33 +250,39 @@ describe('TradingViewNative chart controls', () => {
     );
   });
 
-  it('opens chart settings from opted-in desktop controls', () => {
-    render(
-      <TradingViewNativeChartControlsContainer
-        {...defaultIndicatorSettingsProps}
-        activeIndicatorValues={new Set(['MA'])}
-        enableNativeChartSettings
-        intervalConfig={{ activeInterval: '60', intervals: [] }}
-        layoutMode="desktop"
-        onIndicatorChange={jest.fn()}
-        onIntervalChange={jest.fn()}
-      />,
-    );
+  it.each([false, true])(
+    'opens desktop settings without leaving the chart (fullscreen: %s)',
+    (isFullscreen) => {
+      const handleFullscreenChange = jest.fn();
+      render(
+        <TradingViewNativeChartControlsContainer
+          {...defaultIndicatorSettingsProps}
+          activeIndicatorValues={new Set(['MA'])}
+          enableNativeChartSettings
+          intervalConfig={{ activeInterval: '60', intervals: [] }}
+          isFullscreen={isFullscreen}
+          layoutMode="desktop"
+          onIndicatorChange={jest.fn()}
+          onIntervalChange={jest.fn()}
+          onFullscreenChange={handleFullscreenChange}
+        />,
+      );
 
-    expect(mockTradingViewChartControls).toHaveBeenCalledWith(
-      expect.objectContaining({
-        settingsEnabled: true,
-      }),
-    );
-    const controlsProps = mockTradingViewChartControls.mock.calls[0][0] as {
-      onSettingsPress: () => void;
-    };
-    controlsProps.onSettingsPress();
+      expect(mockTradingViewChartControls).toHaveBeenCalledWith(
+        expect.objectContaining({
+          settingsEnabled: true,
+        }),
+      );
+      const controlsProps = mockTradingViewChartControls.mock.calls[0][0] as {
+        onSettingsPress: () => void;
+      };
+      controlsProps.onSettingsPress();
 
-    expect(mockPushModal).toHaveBeenCalledWith('MarketModal', {
-      screen: 'MarketChartSettings',
-    });
-  });
+      expect(mockShowMarketChartSettingsDialog).toHaveBeenCalledTimes(1);
+      expect(mockPushModal).not.toHaveBeenCalled();
+      expect(handleFullscreenChange).not.toHaveBeenCalled();
+    },
+  );
 
   it('keeps settings out of opted-in mobile controls', () => {
     render(

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
@@ -14,10 +14,8 @@ import type {
   ITradingViewNativeIndicatorSelection,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls';
 import { getTradingViewTimezone } from '@onekeyhq/kit/src/components/TradingView/utils/tradingViewTimezone';
-import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { EModalMarketRoutes } from '@onekeyhq/kit/src/views/Market/router/types';
+import { showMarketChartSettingsDialog } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 
 import {
   type ITradingViewNativeAnyIndicator,
@@ -90,7 +88,6 @@ export const TradingViewNativeChartControlsContainer = memo(
     onFullscreenChange,
   }: ITradingViewNativeChartControlsContainerProps) => {
     const intl = useIntl();
-    const navigation = useAppNavigation();
     const chartStyleTitle = intl.formatMessage({
       id: ETranslations.market_chart_style,
     });
@@ -110,11 +107,6 @@ export const TradingViewNativeChartControlsContainer = memo(
     const indicatorsTitle = intl.formatMessage({
       id: ETranslations.market_indicators,
     });
-    const openChartSettingsModal = useCallback(() => {
-      navigation.pushModal(EModalRoutes.MarketModal, {
-        screen: EModalMarketRoutes.MarketChartSettings,
-      });
-    }, [navigation]);
     const handleFullscreenToggle = useCallback(() => {
       onFullscreenChange?.(!isFullscreen);
     }, [isFullscreen, onFullscreenChange]);
@@ -235,7 +227,7 @@ export const TradingViewNativeChartControlsContainer = memo(
         onPriceMarketCapModeChange={noop}
         onCalendarPanelOpen={onCalendarPanelOpen}
         onCalendarPanelSubmit={onCalendarPanelSubmit}
-        onSettingsPress={openChartSettingsModal}
+        onSettingsPress={showMarketChartSettingsDialog}
         onFullscreenToggle={
           onFullscreenChange ? handleFullscreenToggle : undefined
         }

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -854,7 +854,9 @@ const TradingViewNativeContent = memo(
               </Button>
             </YStack>
           ) : null}
-          {isMobileControlsLayout && enableNativeChartSettings ? (
+          {isMobileControlsLayout &&
+          enableNativeChartSettings &&
+          !isNativeChartFullscreen ? (
             <TradingViewNativeChartSettingsButton
               priceAxisWidth={priceAxisWidth}
               isChartSwitchDisabled={isChartSwitchDisabled}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal.test.tsx
@@ -11,7 +11,9 @@ import {
   createTradingViewNativeChartSettings,
 } from '@onekeyhq/shared/types/tradingViewNative';
 
-import MarketChartSettingsModal from './MarketChartSettingsModal';
+import MarketChartSettingsModal, {
+  showMarketChartSettingsDialog,
+} from './MarketChartSettingsModal';
 
 type IChartSettingsUpdater = (
   currentSettings: ITradingViewNativeChartSettings,
@@ -31,6 +33,11 @@ const mockGetTradingViewNativeChartSettings = jest.fn<
   [IGetNativeSettingsParams]
 >();
 const mockPanelValue = {} as ITradingViewChartSettingsValue;
+const mockCloseDialog = jest.fn();
+const mockShowTradingViewChartSettingsDialog = jest.fn<
+  void,
+  [{ renderContent: (closeDialog: () => void) => ReactNode }]
+>();
 let mockIsMobileLayout = false;
 let mockIsNative = false;
 let mockChartSettings = createTradingViewNativeChartSettings();
@@ -66,6 +73,9 @@ jest.mock(
   () => ({
     TradingViewChartSettings: (props: ITradingViewChartSettingsProps) =>
       mockTradingViewChartSettings(props),
+    showTradingViewChartSettingsDialog: (options: {
+      renderContent: (closeDialog: () => void) => ReactNode;
+    }) => mockShowTradingViewChartSettingsDialog(options),
   }),
 );
 
@@ -140,6 +150,38 @@ describe('MarketChartSettingsModal', () => {
     });
 
     expect(mockSetChartSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps dialog edits in a draft and saves them only on confirmation', async () => {
+    showMarketChartSettingsDialog();
+    render(
+      mockShowTradingViewChartSettingsDialog.mock.calls[0][0].renderContent(
+        mockCloseDialog,
+      ),
+    );
+
+    const props = mockTradingViewChartSettings.mock.calls[0][0];
+    expect(props.usePageFooter).toBe(false);
+    expect(props.mobileLayout).toBe(false);
+    expect(props.onChange).toBeUndefined();
+    expect(props.hiddenOptionIds).toContain('clickInteraction');
+
+    act(() => {
+      props.onCancel?.();
+    });
+    expect(mockCloseDialog).toHaveBeenCalledTimes(1);
+    expect(mockSetChartSettings).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await props.onConfirm?.(mockPanelValue);
+      await props.onConfirmSuccess?.();
+    });
+    expect(mockSetChartSettings).toHaveBeenCalledTimes(1);
+    expect(mockGetTradingViewNativeChartSettings).toHaveBeenCalledWith({
+      currentSettings: mockChartSettings,
+      value: mockPanelValue,
+    });
+    expect(mockCloseDialog).toHaveBeenCalledTimes(2);
   });
 
   it('exposes the implemented click interaction only on native platforms', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal.tsx
@@ -3,7 +3,10 @@ import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Page, useMedia } from '@onekeyhq/components';
-import { TradingViewChartSettings } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/chartSettings';
+import {
+  TradingViewChartSettings,
+  showTradingViewChartSettingsDialog,
+} from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/chartSettings';
 import type {
   ITradingViewChartSettingsProps,
   ITradingViewChartSettingsValue,
@@ -36,9 +39,15 @@ const NON_NATIVE_HIDDEN_OPTION_IDS = [
   ITradingViewChartSettingsProps['hiddenOptionIds']
 >;
 
-export default function MarketChartSettingsModal() {
-  const intl = useIntl();
-  const { md } = useMedia();
+function MarketChartSettingsContent({
+  mobileLayout = false,
+  usePageFooter = false,
+  onClose,
+}: {
+  mobileLayout?: boolean;
+  usePageFooter?: boolean;
+  onClose?: () => void;
+}) {
   const [chartSettings, setChartSettings] =
     useMarketTradingViewChartSettingsPersistAtom();
   const settingsValue = useMemo(
@@ -61,25 +70,44 @@ export default function MarketChartSettingsModal() {
   );
 
   return (
+    <TradingViewChartSettings
+      value={settingsValue}
+      usePageFooter={usePageFooter}
+      mobileLayout={mobileLayout}
+      showChartType={mobileLayout}
+      hiddenAppearanceSectionIds={NATIVE_HIDDEN_APPEARANCE_SECTION_IDS}
+      hiddenOptionIds={
+        platformEnv.isNative
+          ? NATIVE_HIDDEN_OPTION_IDS
+          : NON_NATIVE_HIDDEN_OPTION_IDS
+      }
+      onChange={mobileLayout ? handleMobileSettingsChange : undefined}
+      onConfirm={updateChartSettings}
+      onCancel={onClose}
+      onConfirmSuccess={onClose}
+    />
+  );
+}
+
+export function showMarketChartSettingsDialog() {
+  return showTradingViewChartSettingsDialog({
+    renderContent: (closeDialog) => (
+      <MarketChartSettingsContent onClose={closeDialog} />
+    ),
+  });
+}
+
+export default function MarketChartSettingsModal() {
+  const intl = useIntl();
+  const { md } = useMedia();
+
+  return (
     <Page>
       <Page.Header
         title={intl.formatMessage({ id: ETranslations.market_chart_settings })}
       />
       <Page.Body minHeight={0}>
-        <TradingViewChartSettings
-          value={settingsValue}
-          usePageFooter={!md}
-          mobileLayout={md}
-          showChartType={md}
-          hiddenAppearanceSectionIds={NATIVE_HIDDEN_APPEARANCE_SECTION_IDS}
-          hiddenOptionIds={
-            platformEnv.isNative
-              ? NATIVE_HIDDEN_OPTION_IDS
-              : NON_NATIVE_HIDDEN_OPTION_IDS
-          }
-          onChange={md ? handleMobileSettingsChange : undefined}
-          onConfirm={updateChartSettings}
-        />
+        <MarketChartSettingsContent usePageFooter={!md} mobileLayout={md} />
       </Page.Body>
     </Page>
   );


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-62135](https://onekeyhq.atlassian.net/browse/OK-62135) [OK-61428](https://onekeyhq.atlassian.net/browse/OK-61428)

----------

<!-- github-pr-monitor:jira-links:end -->


TradingView native kept showing its settings button in mobile fullscreen. On desktop, opening settings navigated away from the chart and cleared fullscreen.

Hide the mobile settings button while fullscreen is active. Open desktop settings in a dialog over the chart, reusing the existing settings content and persistence behavior. Opening, canceling, confirming, and closing settings now preserve desktop fullscreen; settings are saved only on confirmation.

Fixes OK-62135 and OK-61428.

Validation:
- `yarn agent:check --profile commit` passed.
- `yarn agent:check --profile pr --pr 13224`: all local checks passed; GitHub CI and review remain pending, with no failed CI checks at the time of validation.
- 26 tests passed across five chart controls and settings suites, including regression coverage for opening desktop settings without navigation and preserving settings confirmation behavior.
- Reproduced the desktop issue in Electron and verified fullscreen remains active when opening, canceling, confirming, and closing settings. Confirmed preferences survive reopening; canceled changes are discarded. Restored the original preference after verification and checked normal desktop mode as well.
- Mobile simulator UI verification was blocked by local device-tool permissions.

[OK-62135]: https://onekeyhq.atlassian.net/browse/OK-62135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-61428]: https://onekeyhq.atlassian.net/browse/OK-61428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ