### PR TITLE
fix: prepare injected assets before native bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "app:web-embed:build": "yarn workspace @onekeyhq/web-embed build",
     "app:web-embed:restore": "yarn workspace @onekeyhq/web-embed prebundle:restore",
     "app:playground": "yarn workspace @onekeyhq/playground sb:dev",
-    "app:native-bundle": "yarn workspace @onekeyhq/mobile dev-vendor:prepare && cross-env ONEKEY_DEV_VENDOR=true ONEKEY_DEV_BG_HMR=true ENABLE_NATIVE_BACKGROUND_THREAD=true NODE_OPTIONS=\"--max-old-space-size=8192\" yarn workspace @onekeyhq/mobile native-bundle",
+    "app:native-bundle": "yarn copy:inject && yarn workspace @onekeyhq/mobile dev-vendor:prepare && cross-env ONEKEY_DEV_VENDOR=true ONEKEY_DEV_BG_HMR=true ENABLE_NATIVE_BACKGROUND_THREAD=true NODE_OPTIONS=\"--max-old-space-size=8192\" yarn workspace @onekeyhq/mobile native-bundle",
     "app:native-bundle:bg": "cross-env ENABLE_NATIVE_BACKGROUND_THREAD=true NODE_OPTIONS=\"--max-old-space-size=8192\" yarn workspace @onekeyhq/mobile native-bundle:bg",
     "app:split-bundle": "yarn workspace @onekeyhq/mobile split-bundle",
     "app:build-bundle": "yarn workspace @onekeyhq/mobile build-bundle",


### PR DESCRIPTION
Run `yarn copy:inject` at the start of `app:native-bundle` so generated injected assets are prepared before vendor preparation and Metro startup. This avoids starting native bundling with missing injection files.

Validation:
- `yarn agent:check --profile commit`: passed.
- `yarn agent:check --profile pr --pr 13227`: all local checks passed; GitHub CI has 11 passed, 0 failed, and 11 pending checks. Review is pending.
- Checked JSON validity and the script execution order. Native bundling and Metro were not launched.
