### PR TITLE
fix: backport stale wallet config refresh to v6.5.2(OK-58112)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
@@ -35,6 +35,12 @@ export interface ISimpleDBAggregateToken {
     }
   >;
   allAggregateTokens?: IAccountToken[];
+  // Tracks the last successful wallet-config sync so stale caches written by
+  // older app versions (with a different preset network list) get refreshed.
+  configSyncMeta?: {
+    appVersion: string;
+    syncedAt: number;
+  };
   tokenDetails?: Record<
     string, // all networks accountId
     Record<
@@ -186,6 +192,7 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     homeDefaultTokenMap,
     allAggregateTokenMap,
     allAggregateTokens,
+    configSyncMeta,
     merge = false,
   }: {
     allAggregateTokenMap: Record<string, { tokens: IAccountToken[] }>;
@@ -193,10 +200,15 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     aggregateTokenConfigMap: Record<string, IAggregateToken>;
     aggregateTokenSymbolMap: Record<string, boolean>;
     homeDefaultTokenMap: Record<string, IHomeDefaultToken>;
+    configSyncMeta?: {
+      appVersion: string;
+      syncedAt: number;
+    };
     merge?: boolean;
   }) {
     await this.setRawData((rawData) => ({
       ...rawData,
+      configSyncMeta: configSyncMeta ?? rawData?.configSyncMeta,
       aggregateTokenSymbolMap: merge
         ? { ...rawData?.aggregateTokenSymbolMap, ...aggregateTokenSymbolMap }
         : aggregateTokenSymbolMap,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
@@ -36,9 +36,12 @@ export interface ISimpleDBAggregateToken {
   >;
   allAggregateTokens?: IAccountToken[];
   // Tracks the last successful wallet-config sync so stale caches written by
-  // older app versions (with a different preset network list) get refreshed.
+  // older builds (with a different preset network list) get refreshed. Hot
+  // updates keep appVersion but change bundleVersion, so both are tracked.
   configSyncMeta?: {
     appVersion: string;
+    // Absent on caches written before bundle tracking was added.
+    bundleVersion?: string;
     syncedAt: number;
   };
   tokenDetails?: Record<
@@ -202,6 +205,7 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
     homeDefaultTokenMap: Record<string, IHomeDefaultToken>;
     configSyncMeta?: {
       appVersion: string;
+      bundleVersion?: string;
       syncedAt: number;
     };
     merge?: boolean;

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
+import ServiceSetting from './ServiceSetting';
+
+import type { ISimpleDBAggregateToken } from '../dbs/simple/entity/SimpleDbEntityAggregateToken';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: any) => target,
+  backgroundMethod: () => (_t: any, _k: string, desc: any) => desc,
+  backgroundMethodForDev: () => (_t: any, _k: string, desc: any) => desc,
+  toastIfError: () => (_t: any, _k: string, desc: any) => desc,
+  checkDevOnlyPassword: jest.fn(),
+}));
+
+const currentAppVersion = platformEnv.version ?? '';
+const oneDayMs = timerUtils.getTimeDurationMs({ day: 1 });
+
+function buildService(rawData: ISimpleDBAggregateToken | null) {
+  const service = new ServiceSetting({
+    backgroundApi: {
+      simpleDb: {
+        aggregateToken: {
+          getRawData: jest.fn(async () => rawData),
+        },
+      },
+    },
+  });
+  const syncSpy = jest
+    .spyOn(service, 'syncWalletConfig')
+    .mockResolvedValue({} as any);
+  return { service, syncSpy };
+}
+
+describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
+  it('syncs when the config has never been synced', async () => {
+    const { service, syncSpy } = buildService(null);
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the cached config has no sync meta', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the app version changed since the last sync', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: 'stale-app-version',
+        syncedAt: Date.now(),
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the cached config is older than the TTL', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: currentAppVersion,
+        syncedAt: Date.now() - oneDayMs - 1,
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips syncing when the cached config is fresh', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: currentAppVersion,
+        syncedAt: Date.now(),
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent calls into a single sync', async () => {
+    const { service, syncSpy } = buildService(null);
+
+    await Promise.all([
+      service.syncWalletConfigIfNeeded(),
+      service.syncWalletConfigIfNeeded(),
+    ]);
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts
@@ -16,6 +16,7 @@ jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
 }));
 
 const currentAppVersion = platformEnv.version ?? '';
+const currentBundleVersion = platformEnv.bundleVersion ?? '';
 const oneDayMs = timerUtils.getTimeDurationMs({ day: 1 });
 
 function buildService(rawData: ISimpleDBAggregateToken | null) {
@@ -58,6 +59,7 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
       aggregateTokenConfigMap: {},
       configSyncMeta: {
         appVersion: 'stale-app-version',
+        bundleVersion: currentBundleVersion,
         syncedAt: Date.now(),
       },
     });
@@ -72,6 +74,7 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
       aggregateTokenConfigMap: {},
       configSyncMeta: {
         appVersion: currentAppVersion,
+        bundleVersion: currentBundleVersion,
         syncedAt: Date.now() - oneDayMs - 1,
       },
     });
@@ -86,6 +89,7 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
       aggregateTokenConfigMap: {},
       configSyncMeta: {
         appVersion: currentAppVersion,
+        bundleVersion: currentBundleVersion,
         syncedAt: Date.now(),
       },
     });
@@ -104,5 +108,49 @@ describe('ServiceSetting.syncWalletConfigIfNeeded', () => {
     ]);
 
     expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs when the hot-update bundle version changed since the last sync', async () => {
+    const { service, syncSpy } = buildService({
+      aggregateTokenConfigMap: {},
+      configSyncMeta: {
+        appVersion: currentAppVersion,
+        bundleVersion: 'stale-bundle-version',
+        syncedAt: Date.now(),
+      },
+    });
+
+    await service.syncWalletConfigIfNeeded();
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a cache without bundle version as stale only when the build has one', async () => {
+    const originalBundleVersion = platformEnv.bundleVersion;
+    try {
+      platformEnv.bundleVersion = 'hot-update-1';
+      const stale = buildService({
+        aggregateTokenConfigMap: {},
+        configSyncMeta: {
+          appVersion: currentAppVersion,
+          syncedAt: Date.now(),
+        },
+      });
+      await stale.service.syncWalletConfigIfNeeded();
+      expect(stale.syncSpy).toHaveBeenCalledTimes(1);
+
+      platformEnv.bundleVersion = undefined;
+      const fresh = buildService({
+        aggregateTokenConfigMap: {},
+        configSyncMeta: {
+          appVersion: currentAppVersion,
+          syncedAt: Date.now(),
+        },
+      });
+      await fresh.service.syncWalletConfigIfNeeded();
+      expect(fresh.syncSpy).not.toHaveBeenCalled();
+    } finally {
+      platformEnv.bundleVersion = originalBundleVersion;
+    }
   });
 });

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -1001,6 +1001,10 @@ class ServiceSetting extends ServiceBase {
         homeDefaultTokenMap,
         allAggregateTokenMap,
         aggregateTokenSymbolMap,
+        configSyncMeta: {
+          appVersion: platformEnv.version ?? '',
+          syncedAt: Date.now(),
+        },
       }),
       this.backgroundApi.simpleDb.approval.updateApprovalResurfaceDaysConfig({
         approvalResurfaceDays,
@@ -1009,6 +1013,37 @@ class ServiceSetting extends ServiceBase {
     ]);
 
     return aggregateTokenConfigMap;
+  }
+
+  _syncWalletConfigIfNeededPromise: Promise<void> | undefined;
+
+  @backgroundMethod()
+  public async syncWalletConfigIfNeeded() {
+    if (this._syncWalletConfigIfNeededPromise) {
+      return this._syncWalletConfigIfNeededPromise;
+    }
+    this._syncWalletConfigIfNeededPromise = (async () => {
+      const rawData =
+        await this.backgroundApi.simpleDb.aggregateToken.getRawData();
+      const configSyncMeta = rawData?.configSyncMeta;
+      const appVersion = platformEnv.version ?? '';
+      // Re-sync when the config has never been synced, when the app version
+      // changed (the bundled preset network list may differ, leaving stale
+      // networks in the cached aggregate-token maps), or when the cache is
+      // older than the TTL.
+      const shouldSync =
+        !rawData?.aggregateTokenConfigMap ||
+        !configSyncMeta ||
+        configSyncMeta.appVersion !== appVersion ||
+        Date.now() - configSyncMeta.syncedAt >
+          timerUtils.getTimeDurationMs({ day: 1 });
+      if (shouldSync) {
+        await this.syncWalletConfig();
+      }
+    })().finally(() => {
+      this._syncWalletConfigIfNeededPromise = undefined;
+    });
+    return this._syncWalletConfigIfNeededPromise;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -1003,6 +1003,7 @@ class ServiceSetting extends ServiceBase {
         aggregateTokenSymbolMap,
         configSyncMeta: {
           appVersion: platformEnv.version ?? '',
+          bundleVersion: platformEnv.bundleVersion ?? '',
           syncedAt: Date.now(),
         },
       }),
@@ -1027,14 +1028,17 @@ class ServiceSetting extends ServiceBase {
         await this.backgroundApi.simpleDb.aggregateToken.getRawData();
       const configSyncMeta = rawData?.configSyncMeta;
       const appVersion = platformEnv.version ?? '';
-      // Re-sync when the config has never been synced, when the app version
-      // changed (the bundled preset network list may differ, leaving stale
-      // networks in the cached aggregate-token maps), or when the cache is
-      // older than the TTL.
+      const bundleVersion = platformEnv.bundleVersion ?? '';
+      // Re-sync when the config has never been synced, when the app or
+      // hot-update bundle version changed (the bundled preset network list may
+      // differ, leaving stale networks in the cached aggregate-token maps), or
+      // when the cache is older than the TTL. Hot updates keep
+      // platformEnv.version, so bundleVersion is what tells them apart.
       const shouldSync =
         !rawData?.aggregateTokenConfigMap ||
         !configSyncMeta ||
         configSyncMeta.appVersion !== appVersion ||
+        (configSyncMeta.bundleVersion ?? '') !== bundleVersion ||
         Date.now() - configSyncMeta.syncedAt >
           timerUtils.getTimeDurationMs({ day: 1 });
       if (shouldSync) {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1293,10 +1293,10 @@ function TokenListBlock({
         a = await backgroundApiProxy.simpleDb.aggregateToken.getRawData();
       } else {
         // Refresh the cached wallet config in the background when it is stale
-        // (app version changed or TTL expired) so delisted networks get purged
-        // from the persisted aggregate-token maps. Not awaited: the current
-        // refresh renders with the cached data and the next one picks up the
-        // fresh config.
+        // (app/bundle version changed or TTL expired) so delisted networks get
+        // purged from the persisted aggregate-token maps. Not awaited: the
+        // current refresh renders with the cached data and the next one picks
+        // up the fresh config.
         backgroundApiProxy.serviceSetting
           .syncWalletConfigIfNeeded()
           .catch(() => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1291,6 +1291,18 @@ function TokenListBlock({
       if (!a?.aggregateTokenConfigMap) {
         await backgroundApiProxy.serviceSetting.syncWalletConfig();
         a = await backgroundApiProxy.simpleDb.aggregateToken.getRawData();
+      } else {
+        // Refresh the cached wallet config in the background when it is stale
+        // (app version changed or TTL expired) so delisted networks get purged
+        // from the persisted aggregate-token maps. Not awaited: the current
+        // refresh renders with the cached data and the next one picks up the
+        // fresh config.
+        backgroundApiProxy.serviceSetting
+          .syncWalletConfigIfNeeded()
+          .catch(() => {
+            // Background refresh failure is non-fatal; the stale cache heals on
+            // the next refresh attempt.
+          });
       }
 
       customTokensRawData.current = c ?? undefined;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58112](https://onekeyhq.atlassian.net/browse/OK-58112)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Backports the stale wallet-config refresh from #12533 (OK-58112) to the 6.5.2 hot-update line: `/wallet/v1/wallet/config` is now re-fetched when the cached config is older than 1 day or was written by a different app version.
- Adds `configSyncMeta` (`appVersion`, `syncedAt`) to `simpleDb.aggregateToken`, a single-flight `serviceSetting.syncWalletConfigIfNeeded()`, and a non-blocking background refresh from the home token list.
- Goes one step beyond #12533: the staleness key also includes `platformEnv.bundleVersion`, so every hot-update bundle triggers one refresh even though `platformEnv.version` stays `6.5.2` across hot updates.
- Brings the `syncWalletConfigIfNeeded` unit tests along and adds hot-update cases (8 cases).

## Intent & Context
On `release/v6.5.2` the wallet config (aggregate-token config, home default tokens, approval resurface days) is fetched exactly once — the only trigger is the home All Networks token-list run, gated on `simpleDb.aggregateToken.aggregateTokenConfigMap` being absent. After the first successful fetch the data is never refreshed until the user resets the app, so server-side config changes never reach existing 6.5.2 users. `x` fixed this in #12533 (merged 2026-07-20), but `release/v6.5.2` forked from `x` on 2026-07-13 and never received it. The user asked to backport that TTL logic to 6.5.2.

## Design Decisions
- **Only the TTL/refresh slice of #12533 is backported.** #12533 also degraded stale aggregate-token groups in `TokenDetails` / `TokenSelector` / `ServiceToken.getAllAggregateTokenInfo` for delisted networks. Those hunks conflict with the 6.5.2 `TokenDetails` page and are a separate concern, so they are intentionally left out; `syncWalletConfig` on 6.5.2 already filters incoming tokens through `getListedNetworkMap()`, so a refreshed config is written clean.
- **Same semantics as `x`, plus bundle awareness.** Re-sync when `aggregateTokenConfigMap` is missing, when `configSyncMeta` is missing (existing 6.5.2 caches), when `appVersion` differs, when `bundleVersion` differs, or when `syncedAt` is more than 1 day old. Concurrent callers share one promise.
- **Why `bundleVersion`.** Hot-update bundles on this line are all built with `VERSION=6.5.2`; only `BUNDLE_VERSION` (`platformEnv.bundleVersion`) changes. Without it, a hot update that ships a changed preset network list would keep the stale config for up to 24 h. `x` has the same gap; a cache without `bundleVersion` is treated as stale only when the running build has one, so web/desktop builds without a bundle version do not refetch spuriously.
- **Non-blocking on the hot path.** The first fetch (no cache) still awaits so the home list renders with config; the stale-cache refresh is fire-and-forget and the next home refresh picks up the new data. A failed background refresh is swallowed and retried on the next run.
- **No schema migration needed.** `configSyncMeta` is an optional field on an existing simpleDb entity; caches without it are treated as stale and refreshed once.

## Changes Detail
- `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts`: add `configSyncMeta { appVersion, bundleVersion?, syncedAt }` to the struct and to `updateAllAggregateInfo` (kept when not supplied).
- `packages/kit-bg/src/services/ServiceSetting.ts`: `syncWalletConfig` stamps `configSyncMeta` (app + bundle version); new `syncWalletConfigIfNeeded()` with the staleness rule and single-flight promise.
- `packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx`: when the cached config exists, kick off `syncWalletConfigIfNeeded()` in the background.
- `packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts`: never synced / no meta / app version changed / bundle version changed / meta without bundle version / TTL expired / fresh / concurrent dedupe.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**:
  - One extra `/wallet/v1/wallet/config` request per install on first launch after upgrade (existing caches have no `configSyncMeta`), then at most one per day.
  - `syncWalletConfig` replaces the aggregate maps wholesale; this is the same write path already used for the first fetch.
  - Single-network home never triggers the fetch (unchanged behavior).

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceSetting.syncWalletConfigIfNeeded.test.ts` — 8/8 pass.
- [x] Local desktop dev (working tree hot-reloaded onto this branch): first All Networks home run stamped `configSyncMeta` once (08:21), no further request on later reloads.
- [x] `yarn agent:check --profile commit` — lint-worktree-ts / lint-staged / tsc-staged PASS.
- [ ] Upgrade from a 6.5.2 build with a cached config: first All Networks home load issues one `/wallet/v1/wallet/config` request in the background, `simpleDb.aggregateToken.configSyncMeta` gets stamped.
- [ ] Reopen within 24 h: no additional config request; after 24 h, after a native upgrade, or after installing a new hot-update bundle: one request.
- [ ] Fresh install: first All Networks load still awaits the config before rendering aggregate tokens.

[OK-58112]: https://onekeyhq.atlassian.net/browse/OK-58112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ