### PR TITLE
fix: prevent indicator settings autofocus | OK-61429

### DIFF
--- a/packages/components/src/composite/Dialog/Dialog.focus.test.tsx
+++ b/packages/components/src/composite/Dialog/Dialog.focus.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node", "node-addons"]}
+ */
+
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { DialogContainer } from '.';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+let mockIsSheet = false;
+const mockClose = jest.fn(() => Promise.resolve());
+const mockPeriodInput = <input aria-label="Period" />;
+
+jest.mock('@onekeyhq/components', () => {
+  const { FocusScope } = jest.requireActual(
+    '@tamagui/focus-scope',
+  ) as typeof import('@tamagui/focus-scope');
+  const Wrapper = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+  const DialogContent = ({
+    children,
+    onOpenAutoFocus,
+    trapFocus,
+  }: {
+    children?: ReactNode;
+    onOpenAutoFocus?: (event: Event) => void;
+    trapFocus?: boolean;
+  }) => (
+    <FocusScope trapped={trapFocus} loop onMountAutoFocus={onOpenAutoFocus}>
+      <div>{children}</div>
+    </FocusScope>
+  );
+  return {
+    useMedia: () => ({ md: mockIsSheet }),
+    AnimatePresence: Wrapper,
+    Sheet: Object.assign(Wrapper, { Frame: Wrapper, Overlay: () => null }),
+    TMDialog: Object.assign(Wrapper, {
+      Content: DialogContent,
+      Overlay: () => null,
+      Title: () => null,
+    }),
+  };
+});
+
+jest.mock('../../primitives', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  return {
+    Stack: React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+      ({ children, tabIndex }, ref) => (
+        <div ref={ref} tabIndex={tabIndex}>
+          {children}
+        </div>
+      ),
+    ),
+  };
+});
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({ formatMessage: ({ id }: { id: string }) => id }),
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: ({ children }: { children?: ReactNode }) => children },
+  useSharedValue: (value: number) => ({ value }),
+  useAnimatedStyle: () => ({}),
+}));
+jest.mock('react-native-safe-area-context', () => ({}));
+jest.mock('expo-clipboard', () => ({}));
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: { isNative: false },
+}));
+jest.mock('@onekeyhq/shared/src/locale', () => ({ ETranslations: {} }));
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({}));
+jest.mock('@onekeyhq/shared/src/errors/utils/errorUtils', () => ({}));
+jest.mock('@onekeyhq/shared/src/utils/stringUtils', () => ({}));
+jest.mock('@onekeyhq/shared/src/lazyLoad', () => ({
+  createLazyModuleComponent: () => () => null,
+}));
+jest.mock('../../actions/Toast', () => ({}));
+jest.mock('../../content/Keyboard', () => ({
+  Keyboard: { dismissWithDelay: jest.fn() },
+}));
+jest.mock('../../content/SheetGrabber', () => ({ SheetGrabber: () => null }));
+jest.mock('../../hocs', () => ({}));
+jest.mock('../../hooks', () => ({
+  useBackHandler: jest.fn(),
+  useKeyboardEventWithoutNavigation: jest.fn(),
+  useOverlayZIndex: () => 1,
+  useSafeAreaInsets: () => ({ bottom: 0 }),
+}));
+jest.mock('../../layouts/Page/PageContext', () => ({}));
+jest.mock('../../layouts/ScrollView', () => ({}));
+jest.mock('./Content', () => ({
+  Content: ({ children }: { children?: ReactNode }) => children,
+}));
+jest.mock('./Footer', () => ({ Footer: () => null }));
+jest.mock('./Header', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  return { DialogHeaderContext: React.createContext({}) };
+});
+jest.mock('./DialogScrollView', () => ({}));
+jest.mock('./renderToContainer', () => ({}));
+
+describe.each([false, true])('Dialog opening focus (sheet: %s)', (isSheet) => {
+  beforeEach(() => {
+    mockIsSheet = isSheet;
+  });
+
+  it('keeps default input autofocus when no override is provided', async () => {
+    render(
+      <DialogContainer
+        open
+        showHeader={false}
+        showFooter={false}
+        onClose={mockClose}
+        renderContent={mockPeriodInput}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByRole('textbox')),
+    );
+  });
+
+  it('focuses the container without selecting an input and preserves keyboard navigation', async () => {
+    const trigger = document.createElement('button');
+    document.body.append(trigger);
+    trigger.focus();
+    const onOpenAutoFocus = jest.fn((event: Event) => {
+      const container = event.currentTarget;
+      if (container instanceof HTMLElement) {
+        event.preventDefault();
+        container.tabIndex = -1;
+        container.focus();
+      }
+    });
+    const view = render(
+      <DialogContainer
+        open
+        showHeader={false}
+        showFooter={false}
+        onClose={mockClose}
+        onOpenAutoFocus={onOpenAutoFocus}
+        renderContent={
+          <>
+            <input aria-label="Period" defaultValue="14" />
+            <button type="button">Confirm</button>
+          </>
+        }
+      />,
+    );
+
+    await waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(1));
+    const input = screen.getByRole('textbox');
+    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    const focusTarget = document.activeElement;
+    expect(focusTarget).not.toBe(input);
+    expect(focusTarget).not.toBe(trigger);
+    expect(focusTarget?.contains(input)).toBe(true);
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(confirm);
+    fireEvent.keyDown(confirm, { key: 'Tab' });
+    expect(document.activeElement).toBe(input);
+
+    view.unmount();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+    trigger.remove();
+  });
+});
+
+it('defers sheet opening focus until the sheet is open', async () => {
+  mockIsSheet = true;
+  const onOpenAutoFocus = jest.fn((event: Event) => event.preventDefault());
+  const dialogProps = {
+    showHeader: false,
+    showFooter: false,
+    onClose: async () => undefined,
+    onOpenAutoFocus,
+    renderContent: <input aria-label="Period" />,
+  };
+  const view = render(<DialogContainer {...dialogProps} open={false} />);
+  expect(onOpenAutoFocus).not.toHaveBeenCalled();
+
+  view.rerender(<DialogContainer {...dialogProps} open />);
+  await waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(1));
+});

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -238,6 +238,7 @@ function DialogFrame({
   onConfirmText,
   onCancel,
   onOpen,
+  onOpenAutoFocus,
   onCancelText,
   tone,
   confirmButtonProps,
@@ -425,14 +426,19 @@ function DialogFrame({
           width={platformEnv.isNativeIOSPad ? MAX_CONTENT_WIDTH : undefined}
           maxWidth={platformEnv.isNativeIOSPad ? MAX_CONTENT_WIDTH : undefined}
         >
-          <FocusScope trapped={open ? effectiveTrapFocus : undefined} loop>
-            <DialogSheetContext.Provider value>
+          <DialogSheetContext.Provider value>
+            <FocusScope
+              enabled={open}
+              trapped={open ? effectiveTrapFocus : undefined}
+              onMountAutoFocus={onOpenAutoFocus}
+              loop
+            >
               <Stack>
                 {!disableDrag ? <SheetGrabber /> : null}
                 {renderDialogContent}
               </Stack>
-            </DialogSheetContext.Provider>
-          </FocusScope>
+            </FocusScope>
+          </DialogSheetContext.Provider>
         </Sheet.Frame>
       </Sheet>
     );
@@ -503,6 +509,9 @@ function DialogFrame({
               width={MAX_CONTENT_WIDTH}
               p="$0"
               {...floatingPanelProps}
+              onOpenAutoFocus={
+                onOpenAutoFocus ?? floatingPanelProps?.onOpenAutoFocus
+              }
               zIndex={floatingPanelProps?.zIndex || zIndex}
             >
               {renderDialogContent}

--- a/packages/components/src/composite/Dialog/type.ts
+++ b/packages/components/src/composite/Dialog/type.ts
@@ -78,6 +78,8 @@ interface IBasicDialogProps extends TMDialogProps {
   /* If true, the content will be rendered later and fit content height. */
   isAsync?: boolean;
   onOpen?: () => void;
+  /** Controls initial focus for both the floating panel and sheet on web. */
+  onOpenAutoFocus?: TMDialogContentProps['onOpenAutoFocus'];
   onHeaderCloseButtonPress?: () => void;
   onClose: (extra?: { flag?: string }) => Promise<void>;
   isExist?: () => boolean;

--- a/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.test.tsx
@@ -11,6 +11,7 @@ import type {
 } from '../TradingViewChartControls/chartSettings';
 
 type IDialogConfig = {
+  onOpenAutoFocus?: (event: Event) => void;
   floatingPanelProps: {
     maxWidth: number | string;
     width: number | string;
@@ -38,6 +39,36 @@ jest.mock('../TradingViewChartControls/chartSettings', () => ({
 describe('showTradingViewNativeIndicatorSettingsDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('moves opening focus to the container and leaves inputs available for manual focus', () => {
+    showTradingViewNativeIndicatorSettingsDialog({
+      intl: { formatMessage: ({ id }) => id },
+      onConfirm: jest.fn(),
+      value: { indicators: [], schemaVersion: 1 },
+    });
+    const { onOpenAutoFocus } = mockShowDialog.mock.calls[0][0];
+    const trigger = document.createElement('button');
+    const container = document.createElement('div');
+    const input = document.createElement('input');
+    container.append(input);
+    document.body.append(trigger, container);
+    trigger.focus();
+
+    const event = new Event('dialog-open', { cancelable: true });
+    container.addEventListener('dialog-open', (openEvent) =>
+      onOpenAutoFocus?.(openEvent),
+    );
+    container.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(container);
+    expect(container.tabIndex).toBe(-1);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    container.remove();
+    trigger.remove();
   });
 
   it('closes only after the child has committed a successful confirmation', async () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.tsx
@@ -44,11 +44,21 @@ export function showTradingViewNativeIndicatorSettingsDialog({
     showHeader: false,
     showFooter: false,
     testID: 'trading-view-native-indicator-settings-dialog',
+    onOpenAutoFocus: (event) => {
+      const container = event.currentTarget;
+      if (
+        typeof HTMLElement !== 'undefined' &&
+        container instanceof HTMLElement
+      ) {
+        event.preventDefault();
+        container.tabIndex = -1;
+        container.focus({ preventScroll: true });
+      }
+    },
     contentContainerProps: {
       p: '$0',
     },
     floatingPanelProps: {
-      onOpenAutoFocus: (event) => event.preventDefault(),
       width: isFocused
         ? '100%'
         : TRADING_VIEW_NATIVE_INDICATOR_SETTINGS_DIALOG_WIDTH,

--- a/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/showTradingViewNativeIndicatorSettingsDialog.tsx
@@ -48,6 +48,7 @@ export function showTradingViewNativeIndicatorSettingsDialog({
       p: '$0',
     },
     floatingPanelProps: {
+      onOpenAutoFocus: (event) => event.preventDefault(),
       width: isFocused
         ? '100%'
         : TRADING_VIEW_NATIVE_INDICATOR_SETTINGS_DIALOG_WIDTH,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61429](https://onekeyhq.atlassian.net/browse/OK-61429)

----------

<!-- github-pr-monitor:jira-links:end -->


Opening Market indicator settings automatically focused the first input. Move initial focus to the dialog container so inputs remain available for deliberate mouse or keyboard interaction.

Expose a shared Dialog opening-focus callback for floating panels and responsive sheets, and attach the sheet's focus scope to its content view. This covers narrow Web layouts while keeping focus inside the modal and restoring it to the trigger on close.

Fixes OK-61429.

Validation:
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- Dialog and indicator settings tests: 7 passed, covering both layouts, keyboard focus looping, focus restoration, default autofocus, and closed sheets.
- Browser verification remains pending because the browser connection failed during initialization.

[OK-61429]: https://onekeyhq.atlassian.net/browse/OK-61429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ