### PR TITLE
feat: show token and network in receive selector title | OK-61964

### DIFF
--- a/packages/kit/src/views/Receive/pages/ReceiveSelector.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -136,6 +136,48 @@ function ReceiveSelectorContent() {
   const isLightningNetwork = networkUtils.isLightningNetworkByNetworkId(
     token?.networkId ?? networkId,
   );
+
+  const titleNetworkId = token?.networkId ?? networkId;
+
+  // Preset networks resolve synchronously so the title is complete on the
+  // first frame; custom and server-delivered networks need a background lookup.
+  const presetNetworkName = useMemo(
+    () =>
+      titleNetworkId
+        ? networkUtils.getLocalNetworkInfo(titleNetworkId)?.name
+        : undefined,
+    [titleNetworkId],
+  );
+
+  const { result: resolvedNetworkName } = usePromiseResult(
+    async () => {
+      if (!token?.symbol || !titleNetworkId || presetNetworkName) {
+        return presetNetworkName;
+      }
+      const titleNetwork =
+        await backgroundApiProxy.serviceNetwork.getNetworkSafe({
+          networkId: titleNetworkId,
+        });
+      return titleNetwork?.name;
+    },
+    [token?.symbol, titleNetworkId, presetNetworkName],
+    { initResult: presetNetworkName },
+  );
+
+  // With a token param the selector is scoped to one asset, so the title
+  // names it together with its chain, e.g. "Receive BNB (BNB Chain)".
+  const pageTitle = useMemo(() => {
+    if (!token?.symbol) {
+      return intl.formatMessage({ id: ETranslations.global_receive });
+    }
+    const networkName = resolvedNetworkName ?? presetNetworkName;
+    return intl.formatMessage(
+      { id: ETranslations.receive_token__title },
+      {
+        token: networkName ? `${token.symbol} (${networkName})` : token.symbol,
+      },
+    );
+  }, [intl, token?.symbol, resolvedNetworkName, presetNetworkName]);
 
   const navigation = useAppNavigation();
 
@@ -406,9 +448,7 @@ function ReceiveSelectorContent() {
           : undefined
       }
     >
-      <Page.Header
-        title={intl.formatMessage({ id: ETranslations.global_receive })}
-      />
+      <Page.Header title={pageTitle} />
       <Page.Body pb={showSwapEntry ? '$5' : undefined}>
         <YStack gap="$5" px="$5" pt="$px">
           {showBuyAction ? (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61964](https://onekeyhq.atlassian.net/browse/OK-61964)

----------

<!-- github-pr-monitor:jira-links:end -->


When the Receive selector modal is opened with a `token` param (Perps deposit, Swap deposit entry, tx-confirm top-up, Reward Center), its header only read "Receive", so the user could not tell which asset or chain the panel was scoped to.

The title now names the asset together with its chain, e.g. "Receive BNB (BNB Chain)", reusing the existing `receive_token__title` key ("Receive {token}") with the network name appended. Without a token param the title stays "Receive".

Network name resolution: preset networks resolve synchronously via `networkUtils.getLocalNetworkInfo` so the title is complete on the first frame; custom and server-delivered networks fall back to `serviceNetwork.getNetworkSafe` in the background. If no name resolves, the title falls back to the bare symbol.

Fixes OK-61964.

Validation:
- `yarn agent:check --profile commit`
- Desktop dev app driven over CDP, three cases screenshot-verified:
  - BNB on `evm--56` with the swap entry: title "接收 BNB (BNB Chain)"
  - No token param: title "接收"
  - ETH on `evm--4663` (Robinhood, not a preset): title "接收 ETH (Robinhood)"

[OK-61964]: https://onekeyhq.atlassian.net/browse/OK-61964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ