### PR TITLE
fix: align EVM addresses in signature confirm display with EIP-55 checksum | OK-62341

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -19047,6 +19047,7 @@
     "packages/kit-bg/src/services/utils/borrowActionServiceUtils.ts": 18125,
     "packages/kit-bg/src/services/utils/buildSpeedSwapTxParams.ts": 8003,
     "packages/kit-bg/src/services/utils/currencySymbolSyncUtils.ts": 7359,
+    "packages/kit-bg/src/services/utils/displayComponentAddressUtils.ts": 2904,
     "packages/kit-bg/src/services/utils/marketStockUtils.ts": 10760,
     "packages/kit-bg/src/services/utils/marketTokenDetailUtils.ts": 19353,
     "packages/kit-bg/src/services/utils/permit2SignatureConfirmUtils.ts": 14635,

--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.test.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.test.ts
@@ -49,6 +49,7 @@ import {
   EParseTxComponentType,
   EParseTxType,
   type IDisplayComponent,
+  type IDisplayComponentApprove,
   type IDisplayComponentSimulation,
   type IParseTransactionResp,
 } from '@onekeyhq/shared/types/signatureConfirm';
@@ -71,6 +72,11 @@ const networkId = 'evm--56';
 const accountId = 'account-id';
 const accountAddress = '0xaccount';
 const contractAddress = '0xcontract';
+// EIP-55 reference vectors.
+const evmLowerAddress = '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed';
+const evmChecksumAddress = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+const evmLowerSpender = '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359';
+const evmChecksumSpender = '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359';
 
 function buildParsedTx({
   components,
@@ -260,6 +266,133 @@ describe('ServiceSignatureConfirm.buildDecodedTx', () => {
 
     expect(decodedTx.isLocalParsed).toBeUndefined();
     expect(decodedTx.txDisplay).toBe(parsedTx.display);
+  });
+
+  it('checksums EVM addresses on the server display', async () => {
+    const parsedTx = buildParsedTx({
+      components: [
+        {
+          type: EParseTxComponentType.Address,
+          label: 'To',
+          address: evmLowerAddress,
+          tags: [],
+        },
+        {
+          type: EParseTxComponentType.Approve,
+          label: 'Approve',
+          spender: evmLowerSpender,
+        } as IDisplayComponentApprove,
+      ],
+    });
+
+    const decodedTx = await buildService(parsedTx).buildDecodedTx({
+      networkId,
+      accountId,
+      accountAddress,
+      unsignedTx: { encodedTx: {} },
+    });
+
+    expect(decodedTx.isLocalParsed).toBeUndefined();
+    expect(decodedTx.txDisplay?.components).toEqual([
+      expect.objectContaining({
+        type: EParseTxComponentType.Address,
+        address: evmChecksumAddress,
+      }),
+      expect.objectContaining({
+        type: EParseTxComponentType.Approve,
+        spender: evmChecksumSpender,
+      }),
+    ]);
+  });
+
+  it('checksums EVM addresses on the local fallback display', async () => {
+    const parsedTx = buildParsedTx({ components: [] });
+    const service = buildService(parsedTx);
+    const localDecodedTx = buildLocalDecodedTx();
+    localDecodedTx.actions[0].unknownAction = {
+      from: accountAddress,
+      to: evmLowerAddress,
+    };
+    (vaultFactory.getVault as unknown as jest.Mock).mockResolvedValue({
+      buildDecodedTx: jest.fn().mockResolvedValue(localDecodedTx),
+    });
+
+    const decodedTx = await service.buildDecodedTx({
+      networkId,
+      accountId,
+      accountAddress,
+      unsignedTx: buildUnsignedTx(),
+    });
+
+    expect(decodedTx.isLocalParsed).toBe(true);
+    expect(decodedTx.txDisplay?.components).toContainEqual(
+      expect.objectContaining({
+        type: EParseTxComponentType.Address,
+        address: evmChecksumAddress,
+      }),
+    );
+    expect(decodedTx.txDisplay?.components).not.toContainEqual(
+      expect.objectContaining({ address: evmLowerAddress }),
+    );
+  });
+});
+
+describe('ServiceSignatureConfirm.parseMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('checksums EVM addresses on the parsed message display', async () => {
+    const post = jest.fn().mockResolvedValue({
+      data: {
+        data: {
+          accountAddress,
+          display: {
+            title: 'Permit',
+            components: [
+              {
+                type: EParseTxComponentType.Address,
+                label: 'Spender',
+                address: evmLowerAddress,
+                tags: [],
+              },
+            ],
+            alerts: [],
+          },
+          type: EParseTxType.Unknown,
+        },
+      },
+    });
+    const backgroundApi = {
+      serviceNetwork: {
+        isCustomNetwork: jest.fn().mockResolvedValue(false),
+      },
+      serviceAccount: {
+        getAccountAddressForApi: jest.fn().mockResolvedValue(accountAddress),
+      },
+      serviceGas: {
+        getClient: jest.fn().mockResolvedValue({ post }),
+      },
+      serviceAccountProfile: {
+        _getWalletTypeHeader: jest
+          .fn()
+          .mockResolvedValue({ 'X-Wallet-Type': 'hd' }),
+      },
+    };
+    const service = new ServiceSignatureConfirm({ backgroundApi });
+
+    const parsedMessage = await service.parseMessage({
+      networkId,
+      accountId,
+      message: '{"primaryType":"Permit"}',
+    });
+
+    expect(parsedMessage?.display.components).toEqual([
+      expect.objectContaining({
+        type: EParseTxComponentType.Address,
+        address: evmChecksumAddress,
+      }),
+    ]);
   });
 });
 

--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -64,6 +64,7 @@ import { primePersistAtom } from '../states/jotai/atoms/prime';
 import { vaultFactory } from '../vaults/factory';
 
 import ServiceBase from './ServiceBase';
+import { checksumDisplayComponentAddresses } from './utils/displayComponentAddressUtils';
 import {
   getPermit2ServerDisplayExtras,
   shouldUseLocalPermit2Display,
@@ -586,6 +587,16 @@ class ServiceSignatureConfirm extends ServiceBase {
       decodedTx.isCustomHexData = true;
     }
 
+    // Display-only: align EVM addresses with the checksum form hardware
+    // devices render. Runs last so server, local-fallback and private-send
+    // rewrites are all covered.
+    if (decodedTx.txDisplay?.components) {
+      decodedTx.txDisplay.components = await checksumDisplayComponentAddresses({
+        networkId,
+        components: decodedTx.txDisplay.components,
+      });
+    }
+
     return decodedTx;
   }
 
@@ -871,6 +882,14 @@ class ServiceSignatureConfirm extends ServiceBase {
             component.tags = [];
           }
         });
+      }
+
+      if (parsedMessage?.display?.components) {
+        parsedMessage.display.components =
+          await checksumDisplayComponentAddresses({
+            networkId,
+            components: parsedMessage.display.components,
+          });
       }
 
       return parsedMessage;

--- a/packages/kit-bg/src/services/utils/displayComponentAddressUtils.test.ts
+++ b/packages/kit-bg/src/services/utils/displayComponentAddressUtils.test.ts
@@ -1,0 +1,121 @@
+import { EParseTxComponentType } from '@onekeyhq/shared/types/signatureConfirm';
+import type {
+  IDisplayComponentAddress,
+  IDisplayComponentApprove,
+  IDisplayComponentDefault,
+} from '@onekeyhq/shared/types/signatureConfirm';
+
+import { checksumDisplayComponentAddresses } from './displayComponentAddressUtils';
+
+// EIP-55 reference vectors.
+const lowerA = '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed';
+const checksumA = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+const lowerB = '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359';
+const checksumB = '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359';
+const solAddress = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+
+function buildAddress(
+  address: string,
+  extra: Partial<IDisplayComponentAddress> = {},
+): IDisplayComponentAddress {
+  return {
+    type: EParseTxComponentType.Address,
+    label: 'To',
+    address,
+    tags: [],
+    ...extra,
+  };
+}
+
+describe('checksumDisplayComponentAddresses', () => {
+  test('formats EVM Address component addresses to EIP-55 checksum', async () => {
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'evm--1',
+      components: [buildAddress(lowerA)],
+    });
+
+    expect(result).toEqual([buildAddress(checksumA)]);
+  });
+
+  test('formats EVM Approve component spender to EIP-55 checksum', async () => {
+    const approve = {
+      type: EParseTxComponentType.Approve,
+      label: 'Approve',
+      spender: lowerB,
+    } as IDisplayComponentApprove;
+
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'evm--1',
+      components: [approve],
+    });
+
+    expect(result).toEqual([{ ...approve, spender: checksumB }]);
+  });
+
+  test('keeps non-EVM network addresses unchanged', async () => {
+    const components = [buildAddress(solAddress)];
+
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'sol--101',
+      components,
+    });
+
+    expect(result).toEqual(components);
+  });
+
+  test('prefers the component networkId over the transaction networkId', async () => {
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'evm--1',
+      components: [
+        buildAddress(solAddress, { networkId: 'sol--101' }),
+        buildAddress(lowerA, { networkId: 'evm--42161' }),
+      ],
+    });
+
+    expect(result).toEqual([
+      buildAddress(solAddress, { networkId: 'sol--101' }),
+      buildAddress(checksumA, { networkId: 'evm--42161' }),
+    ]);
+  });
+
+  test('keeps values that are not valid EVM addresses unchanged', async () => {
+    const components = [
+      buildAddress('vitalik.eth'),
+      buildAddress('0xserver-contract'),
+      buildAddress(''),
+    ];
+
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'evm--1',
+      components,
+    });
+
+    expect(result).toEqual(components);
+  });
+
+  test('returns the same array instance when nothing changes', async () => {
+    const components = [buildAddress(checksumA), buildAddress(solAddress)];
+
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'evm--1',
+      components,
+    });
+
+    expect(result).toBe(components);
+  });
+
+  test('passes other component types through by reference', async () => {
+    const defaultComponent: IDisplayComponentDefault = {
+      type: EParseTxComponentType.Default,
+      label: 'Owner',
+      value: lowerA,
+    };
+
+    const result = await checksumDisplayComponentAddresses({
+      networkId: 'evm--1',
+      components: [defaultComponent],
+    });
+
+    expect(result[0]).toBe(defaultComponent);
+  });
+});

--- a/packages/kit-bg/src/services/utils/displayComponentAddressUtils.ts
+++ b/packages/kit-bg/src/services/utils/displayComponentAddressUtils.ts
@@ -1,0 +1,64 @@
+import { validateEvmAddress } from '@onekeyhq/core/src/chains/evm/sdkEvm';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import { EParseTxComponentType } from '@onekeyhq/shared/types/signatureConfirm';
+import type { IDisplayComponent } from '@onekeyhq/shared/types/signatureConfirm';
+
+// Server-parsed display components carry lowercase (normalized) EVM addresses,
+// while hardware devices render EIP-55 checksum addresses. Keep the wallet UI
+// aligned with the device by applying EIP-55 to EVM addresses at display-build time.
+// Non-EVM networks and values that are not valid EVM addresses (ENS names,
+// placeholders) are returned untouched.
+async function toEvmDisplayAddress({
+  networkId,
+  address,
+}: {
+  networkId: string | undefined;
+  address: string;
+}): Promise<string> {
+  if (!address || !networkUtils.isEvmNetwork({ networkId })) {
+    return address;
+  }
+  const { isValid, displayAddress } = await validateEvmAddress(address);
+  return isValid && displayAddress ? displayAddress : address;
+}
+
+// Returns the input array instance when no component needed rewriting so
+// callers can keep the original display object untouched.
+export async function checksumDisplayComponentAddresses({
+  networkId,
+  components,
+}: {
+  networkId: string;
+  components: IDisplayComponent[];
+}): Promise<IDisplayComponent[]> {
+  const nextComponents = await Promise.all(
+    components.map(async (component) => {
+      if (component.type === EParseTxComponentType.Address) {
+        const address = await toEvmDisplayAddress({
+          networkId: component.networkId || networkId,
+          address: component.address,
+        });
+        return address === component.address
+          ? component
+          : { ...component, address };
+      }
+      if (
+        component.type === EParseTxComponentType.Approve &&
+        component.spender
+      ) {
+        const spender = await toEvmDisplayAddress({
+          networkId: component.networkId || networkId,
+          address: component.spender,
+        });
+        return spender === component.spender
+          ? component
+          : { ...component, spender };
+      }
+      return component;
+    }),
+  );
+  const isChanged = nextComponents.some(
+    (component, index) => component !== components[index],
+  );
+  return isChanged ? nextComponents : components;
+}


### PR DESCRIPTION
## Summary
- Signature confirm (transaction and message parsing) now shows EVM addresses in EIP-55 checksum form, matching what the hardware device renders.
- Applies to `Address` components (`address`) and `Approve` components (`spender`) on the server display, the local-fallback display, and the parsed-message display. Non-EVM networks and non-address values (ENS names, placeholders) are left untouched.

## Intent & Context
OK-62341: on the tx confirm page the "接收地址" / "交互合约" rows showed plain lowercase hex (`0x8b844f...`) while the OneKey Pro showed the checksum form (`0x8B844f...`). Hardware users compared the two and doubted whether they were the same address.

## Root Cause
`/wallet/v1/account/parse-transaction` and `/wallet/v1/account/parse-signature` return normalized lowercase addresses. `ServiceSignatureConfirm.buildDecodedTx` copies `display.components` into `decodedTx.txDisplay` and `SignatureConfirmComponents/Address.tsx` prints `component.address` verbatim, so the UI showed the server's canonical form instead of the display form. The local fallback (`convertDecodedTxActionsToSignatureConfirmTxDisplayComponents`) has the same gap: it uses `action.to` as supplied by the dApp.

## Design Decisions
- **Client-side, at display-build time, not on the server.** Lowercase is the right canonical form for data and every client comparison already lowercases (`getAddressKey`, address book `_findItemByConditions`, localDb EVM index keys). Only the display should change, and the server only covers one of the three display paths (server display / local fallback / message display).
- **One hook point in the background.** `checksumDisplayComponentAddresses` runs once at the end of `buildDecodedTx` (after the Approve backfill and private-send recipient rewrite, so their substitutions are covered too) and once before `parseMessage` returns. UI components need no change, and copy / explorer links also get the checksum form.
- **Reuses the existing validator.** `validateEvmAddress` (`@ethersproject/address` `getAddress`) already produces `displayAddress`; this is the same path `serviceAccountProfile.queryAddress` and `BulkSendApprovalCard` use.
- **Component `networkId` wins over the tx `networkId`** so bridge destinations on non-EVM chains are not touched.
- **Identity-preserving no-op.** The helper returns the same array instance when nothing changed, so a display with no EVM addresses keeps the original server object.

## Changes Detail
- `packages/kit-bg/src/services/utils/displayComponentAddressUtils.ts` (new): `checksumDisplayComponentAddresses({ networkId, components })`.
- `packages/kit-bg/src/services/ServiceSignatureConfirm.ts`: apply the helper at the end of `buildDecodedTx` and before `parseMessage` returns.
- `packages/kit-bg/src/services/utils/displayComponentAddressUtils.test.ts` (new): 7 unit tests (EIP-55 vectors, Approve spender, non-EVM passthrough, component networkId override, invalid values, identity no-op, other component types by reference).
- `packages/kit-bg/src/services/ServiceSignatureConfirm.test.ts`: 3 integration tests (server display, local fallback display, parsed message display).
- `apps/mobile/bundle-registry/module-id-registry.json`: register the new module.

## Risk Assessment
- Low. Display-only change in the background; addresses are only rewritten when `validateEvmAddress` accepts them, otherwise the original string is kept. All local lookups that consume `component.address` (account name, address book, contract tags, explorer URL) are case-insensitive or format-agnostic.
- Not covered by design: `Default` component values and `txABI.args` are untyped strings, so the client cannot know which of them are addresses. If product wants those checksummed too, the server needs to emit `Address` components or a type hint (follow-up).

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/utils/displayComponentAddressUtils.test.ts packages/kit-bg/src/services/ServiceSignatureConfirm.test.ts` (25 passed)
- [x] `yarn agent:check --profile commit` and `--profile pr` green
- [ ] Device QA: EVM send / swap / approve confirm page and EIP-712 sign page show checksum addresses; compare with the device screen; non-EVM (SOL/BTC) unchanged
