### PR TITLE
refactor: simplify security check presentation OK-62382

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/SecurityCheckCard.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/SecurityCheckCard.tsx
@@ -748,8 +748,8 @@ function SecurityCheckCard({ model, onRetry }: IProps) {
     ? intl.formatMessage({ id: STATUS_LABEL_ID[model.status] })
     : '';
   const cardFindings = useMemo(
-    () => getCardSecurityFindings(model.findings),
-    [model.findings],
+    () => getCardSecurityFindings(model.findings, model.status),
+    [model.findings, model.status],
   );
   const isStandaloneFinding = cardFindings.visibleFindings.length === 1;
   const showViewAll = cardFindings.hasHiddenDecisionFindings;

--- a/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/securityCheckModel.test.ts
+++ b/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/securityCheckModel.test.ts
@@ -22,6 +22,10 @@ import {
   sortSecurityFindings,
 } from './securityCheckModel';
 
+import type {
+  ISecurityCheckFinding,
+  ISecurityCheckStatus,
+} from './securityCheckModel';
 import type { IntlShape } from 'react-intl';
 
 const intl = {
@@ -964,4 +968,227 @@ describe('security check display helpers', () => {
     ]);
     expect(card.hasHiddenDecisionFindings).toBe(true);
   });
+});
+
+describe('getCardSecurityFindings presentation', () => {
+  function cardFinding(
+    id: string,
+    status: ISecurityCheckFinding['status'],
+    overrides: Partial<ISecurityCheckFinding> = {},
+  ): ISecurityCheckFinding {
+    return {
+      id,
+      category: 'operation',
+      status,
+      title: id,
+      ...overrides,
+    };
+  }
+
+  const siteUnknown = cardFinding('site-unknown', 'unknown', {
+    category: 'site',
+  });
+  const parseFallback = cardFinding('tx-parse-fallback', 'unknown');
+  const partialCoverage = cardFinding(
+    'tx-security-partial-coverage',
+    'unknown',
+  );
+  const siteAction = {
+    type: 'site' as const,
+    origin: 'https://app.example.com',
+    urlSecurityInfo: verifiedSite,
+  };
+
+  it.each([
+    ['site-unknown', undefined, undefined, true],
+    ['tx-parse-fallback', undefined, undefined, true],
+    ['tx-security-partial-coverage', undefined, undefined, true],
+    ['site-unknown', '   ', undefined, true],
+    ['site-unknown', 'Coverage is incomplete', undefined, false],
+    ['tx-parse-fallback', undefined, siteAction, false],
+    ['tx-security-check-failed', undefined, undefined, false],
+    ['message-parse-fallback', undefined, undefined, false],
+    ['tx-security-unable_to_assess', undefined, undefined, false],
+  ] as const)(
+    'unknown whitelist omits %s only without description or action',
+    (id, description, action, hidden) => {
+      const finding = cardFinding(id, 'unknown', {
+        ...(id === 'site-unknown' ? { category: 'site' } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(action ? { action } : {}),
+      });
+      const omitted = getCardSecurityFindings([finding], 'unknown');
+      const withoutStatus = getCardSecurityFindings([finding]);
+
+      expect(omitted.visibleFindings).toHaveLength(hidden ? 0 : 1);
+      expect(withoutStatus.visibleFindings).toEqual([finding]);
+    },
+  );
+
+  it('keeps an unknown-only card from becoming success and leaves raw findings', () => {
+    const model = buildSecurityCheckModel({
+      kind: 'transaction',
+      origin: 'https://app.example.com',
+      urlSecurityInfo: { level: EHostSecurityLevel.Unknown } as IHostSecurity,
+      decodedTxs: [
+        {
+          isLocalParsed: true,
+          txDisplay: { title: 'Transaction', components: [], alerts: [] },
+        } as unknown as IDecodedTx,
+      ],
+      intl,
+    });
+    expect(model.status).toBe('unknown');
+    expect(model.findings.map((finding) => finding.id)).toEqual([
+      'site-unknown',
+      'tx-parse-fallback',
+    ]);
+    const rawFindings = stableStringify(model.findings);
+    const card = getCardSecurityFindings(model.findings, model.status);
+
+    expect(stableStringify(model.findings)).toBe(rawFindings);
+    expect(card.visibleFindings).toEqual([]);
+    expect(card.allDecisionFindings).toEqual([]);
+  });
+
+  it('keeps Retry on the check-failed row when the header is unknown', () => {
+    const model = buildSecurityCheckModel({
+      kind: 'message',
+      origin: 'https://app.example.com',
+      urlSecurityInfo: { level: EHostSecurityLevel.Unknown } as IHostSecurity,
+      messageDisplay: parsedMessage,
+      transactionSecurityInfo: {
+        level: EHostSecurityLevel.Unknown,
+        detail: {
+          code: ETransactionSecurityResultCode.CheckFailed,
+          features: [],
+        },
+      },
+      intl,
+    });
+    const card = getCardSecurityFindings(model.findings, model.status);
+
+    expect(model.status).toBe('unknown');
+    expect(model.findings.map((finding) => finding.id)).toEqual([
+      'site-unknown',
+      'tx-security-check-failed',
+    ]);
+    expect(card.visibleFindings.map((finding) => finding.id)).toEqual([
+      'tx-security-check-failed',
+    ]);
+    expect(canRetryTransactionSecurityCheck(card.visibleFindings)).toBe(true);
+  });
+
+  it.each([
+    'warning',
+    'critical',
+    'loading',
+    'check_failed',
+  ] as const satisfies readonly ISecurityCheckStatus[])(
+    'keeps generic unknown rows when the header is %s',
+    (status) => {
+      const siteWarning = cardFinding('site-medium', 'warning', {
+        category: 'site',
+      });
+      const extraWarning = cardFinding('extra', 'warning');
+      const findings = [
+        siteUnknown,
+        parseFallback,
+        partialCoverage,
+        extraWarning,
+        siteWarning,
+      ];
+      const card = getCardSecurityFindings(findings, status);
+
+      expect(card.allDecisionFindings.map((finding) => finding.id)).toEqual([
+        'site-medium',
+        'extra',
+      ]);
+      expect(card.visibleFindings.map((finding) => finding.id)).toEqual([
+        'site-medium',
+        'extra',
+        'site-unknown',
+        'tx-parse-fallback',
+        'tx-security-partial-coverage',
+      ]);
+    },
+  );
+
+  it.each([
+    ['message-typed-data', 'info', true],
+    ['message-typed-data', 'warning', false],
+    ['message-permit', 'warning', false],
+    ['message-order', 'warning', false],
+    ['message-risk-sign-method', 'critical', false],
+  ] as const)('hides typed-data info only for %s %s', (id, status, hidden) => {
+    const finding = cardFinding(id, status, {
+      description: `${id} description`,
+    });
+    const card = getCardSecurityFindings([finding], status);
+
+    expect(card.visibleFindings).toHaveLength(hidden ? 0 : 1);
+  });
+
+  it.each([
+    'tx-confirmation-required',
+    'message-confirmation-required',
+  ] as const)(
+    'keeps %s alone or with site-only risk and hides it beside operation risk',
+    (genericId) => {
+      const generic = cardFinding(genericId, 'warning', {
+        description: 'Review this request before continuing.',
+      });
+      const siteWarning = cardFinding('site-medium', 'warning', {
+        category: 'site',
+      });
+      const operationWarning = cardFinding('parser-alert-0', 'warning');
+      const extraWarnings = [
+        cardFinding('spender', 'warning'),
+        cardFinding('allowance', 'warning'),
+        cardFinding('extra', 'warning'),
+      ];
+
+      const alone = getCardSecurityFindings([generic], 'warning');
+      const siteOnly = getCardSecurityFindings(
+        [generic, siteWarning],
+        'warning',
+      );
+      const withOperation = getCardSecurityFindings(
+        [generic, siteWarning, operationWarning, ...extraWarnings],
+        'warning',
+      );
+
+      expect(alone.visibleFindings.map((finding) => finding.id)).toEqual([
+        genericId,
+      ]);
+      expect(alone.allDecisionFindings.map((finding) => finding.id)).toEqual([
+        genericId,
+      ]);
+      expect(siteOnly.visibleFindings.map((finding) => finding.id)).toEqual([
+        'site-medium',
+        genericId,
+      ]);
+      expect(siteOnly.allDecisionFindings.map((finding) => finding.id)).toEqual(
+        ['site-medium', genericId],
+      );
+      expect(
+        withOperation.visibleFindings.map((finding) => finding.id),
+      ).toEqual(['site-medium', 'parser-alert-0', 'spender']);
+      expect(
+        withOperation.allDecisionFindings.map((finding) => finding.id),
+      ).toEqual([
+        'site-medium',
+        'parser-alert-0',
+        'spender',
+        'allowance',
+        'extra',
+      ]);
+      expect(withOperation.hasHiddenDecisionFindings).toBe(true);
+      expect(
+        withOperation.allDecisionFindings.some(
+          (finding) => finding.id === genericId,
+        ),
+      ).toBe(false);
+    },
+  );
 });

--- a/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/securityCheckModel.ts
+++ b/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/securityCheckModel.ts
@@ -297,8 +297,63 @@ export function sortSecurityFindings(findings: ISecurityCheckFinding[]) {
 
 const CARD_DECISION_FINDING_LIMIT = 3;
 
-export function getCardSecurityFindings(findings: ISecurityCheckFinding[]) {
-  const sortedFindings = sortSecurityFindings(findings);
+function isGenericConfirmationFinding(finding: ISecurityCheckFinding) {
+  return (
+    finding.id === 'tx-confirmation-required' ||
+    finding.id === 'message-confirmation-required'
+  );
+}
+
+function hasNonGenericOperationDecision(findings: ISecurityCheckFinding[]) {
+  return findings.some(
+    (finding) =>
+      finding.category === 'operation' &&
+      isDecisionSecurityFinding(finding) &&
+      !isGenericConfirmationFinding(finding),
+  );
+}
+
+function isRedundantUnknownFinding(
+  finding: ISecurityCheckFinding,
+  status?: ISecurityCheckStatus,
+) {
+  // Retry is bound to tx-security-check-failed by row id, so that finding is
+  // never part of this whitelist. Unknown detail text and actions stay visible.
+  return (
+    status === 'unknown' &&
+    finding.status === 'unknown' &&
+    !finding.description?.trim() &&
+    !finding.action &&
+    (finding.id === 'site-unknown' ||
+      finding.id === 'tx-parse-fallback' ||
+      finding.id === 'tx-security-partial-coverage')
+  );
+}
+
+function selectDisplaySecurityFindings(
+  findings: ISecurityCheckFinding[],
+  status?: ISecurityCheckStatus,
+) {
+  const hideGenericConfirmation = hasNonGenericOperationDecision(findings);
+  return findings.filter((finding) => {
+    if (finding.id === 'message-typed-data' && finding.status === 'info') {
+      return false;
+    }
+    // Site-only risk must not hide the generic operation explanation.
+    if (hideGenericConfirmation && isGenericConfirmationFinding(finding)) {
+      return false;
+    }
+    return !isRedundantUnknownFinding(finding, status);
+  });
+}
+
+export function getCardSecurityFindings(
+  findings: ISecurityCheckFinding[],
+  status?: ISecurityCheckStatus,
+) {
+  const sortedFindings = sortSecurityFindings(
+    selectDisplaySecurityFindings(findings, status),
+  );
   const decisionFindings = sortedFindings.filter(isDecisionSecurityFinding);
   const visibleFindings = [
     ...decisionFindings.slice(0, CARD_DECISION_FINDING_LIMIT),


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-62382](https://onekeyhq.atlassian.net/browse/OK-62382)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
Presentation-only part of [OK-62382](https://onekeyhq.atlassian.net/browse/OK-62382), alongside #13243 (confirmation-rule changes). Both PRs are tracked by this single bug; the Jira issue contains the shared review baseline, acceptance boundaries and validation results. [OK-62017](https://onekeyhq.atlassian.net/browse/OK-62017) is retained only as the original feature reference.

- Omit ordinary typed-data informational copy from the visible list; retain Permit, Order and risky-method warnings.
- Omit a generic transaction/message confirmation explanation only when another non-generic operation warning/critical explains the risk. Site-only warnings do not suppress it.
- Deduplicate unknown body rows by exact IDs: `site-unknown`, `tx-parse-fallback`, `tx-security-partial-coverage`. Only hide them when the actual card status is unknown and they have no meaningful description or action.
- Keep `tx-security-check-failed` and its Retry entry, detailed/actionable unknown rows, message parsing fallback, and unknown rows under mixed warning/critical/loading/check-failed statuses.

All raw Findings, coverage, card status, confirmation and acknowledgement remain unchanged. Filtering happens only in the existing card-list selector. Generic confirmation deduplication applies to the card and View all list/count; unknown deduplication does not change the decision count.

## Scope
3 existing files: production +59/-4, tests +227. No new components, test files, snapshots, translation keys, Service changes or Gallery scenarios. No changes to fallback confirmation, Prime eligibility or Batch gate.

This branch is independently based on upstream/x c44d0cfded and does not include the #13243 commit. The selector supports the generic flag IDs restored by #13243. Prefer merging the regression fix first.

## Validation
- Independent branch: SignatureConfirm 9 suites / 171 tests passed.
- `yarn agent:check --profile commit`: passed.
- `yarn agent:check --profile pr`: local checks passed; no PR existed at that point.
- Temporary combination with #13243 merged without conflicts: 9 suites / 189 tests and commit profile passed. Temporary merge was aborted after validation; no merge commit is included.
- Initial full type check encountered cross-worktree dependency aliases. Repeated all required checks successfully after isolating this worktree's dependencies; no source workaround.

## Visual QA
Pending user acceptance. In an unknown-only state the card may show only its header, Unverified badge and coverage tooltip, with no duplicate body row. It must not become success or disappear. Also verify Retry remains visible in mixed unknown/failure cases.


[OK-62017]: https://onekeyhq.atlassian.net/browse/OK-62017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62382]: https://onekeyhq.atlassian.net/browse/OK-62382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ