### PR TITLE
feat: render Earn tokens by displaySymbol so relabels need no symbol …

### DIFF
--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
@@ -69,7 +69,7 @@ function TokenDetailsFooter(props: { networkId: string }) {
           if (tokenMetadata?.coingeckoId) {
             navigation.push(EModalAssetDetailRoutes.MarketDetail, {
               token: tokenMetadata.coingeckoId,
-              networkId,
+              preferredNetworkId: networkId,
             });
           }
         }}

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
@@ -69,6 +69,7 @@ function TokenDetailsFooter(props: { networkId: string }) {
           if (tokenMetadata?.coingeckoId) {
             navigation.push(EModalAssetDetailRoutes.MarketDetail, {
               token: tokenMetadata.coingeckoId,
+              networkId,
             });
           }
         }}

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
@@ -24,8 +24,13 @@ import { AssetDetailsTestIDs } from '../../testIDs';
 
 import { useTokenDetailsContext } from './TokenDetailsContext';
 
-function TokenDetailsFooter(props: { networkId: string }) {
-  const { networkId } = props;
+function TokenDetailsFooter(props: {
+  networkId: string;
+  tokenAddress: string;
+  isNative?: boolean;
+  isAggregateToken?: boolean;
+}) {
+  const { networkId, tokenAddress, isNative, isAggregateToken } = props;
   const intl = useIntl();
   const { bottom } = useSafeAreaInsets();
   const { tokenMetadata } = useTokenDetailsContext();
@@ -67,9 +72,19 @@ function TokenDetailsFooter(props: { networkId: string }) {
         userSelect="none"
         onPress={() => {
           if (tokenMetadata?.coingeckoId) {
+            // Only hand Market a concrete on-chain identity. An aggregate
+            // (all-networks) row has no single network or address, and a
+            // non-native token without an address would send Swap a token
+            // it cannot resolve; those fall back to market data as before.
+            const hasConcreteIdentity =
+              !isAggregateToken &&
+              !networkUtils.isAllNetwork({ networkId }) &&
+              (isNative || Boolean(tokenAddress));
             navigation.push(EModalAssetDetailRoutes.MarketDetail, {
               token: tokenMetadata.coingeckoId,
-              preferredNetworkId: networkId,
+              preferredToken: hasConcreteIdentity
+                ? { networkId, tokenAddress, isNative }
+                : undefined,
             });
           }
         }}

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -848,7 +848,12 @@ function TokenDetailsView() {
     <Page lazyLoad safeAreaEnabled={false}>
       <Page.Header headerRight={headerRight} headerTitle={headerTitle} />
       <Page.Body>{tokenDetailsViewElement}</Page.Body>
-      <TokenDetailsFooter networkId={networkId} />
+      <TokenDetailsFooter
+        networkId={networkId}
+        tokenAddress={tokenInfo.address}
+        isNative={tokenInfo.isNative}
+        isAggregateToken={tokenInfo.isAggregateToken}
+      />
     </Page>
   );
 }

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useTokenSelector.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useTokenSelector.ts
@@ -154,7 +154,7 @@ export function useTokenSelector({
   const tokenSelectorTriggerProps = useMemo<ITokenSelectorTriggerProps>(() => {
     const baseProps: ITokenSelectorTriggerProps = {
       selectedTokenImageUri: tokenImageUri,
-      selectedTokenSymbol: tokenSymbol?.toUpperCase(),
+      selectedTokenSymbol: tokenSymbol,
       selectedNetworkImageUri: networkLogoURI,
     };
 

--- a/packages/kit/src/views/Earn/components/AvailableAssetsFlatList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsFlatList.tsx
@@ -18,6 +18,7 @@ import {
   useEarnAtom,
   useEarnLoadingStatesAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/earn';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
@@ -86,8 +87,10 @@ export function AvailableAssetItem({
       <ListItem.Text
         flex={1}
         primary={
-          <XStack gap="$2" ai="center">
-            <SizableText size="$bodyLgMedium">{asset.symbol}</SizableText>
+          <XStack gap="$2" ai="center" minWidth={0}>
+            <SizableText size="$bodyLgMedium" numberOfLines={1} flexShrink={1}>
+              {earnUtils.getDisplaySymbol(asset)}
+            </SizableText>
             <XStack gap="$1">
               {asset.badges?.map((badge) => (
                 <Badge

--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -30,6 +30,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EModalStakingRoutes } from '@onekeyhq/shared/src/routes';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
@@ -143,7 +144,7 @@ export function AvailableAssetsTabViewList({
     const query = searchText.toLowerCase();
     return source.filter(
       (a) =>
-        a.symbol.toLowerCase().includes(query) ||
+        earnUtils.matchesSymbolKeyword(a, query) ||
         a.name.toLowerCase().includes(query),
     );
   }, [
@@ -272,7 +273,9 @@ export function AvailableAssetsTabViewList({
               tokenImageUri={asset.logoURI}
               borderRadius="$full"
             />
-            <SizableText size="$bodyLgMedium">{asset.symbol}</SizableText>
+            <SizableText size="$bodyLgMedium" numberOfLines={1} flexShrink={1}>
+              {earnUtils.getDisplaySymbol(asset)}
+            </SizableText>
             <XStack gap="$1">
               {asset.badges?.map((badge) => (
                 <Badge
@@ -373,7 +376,13 @@ export function AvailableAssetsTabViewList({
             flex={1}
             primary={
               <XStack gap="$2" ai="center">
-                <SizableText size="$bodyLgMedium">{asset.symbol}</SizableText>
+                <SizableText
+                  size="$bodyLgMedium"
+                  numberOfLines={1}
+                  flexShrink={1}
+                >
+                  {earnUtils.getDisplaySymbol(asset)}
+                </SizableText>
                 <XStack gap="$1">
                   {asset.badges?.map((badge) => (
                     <Badge

--- a/packages/kit/src/views/Earn/components/EarnAssetSearchPopover.tsx
+++ b/packages/kit/src/views/Earn/components/EarnAssetSearchPopover.tsx
@@ -14,6 +14,7 @@ import {
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
@@ -84,8 +85,10 @@ function SearchResultItem({
       <ListItem.Text
         flex={1}
         primary={
-          <XStack gap="$2" ai="center">
-            <SizableText size="$bodyLgMedium">{asset.symbol}</SizableText>
+          <XStack gap="$2" ai="center" minWidth={0}>
+            <SizableText size="$bodyLgMedium" numberOfLines={1} flexShrink={1}>
+              {earnUtils.getDisplaySymbol(asset)}
+            </SizableText>
             <XStack gap="$1">
               {asset.badges?.map((badge) => (
                 <Badge
@@ -140,7 +143,7 @@ export function EarnAssetSearchContent({
     const query = searchText.toLowerCase();
     return source.filter(
       (a) =>
-        a.symbol.toLowerCase().includes(query) ||
+        earnUtils.matchesSymbolKeyword(a, query) ||
         a.name.toLowerCase().includes(query),
     );
   }, [availableAssetsByType, selectedCategory, searchText]);

--- a/packages/kit/src/views/Earn/components/RecommendedSection.tsx
+++ b/packages/kit/src/views/Earn/components/RecommendedSection.tsx
@@ -29,6 +29,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EModalStakingRoutes } from '@onekeyhq/shared/src/routes';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import type { IRecommendAsset } from '@onekeyhq/shared/types/staking';
 
 import { ListItem } from '../../../components/ListItem';
@@ -202,7 +203,7 @@ const RecommendedItem = memo(
         <XStack gap="$3" ai="center" width="100%">
           <Token tokenImageUri={token.logoURI} size="md" />
           <SizableText size="$bodyLgMedium" flex={1} numberOfLines={1}>
-            {token.symbol}
+            {earnUtils.getDisplaySymbol(token)}
           </SizableText>
           <RecommendedBadges token={token} />
         </XStack>
@@ -260,7 +261,7 @@ const RecommendedListItem = memo(({ token }: { token: IRecommendAsset }) => {
         primary={
           <XStack gap="$2" ai="center" flex={1} minWidth={0} flexWrap="wrap">
             <SizableText size="$bodyLgMedium" flexShrink={1} numberOfLines={1}>
-              {token.symbol}
+              {earnUtils.getDisplaySymbol(token)}
             </SizableText>
             <RecommendedBadges
               token={token}

--- a/packages/kit/src/views/Earn/hooks/useEarnAllProtocols.ts
+++ b/packages/kit/src/views/Earn/hooks/useEarnAllProtocols.ts
@@ -9,6 +9,8 @@ import { parseFormattedLiquidityValue } from '../utils/availableAssetsUtils';
 
 export type IEarnProtocolTokenRow = {
   symbol: string;
+  /** Display relabel of `symbol`; rows fall back to `symbol` when absent. */
+  displaySymbol?: string;
   item: IStakeProtocolListItem;
   tvlValue: number;
 };
@@ -82,16 +84,25 @@ function mergeItemIntoProviderMap(
   providerMap: Map<string, IEarnAggregatedProvider>,
   symbol: string,
   item: IStakeProtocolListItem,
+  // Fan-out rows carry the relabel on the v2 asset rather than on the protocol
+  // row, so callers on that path pass it explicitly.
+  displaySymbolOverride?: string,
 ) {
   const providerKey = item.provider.name?.toLowerCase();
   if (!providerKey) {
     return;
   }
   const tvlValue = getItemTvlValue(item);
+  const row: IEarnProtocolTokenRow = {
+    symbol,
+    displaySymbol: displaySymbolOverride ?? item.displaySymbol,
+    item,
+    tvlValue,
+  };
   const existing = providerMap.get(providerKey);
   if (existing) {
     existing.tvlValue += tvlValue;
-    existing.tokens.push({ symbol, item, tvlValue });
+    existing.tokens.push(row);
   } else {
     providerMap.set(providerKey, {
       provider: providerKey,
@@ -99,7 +110,7 @@ function mergeItemIntoProviderMap(
       providerName: getEarnProviderDisplayName(item.provider.name),
       logoURI: item.provider.logoURI,
       tvlValue,
-      tokens: [{ symbol, item, tvlValue }],
+      tokens: [row],
     });
   }
 }
@@ -112,20 +123,30 @@ function mergeItemIntoProviderMap(
 async function fetchAggregatedByFanOut(): Promise<IEarnAggregatedProvider[]> {
   const v2Assets =
     await backgroundApiProxy.serviceStaking.getAvailableAssetsV2();
+  const normalAssets = v2Assets.filter((asset) => asset.type === 'normal');
   const symbols = Array.from(
-    new Set(
-      v2Assets
-        .filter((asset) => asset.type === 'normal')
-        .map((asset) => asset.symbol),
-    ),
+    new Set(normalAssets.map((asset) => asset.symbol)),
   );
+  // The protocol rows this path merges have no relabel of their own, so keep
+  // the one the v2 assets carry, keyed by the symbol they were fetched under.
+  const displaySymbolBySymbol = new Map<string, string>();
+  for (const asset of normalAssets) {
+    if (asset.displaySymbol && !displaySymbolBySymbol.has(asset.symbol)) {
+      displaySymbolBySymbol.set(asset.symbol, asset.displaySymbol);
+    }
+  }
 
   const listsBySymbol = await fetchListsBySymbol(symbols);
 
   const providerMap = new Map<string, IEarnAggregatedProvider>();
   for (const [symbol, items] of listsBySymbol.entries()) {
     for (const item of items) {
-      mergeItemIntoProviderMap(providerMap, symbol, item);
+      mergeItemIntoProviderMap(
+        providerMap,
+        symbol,
+        item,
+        displaySymbolBySymbol.get(symbol),
+      );
     }
   }
   return Array.from(providerMap.values());

--- a/packages/kit/src/views/Earn/pages/EarnFixedRateTokens/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnFixedRateTokens/index.tsx
@@ -18,6 +18,7 @@ import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
@@ -130,7 +131,7 @@ function EarnFixedRateTokensContent() {
       }
       if (
         keyword &&
-        !asset.symbol.toLowerCase().includes(keyword) &&
+        !earnUtils.matchesSymbolKeyword(asset, keyword) &&
         !asset.name?.toLowerCase().includes(keyword)
       ) {
         return false;

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -177,7 +177,7 @@ const ProtocolHeader = ({
           <XStack gap="$2" ai="center" flexShrink={1} minWidth={0}>
             <Token size="xs" tokenImageUri={tokenInfo?.token.logoURI} />
             <SizableText size="$bodyLgMedium" numberOfLines={1} flexShrink={1}>
-              {tokenInfo?.token.symbol || symbol}
+              {earnUtils.getDisplaySymbol(tokenInfo?.token) || symbol}
             </SizableText>
           </XStack>
           {formattedMaturityDate ? (
@@ -870,11 +870,14 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
           <Token size="md" tokenImageUri={headerTokenLogoURI} />
         )}
         <SizableText size="$headingXl" numberOfLines={1} flexShrink={1}>
-          {symbol}
+          {/* The relabel only lands once the detail request resolves; until
+              then the route's symbol stands in, which is what it renders for
+              every token without a relabel anyway. */}
+          {earnUtils.getDisplaySymbol(tokenInfo?.token) || symbol}
         </SizableText>
       </XStack>
     ),
-    [symbol, headerTokenLogoURI, isHeaderTokenLogoPending],
+    [symbol, tokenInfo?.token, headerTokenLogoURI, isHeaderTokenLogoPending],
   );
 
   const handleOpenManageModal = useCallback(

--- a/packages/kit/src/views/Earn/pages/EarnProtocolTokens/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolTokens/index.tsx
@@ -25,6 +25,7 @@ import type {
   ITabEarnParamList,
 } from '@onekeyhq/shared/src/routes';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 import { getEarnProviderDisplayName } from '@onekeyhq/shared/types/earn/earnProvider.constants';
@@ -260,7 +261,7 @@ function EarnProtocolTokensContent({ route }: { route: IRouteProps }) {
                 numberOfLines={1}
                 flexShrink={1}
               >
-                {row.symbol}
+                {earnUtils.getDisplaySymbol(row)}
               </SizableText>
               {/* Sunset protocols (lido/babylon) come back as WithdrawOnly and
                   are deliberately kept in the aggregation (OK-59305), but this

--- a/packages/kit/src/views/Earn/pages/EarnTokens/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnTokens/index.tsx
@@ -18,6 +18,7 @@ import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
@@ -229,7 +230,7 @@ function EarnTokensContent() {
       }
       if (
         keyword &&
-        !asset.symbol.toLowerCase().includes(keyword) &&
+        !earnUtils.matchesSymbolKeyword(asset, keyword) &&
         !asset.name?.toLowerCase().includes(keyword)
       ) {
         return false;

--- a/packages/kit/src/views/Market/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetail.tsx
@@ -8,6 +8,9 @@ export type IMarketDetailProps = IPageScreenProps<any, any>;
 export default function MarketDetail(props: IMarketDetailProps) {
   const { route } = props;
 
+  // `networkId` in params means the caller targeted V2 (it also carries
+  // `network`/`tokenAddress`). V1 callers must not use that key for hints;
+  // they pass `preferredNetworkId` instead.
   if (route.params?.networkId) {
     return <MarketDetailV2 {...(props as any)} />;
   }

--- a/packages/kit/src/views/Market/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetail.tsx
@@ -10,7 +10,7 @@ export default function MarketDetail(props: IMarketDetailProps) {
 
   // `networkId` in params means the caller targeted V2 (it also carries
   // `network`/`tokenAddress`). V1 callers must not use that key for hints;
-  // they pass `preferredNetworkId` instead.
+  // they pass `preferredToken` instead.
   if (route.params?.networkId) {
     return <MarketDetailV2 {...(props as any)} />;
   }

--- a/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
@@ -49,9 +49,11 @@ import { MarketWatchListProviderMirror } from '../MarketWatchListProviderMirror'
 function TokenDetailHeader({
   coinGeckoId,
   token: responseToken,
+  preferredNetworkId,
 }: {
   coinGeckoId: string;
   token: IMarketTokenDetail;
+  preferredNetworkId?: string;
 }) {
   const { gtMd: gtMdMedia } = useMedia();
 
@@ -98,6 +100,7 @@ function TokenDetailHeader({
         coinGeckoId={coinGeckoId}
         token={token}
         accountId={account?.id ?? ''}
+        preferredNetworkId={preferredNetworkId}
       />
       {gtMd ? <MarketDetailOverview token={token} /> : null}
     </YStack>
@@ -133,7 +136,7 @@ function SkeletonHeaderOverItemItem() {
 function MarketDetail({
   route,
 }: IPageScreenProps<ITabMarketParamList, ETabMarketRoutes.MarketDetail>) {
-  const { token: coinGeckoId } = route.params;
+  const { token: coinGeckoId, networkId: preferredNetworkId } = route.params;
   const { gtMd: gtMdMedia } = useMedia();
 
   const isModalPage = useIsOverlayPage();
@@ -200,7 +203,11 @@ function MarketDetail({
   const tokenDetailHeader = useMemo(() => {
     if (tokenDetail) {
       return (
-        <TokenDetailHeader coinGeckoId={coinGeckoId} token={tokenDetail} />
+        <TokenDetailHeader
+          coinGeckoId={coinGeckoId}
+          token={tokenDetail}
+          preferredNetworkId={preferredNetworkId}
+        />
       );
     }
     return (
@@ -244,7 +251,7 @@ function MarketDetail({
         )}
       </YStack>
     );
-  }, [coinGeckoId, gtMd, tokenDetail]);
+  }, [coinGeckoId, gtMd, tokenDetail, preferredNetworkId]);
 
   const defer = useDeferredPromise();
 

--- a/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
@@ -21,7 +21,10 @@ import { ETabMarketRoutes } from '@onekeyhq/shared/src/routes';
 import type { ITabMarketParamList } from '@onekeyhq/shared/src/routes';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
-import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';
+import type {
+  IMarketPreferredToken,
+  IMarketTokenDetail,
+} from '@onekeyhq/shared/types/market';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
@@ -49,11 +52,11 @@ import { MarketWatchListProviderMirror } from '../MarketWatchListProviderMirror'
 function TokenDetailHeader({
   coinGeckoId,
   token: responseToken,
-  preferredNetworkId,
+  preferredToken,
 }: {
   coinGeckoId: string;
   token: IMarketTokenDetail;
-  preferredNetworkId?: string;
+  preferredToken?: IMarketPreferredToken;
 }) {
   const { gtMd: gtMdMedia } = useMedia();
 
@@ -100,7 +103,7 @@ function TokenDetailHeader({
         coinGeckoId={coinGeckoId}
         token={token}
         accountId={account?.id ?? ''}
-        preferredNetworkId={preferredNetworkId}
+        preferredToken={preferredToken}
       />
       {gtMd ? <MarketDetailOverview token={token} /> : null}
     </YStack>
@@ -136,7 +139,7 @@ function SkeletonHeaderOverItemItem() {
 function MarketDetail({
   route,
 }: IPageScreenProps<ITabMarketParamList, ETabMarketRoutes.MarketDetail>) {
-  const { token: coinGeckoId, preferredNetworkId } = route.params;
+  const { token: coinGeckoId, preferredToken } = route.params;
   const { gtMd: gtMdMedia } = useMedia();
 
   const isModalPage = useIsOverlayPage();
@@ -206,7 +209,7 @@ function MarketDetail({
         <TokenDetailHeader
           coinGeckoId={coinGeckoId}
           token={tokenDetail}
-          preferredNetworkId={preferredNetworkId}
+          preferredToken={preferredToken}
         />
       );
     }
@@ -251,7 +254,7 @@ function MarketDetail({
         )}
       </YStack>
     );
-  }, [coinGeckoId, gtMd, tokenDetail, preferredNetworkId]);
+  }, [coinGeckoId, gtMd, tokenDetail, preferredToken]);
 
   const defer = useDeferredPromise();
 

--- a/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
@@ -136,7 +136,7 @@ function SkeletonHeaderOverItemItem() {
 function MarketDetail({
   route,
 }: IPageScreenProps<ITabMarketParamList, ETabMarketRoutes.MarketDetail>) {
-  const { token: coinGeckoId, networkId: preferredNetworkId } = route.params;
+  const { token: coinGeckoId, preferredNetworkId } = route.params;
   const { gtMd: gtMdMedia } = useMedia();
 
   const isModalPage = useIsOverlayPage();

--- a/packages/kit/src/views/Market/components/MarketTradeButton.tsx
+++ b/packages/kit/src/views/Market/components/MarketTradeButton.tsx
@@ -14,7 +14,10 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';
+import type {
+  IMarketPreferredToken,
+  IMarketTokenDetail,
+} from '@onekeyhq/shared/types/market';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useAccountSelectorTrigger } from '../../../components/AccountSelector/hooks/useAccountSelectorTrigger';
@@ -31,22 +34,22 @@ export function MarketTradeButton({
   coinGeckoId,
   token,
   accountId,
-  preferredNetworkId,
+  preferredToken,
 }: {
   coinGeckoId: string;
   token: IMarketTokenDetail;
   accountId: string;
-  preferredNetworkId?: string;
+  preferredToken?: IMarketPreferredToken;
 }) {
   const intl = useIntl();
 
   const { onSwap, onStaking, onBuy, onSell, canStaking } =
-    useMarketTradeActions(token, preferredNetworkId);
+    useMarketTradeActions(token, preferredToken);
   const { showAccountSelector } = useAccountSelectorTrigger({
     num: 0,
     showConnectWalletModalInDappMode: true,
   });
-  const network = useMarketTradeNetwork(token, preferredNetworkId);
+  const network = useMarketTradeNetwork(token, preferredToken);
   const networkId = useMarketTradeNetworkId(network, token.symbol);
 
   const { tokenAddress: realContractAddress = '' } = network || {};

--- a/packages/kit/src/views/Market/components/MarketTradeButton.tsx
+++ b/packages/kit/src/views/Market/components/MarketTradeButton.tsx
@@ -31,20 +31,22 @@ export function MarketTradeButton({
   coinGeckoId,
   token,
   accountId,
+  preferredNetworkId,
 }: {
   coinGeckoId: string;
   token: IMarketTokenDetail;
   accountId: string;
+  preferredNetworkId?: string;
 }) {
   const intl = useIntl();
 
   const { onSwap, onStaking, onBuy, onSell, canStaking } =
-    useMarketTradeActions(token);
+    useMarketTradeActions(token, preferredNetworkId);
   const { showAccountSelector } = useAccountSelectorTrigger({
     num: 0,
     showConnectWalletModalInDappMode: true,
   });
-  const network = useMarketTradeNetwork(token);
+  const network = useMarketTradeNetwork(token, preferredNetworkId);
   const networkId = useMarketTradeNetworkId(network, token.symbol);
 
   const { tokenAddress: realContractAddress = '' } = network || {};

--- a/packages/kit/src/views/Market/components/tradeHook.tsx
+++ b/packages/kit/src/views/Market/components/tradeHook.tsx
@@ -37,24 +37,24 @@ import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
 import { EarnNavigation } from '../../Earn/earnUtils';
 
-export const useMarketTradeNetwork = (token: IMarketTokenDetail | null) => {
-  const { detailPlatforms, platforms = {} } = token || {};
-  const network = useMemo(() => {
-    if (detailPlatforms) {
-      const values = Object.values(detailPlatforms);
-      const nativePlatform = values.find((i) => i.isNative);
-      if (nativePlatform) {
-        return nativePlatform;
-      }
+import { resolveMarketTradeNetwork } from './tradeHook.utils';
 
-      const tokenAddress = Object.values(platforms)[0];
-      const tokenAddressPlatform = values.find(
-        (i) => i.tokenAddress === tokenAddress,
-      );
-      return tokenAddressPlatform ?? values[0];
-    }
-  }, [detailPlatforms, platforms]);
-  return network;
+export const useMarketTradeNetwork = (
+  token: IMarketTokenDetail | null,
+  // Network the caller already knows the token lives on; see
+  // resolveMarketTradeNetwork for why it takes precedence over market data.
+  preferredNetworkId?: string,
+) => {
+  const { detailPlatforms, platforms } = token || {};
+  return useMemo(
+    () =>
+      resolveMarketTradeNetwork({
+        detailPlatforms,
+        platforms,
+        preferredNetworkId,
+      }),
+    [detailPlatforms, platforms, preferredNetworkId],
+  );
 };
 
 export const useMarketTradeNetworkId = (
@@ -66,10 +66,13 @@ export const useMarketTradeNetworkId = (
     return onekeyNetworkId ?? getNetworkIdBySymbol(symbol);
   }, [network, symbol]);
 
-export const useMarketTradeActions = (token: IMarketTokenDetail | null) => {
+export const useMarketTradeActions = (
+  token: IMarketTokenDetail | null,
+  preferredNetworkId?: string,
+) => {
   const { symbol = '', name, image } = token || {};
   const intl = useIntl();
-  const network = useMarketTradeNetwork(token);
+  const network = useMarketTradeNetwork(token, preferredNetworkId);
   const networkId = useMarketTradeNetworkId(network, symbol);
 
   const navigation =

--- a/packages/kit/src/views/Market/components/tradeHook.tsx
+++ b/packages/kit/src/views/Market/components/tradeHook.tsx
@@ -23,6 +23,7 @@ import {
 import type { IFiatCryptoType } from '@onekeyhq/shared/types/fiatCrypto';
 import type {
   IMarketDetailPlatformNetwork,
+  IMarketPreferredToken,
   IMarketTokenDetail,
 } from '@onekeyhq/shared/types/market';
 import { getNetworkIdBySymbol } from '@onekeyhq/shared/types/market/marketProvider.constants';
@@ -41,9 +42,9 @@ import { resolveMarketTradeNetwork } from './tradeHook.utils';
 
 export const useMarketTradeNetwork = (
   token: IMarketTokenDetail | null,
-  // Network the caller already knows the token lives on; see
+  // Asset the caller already knows the user came from; see
   // resolveMarketTradeNetwork for why it takes precedence over market data.
-  preferredNetworkId?: string,
+  preferredToken?: IMarketPreferredToken,
 ) => {
   const { detailPlatforms, platforms } = token || {};
   return useMemo(
@@ -51,9 +52,9 @@ export const useMarketTradeNetwork = (
       resolveMarketTradeNetwork({
         detailPlatforms,
         platforms,
-        preferredNetworkId,
+        preferredToken,
       }),
-    [detailPlatforms, platforms, preferredNetworkId],
+    [detailPlatforms, platforms, preferredToken],
   );
 };
 
@@ -68,11 +69,11 @@ export const useMarketTradeNetworkId = (
 
 export const useMarketTradeActions = (
   token: IMarketTokenDetail | null,
-  preferredNetworkId?: string,
+  preferredToken?: IMarketPreferredToken,
 ) => {
   const { symbol = '', name, image } = token || {};
   const intl = useIntl();
-  const network = useMarketTradeNetwork(token, preferredNetworkId);
+  const network = useMarketTradeNetwork(token, preferredToken);
   const networkId = useMarketTradeNetworkId(network, symbol);
 
   const navigation =

--- a/packages/kit/src/views/Market/components/tradeHook.utils.test.ts
+++ b/packages/kit/src/views/Market/components/tradeHook.utils.test.ts
@@ -1,0 +1,116 @@
+import type { IMarketDetailPlatform } from '@onekeyhq/shared/types/market';
+
+import { resolveMarketTradeNetwork } from './tradeHook.utils';
+
+const KATANA = 'evm--747474';
+const ETH = 'evm--1';
+
+const ethPlatform = {
+  contract_address: '0xeth',
+  onekeyNetworkId: ETH,
+  tokenAddress: '0xeth',
+};
+const basePlatform = {
+  contract_address: '0xbase',
+  onekeyNetworkId: 'evm--8453',
+  tokenAddress: '0xbase',
+};
+const nativePlatform = {
+  contract_address: '',
+  onekeyNetworkId: ETH,
+  isNative: true as const,
+};
+
+describe('resolveMarketTradeNetwork', () => {
+  describe('with a preferred network from the caller', () => {
+    it('picks the platform entry mapped to that network', () => {
+      const detailPlatforms: IMarketDetailPlatform = {
+        ethereum: ethPlatform,
+        base: basePlatform,
+      };
+      expect(
+        resolveMarketTradeNetwork({
+          detailPlatforms,
+          preferredNetworkId: 'evm--8453',
+        }),
+      ).toBe(basePlatform);
+    });
+
+    it('trusts the caller when market data has no entry for that network', () => {
+      // Katana vbUSDC: the market service has not mapped the Katana platform,
+      // so no entry carries its onekeyNetworkId. Guessing another chain here
+      // is what made the DeFi button a silent no-op.
+      const detailPlatforms: IMarketDetailPlatform = {
+        ethereum: ethPlatform,
+      };
+      expect(
+        resolveMarketTradeNetwork({
+          detailPlatforms,
+          preferredNetworkId: KATANA,
+        }),
+      ).toEqual({ contract_address: '', onekeyNetworkId: KATANA });
+    });
+
+    it('still resolves when market data carries no platforms at all', () => {
+      expect(resolveMarketTradeNetwork({ preferredNetworkId: KATANA })).toEqual(
+        { contract_address: '', onekeyNetworkId: KATANA },
+      );
+    });
+
+    it('does not let the hint override an explicit match on another entry', () => {
+      const detailPlatforms: IMarketDetailPlatform = {
+        ethereum: nativePlatform,
+        base: basePlatform,
+      };
+      // Native entry would win without a hint; the hint targets Base.
+      expect(
+        resolveMarketTradeNetwork({
+          detailPlatforms,
+          preferredNetworkId: 'evm--8453',
+        }),
+      ).toBe(basePlatform);
+    });
+  });
+
+  describe('without a hint (original heuristic)', () => {
+    it('returns undefined when there is no market platform data', () => {
+      expect(resolveMarketTradeNetwork({})).toBeUndefined();
+    });
+
+    it('prefers the native entry', () => {
+      const detailPlatforms: IMarketDetailPlatform = {
+        base: basePlatform,
+        ethereum: nativePlatform,
+      };
+      expect(resolveMarketTradeNetwork({ detailPlatforms })).toBe(
+        nativePlatform,
+      );
+    });
+
+    it('falls back to the entry matching the primary platform address', () => {
+      const detailPlatforms: IMarketDetailPlatform = {
+        ethereum: ethPlatform,
+        base: basePlatform,
+      };
+      expect(
+        resolveMarketTradeNetwork({
+          detailPlatforms,
+          platforms: { base: '0xbase' },
+        }),
+      ).toBe(basePlatform);
+    });
+
+    it('falls back to the first entry when nothing matches', () => {
+      const detailPlatforms: IMarketDetailPlatform = {
+        ethereum: ethPlatform,
+        base: basePlatform,
+      };
+      expect(
+        resolveMarketTradeNetwork({
+          detailPlatforms,
+          platforms: { polygon: '0xnope' },
+        }),
+      ).toBe(ethPlatform);
+    });
+  });
+});

--- a/packages/kit/src/views/Market/components/tradeHook.utils.test.ts
+++ b/packages/kit/src/views/Market/components/tradeHook.utils.test.ts
@@ -4,6 +4,8 @@ import { resolveMarketTradeNetwork } from './tradeHook.utils';
 
 const KATANA = 'evm--747474';
 const ETH = 'evm--1';
+const BASE = 'evm--8453';
+const VB_USDC = '0x203a662b0bd271a6ed5a60edfbd04bfce608fd36';
 
 const ethPlatform = {
   contract_address: '0xeth',
@@ -12,7 +14,7 @@ const ethPlatform = {
 };
 const basePlatform = {
   contract_address: '0xbase',
-  onekeyNetworkId: 'evm--8453',
+  onekeyNetworkId: BASE,
   tokenAddress: '0xbase',
 };
 const nativePlatform = {
@@ -22,8 +24,8 @@ const nativePlatform = {
 };
 
 describe('resolveMarketTradeNetwork', () => {
-  describe('with a preferred network from the caller', () => {
-    it('picks the platform entry mapped to that network', () => {
+  describe('with the asset the caller launched Market from', () => {
+    it('prefers the market entry mapped to that network over the hint', () => {
       const detailPlatforms: IMarketDetailPlatform = {
         ethereum: ethPlatform,
         base: basePlatform,
@@ -31,42 +33,71 @@ describe('resolveMarketTradeNetwork', () => {
       expect(
         resolveMarketTradeNetwork({
           detailPlatforms,
-          preferredNetworkId: 'evm--8453',
+          preferredToken: { networkId: BASE, tokenAddress: '0xstale' },
         }),
       ).toBe(basePlatform);
     });
 
-    it('trusts the caller when market data has no entry for that network', () => {
-      // Katana vbUSDC: the market service has not mapped the Katana platform,
-      // so no entry carries its onekeyNetworkId. Guessing another chain here
-      // is what made the DeFi button a silent no-op.
+    it('rebuilds the entry from the full identity when the network is unmapped', () => {
+      // Katana vbUSDC: the market service has not mapped the Katana platform.
+      // The rebuilt entry must carry the contract address, otherwise Swap is
+      // opened on a non-native token with no address.
       const detailPlatforms: IMarketDetailPlatform = {
         ethereum: ethPlatform,
       };
       expect(
         resolveMarketTradeNetwork({
           detailPlatforms,
-          preferredNetworkId: KATANA,
+          preferredToken: { networkId: KATANA, tokenAddress: VB_USDC },
         }),
-      ).toEqual({ contract_address: '', onekeyNetworkId: KATANA });
+      ).toEqual({
+        contract_address: VB_USDC,
+        tokenAddress: VB_USDC,
+        onekeyNetworkId: KATANA,
+      });
+    });
+
+    it('marks a rebuilt native entry as native with an empty address', () => {
+      expect(
+        resolveMarketTradeNetwork({
+          preferredToken: {
+            networkId: KATANA,
+            tokenAddress: '',
+            isNative: true,
+          },
+        }),
+      ).toEqual({
+        contract_address: '',
+        tokenAddress: '',
+        onekeyNetworkId: KATANA,
+        isNative: true,
+      });
+    });
+
+    it('does not tag a rebuilt ERC-20 entry as native', () => {
+      const entry = resolveMarketTradeNetwork({
+        preferredToken: { networkId: KATANA, tokenAddress: VB_USDC },
+      });
+      expect(entry).not.toHaveProperty('isNative');
     });
 
     it('still resolves when market data carries no platforms at all', () => {
-      expect(resolveMarketTradeNetwork({ preferredNetworkId: KATANA })).toEqual(
-        { contract_address: '', onekeyNetworkId: KATANA },
-      );
+      expect(
+        resolveMarketTradeNetwork({
+          preferredToken: { networkId: KATANA, tokenAddress: VB_USDC },
+        }),
+      ).toMatchObject({ onekeyNetworkId: KATANA, tokenAddress: VB_USDC });
     });
 
-    it('does not let the hint override an explicit match on another entry', () => {
+    it('lets the hint pick a mapped entry the native-first heuristic would skip', () => {
       const detailPlatforms: IMarketDetailPlatform = {
         ethereum: nativePlatform,
         base: basePlatform,
       };
-      // Native entry would win without a hint; the hint targets Base.
       expect(
         resolveMarketTradeNetwork({
           detailPlatforms,
-          preferredNetworkId: 'evm--8453',
+          preferredToken: { networkId: BASE, tokenAddress: '0xbase' },
         }),
       ).toBe(basePlatform);
     });

--- a/packages/kit/src/views/Market/components/tradeHook.utils.ts
+++ b/packages/kit/src/views/Market/components/tradeHook.utils.ts
@@ -1,0 +1,56 @@
+import type {
+  IMarketDetailPlatform,
+  IMarketDetailPlatformNetwork,
+} from '@onekeyhq/shared/types/market';
+
+/**
+ * Picks the platform entry the market trade actions operate on.
+ *
+ * Market data describes a token once per CoinGecko platform, and an entry only
+ * carries `onekeyNetworkId` when the market service has mapped that platform.
+ * A caller that already knows which network the user came from (the
+ * AssetDetails "Market" footer does) passes it as `preferredNetworkId`: the
+ * matching entry wins, and when market data has no entry for that network at
+ * all we trust the caller instead of guessing another chain — otherwise the
+ * Earn/Swap handoffs bail out silently on a missing networkId. Katana vbUSDC
+ * was the first token to hit this.
+ *
+ * Without a hint the original heuristic is kept as-is: native entry, then the
+ * entry whose address matches the token's primary platform, then the first.
+ */
+export function resolveMarketTradeNetwork({
+  detailPlatforms,
+  platforms,
+  preferredNetworkId,
+}: {
+  detailPlatforms?: IMarketDetailPlatform;
+  platforms?: Record<string, string>;
+  preferredNetworkId?: string;
+}): IMarketDetailPlatformNetwork | undefined {
+  const values = detailPlatforms ? Object.values(detailPlatforms) : [];
+
+  if (preferredNetworkId) {
+    const preferred = values.find(
+      (platform) => platform.onekeyNetworkId === preferredNetworkId,
+    );
+    if (preferred) {
+      return preferred;
+    }
+    return { contract_address: '', onekeyNetworkId: preferredNetworkId };
+  }
+
+  if (!detailPlatforms) {
+    return undefined;
+  }
+
+  const nativePlatform = values.find((platform) => platform.isNative);
+  if (nativePlatform) {
+    return nativePlatform;
+  }
+
+  const tokenAddress = Object.values(platforms ?? {})[0];
+  const tokenAddressPlatform = values.find(
+    (platform) => platform.tokenAddress === tokenAddress,
+  );
+  return tokenAddressPlatform ?? values[0];
+}

--- a/packages/kit/src/views/Market/components/tradeHook.utils.ts
+++ b/packages/kit/src/views/Market/components/tradeHook.utils.ts
@@ -1,6 +1,7 @@
 import type {
   IMarketDetailPlatform,
   IMarketDetailPlatformNetwork,
+  IMarketPreferredToken,
 } from '@onekeyhq/shared/types/market';
 
 /**
@@ -8,12 +9,13 @@ import type {
  *
  * Market data describes a token once per CoinGecko platform, and an entry only
  * carries `onekeyNetworkId` when the market service has mapped that platform.
- * A caller that already knows which network the user came from (the
- * AssetDetails "Market" footer does) passes it as `preferredNetworkId`: the
- * matching entry wins, and when market data has no entry for that network at
- * all we trust the caller instead of guessing another chain — otherwise the
- * Earn/Swap handoffs bail out silently on a missing networkId. Katana vbUSDC
- * was the first token to hit this.
+ * A caller that already knows which asset the user came from (the
+ * AssetDetails "Market" footer does) passes it as `preferredToken`: the
+ * entry mapped to that network wins, and when market data has no entry for
+ * that network at all we rebuild one from the caller's identity instead of
+ * guessing another chain — otherwise the Earn/Swap handoffs either bail out
+ * silently on a missing networkId or, worse, open Swap on a token with no
+ * contract address. Katana vbUSDC was the first token to hit this.
  *
  * Without a hint the original heuristic is kept as-is: native entry, then the
  * entry whose address matches the token's primary platform, then the first.
@@ -21,22 +23,27 @@ import type {
 export function resolveMarketTradeNetwork({
   detailPlatforms,
   platforms,
-  preferredNetworkId,
+  preferredToken,
 }: {
   detailPlatforms?: IMarketDetailPlatform;
   platforms?: Record<string, string>;
-  preferredNetworkId?: string;
+  preferredToken?: IMarketPreferredToken;
 }): IMarketDetailPlatformNetwork | undefined {
   const values = detailPlatforms ? Object.values(detailPlatforms) : [];
 
-  if (preferredNetworkId) {
+  if (preferredToken) {
     const preferred = values.find(
-      (platform) => platform.onekeyNetworkId === preferredNetworkId,
+      (platform) => platform.onekeyNetworkId === preferredToken.networkId,
     );
     if (preferred) {
       return preferred;
     }
-    return { contract_address: '', onekeyNetworkId: preferredNetworkId };
+    return {
+      contract_address: preferredToken.tokenAddress,
+      tokenAddress: preferredToken.tokenAddress,
+      onekeyNetworkId: preferredToken.networkId,
+      ...(preferredToken.isNative ? { isNative: true as const } : {}),
+    };
   }
 
   if (!detailPlatforms) {

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -2366,7 +2366,7 @@ export function UniversalStake({
               tokenSelectorTriggerProps={{
                 selectedTokenImageUri: tokenImageUri,
                 selectedTokenImageLoading: tokenImageLoading,
-                selectedTokenSymbol: tokenSymbol?.toUpperCase(),
+                selectedTokenSymbol: tokenSymbol,
                 selectedNetworkImageUri: network?.logoURI,
                 ...tokenSelectorTriggerProps,
               }}

--- a/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
@@ -43,6 +43,7 @@ import {
   EModalStakingRoutes,
   type IModalStakingParamList,
 } from '@onekeyhq/shared/src/routes';
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import {
@@ -1088,7 +1089,7 @@ const ProtocolDetailsPage = () => {
           {
             'symbol': networkUtils.isBTCNetwork(networkId)
               ? `${symbol} (Taproot)`
-              : symbol,
+              : earnUtils.getDisplaySymbol(tokenInfo?.token) || symbol,
           },
         )}
       />

--- a/packages/shared/src/routes/assetDetails.ts
+++ b/packages/shared/src/routes/assetDetails.ts
@@ -62,6 +62,12 @@ export type IModalAssetDetailsParamList = {
   };
   [EModalAssetDetailRoutes.MarketDetail]: {
     token: string;
+    /**
+     * Network the caller already knows the token lives on. Lets the trade
+     * actions resolve a networkId even when market data has not mapped
+     * that platform; entries that only know the CoinGecko id omit it.
+     */
+    networkId?: string;
   };
   [EModalAssetDetailRoutes.NFTDetails]: {
     networkId: string;

--- a/packages/shared/src/routes/assetDetails.ts
+++ b/packages/shared/src/routes/assetDetails.ts
@@ -66,8 +66,10 @@ export type IModalAssetDetailsParamList = {
      * Network the caller already knows the token lives on. Lets the trade
      * actions resolve a networkId even when market data has not mapped
      * that platform; entries that only know the CoinGecko id omit it.
+     * Deliberately not named `networkId`: the MarketDetail dispatcher
+     * treats that key as "render V2", which needs `network`/`tokenAddress`.
      */
-    networkId?: string;
+    preferredNetworkId?: string;
   };
   [EModalAssetDetailRoutes.NFTDetails]: {
     networkId: string;

--- a/packages/shared/src/routes/assetDetails.ts
+++ b/packages/shared/src/routes/assetDetails.ts
@@ -9,6 +9,7 @@ import type {
   IProtocolSummary,
   IResolvedDeFiPositionAction,
 } from '../../types/defi';
+import type { IMarketPreferredToken } from '../../types/market';
 import type { ISendTxOnSuccessData, IUtxoAddressInfo } from '../../types/tx';
 
 export enum EModalAssetDetailRoutes {
@@ -63,13 +64,13 @@ export type IModalAssetDetailsParamList = {
   [EModalAssetDetailRoutes.MarketDetail]: {
     token: string;
     /**
-     * Network the caller already knows the token lives on. Lets the trade
-     * actions resolve a networkId even when market data has not mapped
-     * that platform; entries that only know the CoinGecko id omit it.
-     * Deliberately not named `networkId`: the MarketDetail dispatcher
-     * treats that key as "render V2", which needs `network`/`tokenAddress`.
+     * The wallet asset the caller launched Market from. Lets the trade
+     * actions resolve the network and contract address even when market
+     * data has not mapped that platform; entries that only know the
+     * CoinGecko id omit it. Deliberately not keyed `networkId`: the
+     * MarketDetail dispatcher treats that key as "render V2".
      */
-    preferredNetworkId?: string;
+    preferredToken?: IMarketPreferredToken;
   };
   [EModalAssetDetailRoutes.NFTDetails]: {
     networkId: string;

--- a/packages/shared/src/routes/tabMarket.ts
+++ b/packages/shared/src/routes/tabMarket.ts
@@ -17,8 +17,10 @@ export type ITabMarketParamList = {
      * Network the caller already knows the token lives on. Lets the trade
      * actions resolve a networkId even when market data has not mapped
      * that platform; entries that only know the CoinGecko id omit it.
+     * Deliberately not named `networkId`: the MarketDetail dispatcher
+     * treats that key as "render V2", which needs `network`/`tokenAddress`.
      */
-    networkId?: string;
+    preferredNetworkId?: string;
   };
   [ETabMarketRoutes.MarketDetailV2]: {
     tokenAddress: string;

--- a/packages/shared/src/routes/tabMarket.ts
+++ b/packages/shared/src/routes/tabMarket.ts
@@ -13,6 +13,12 @@ export type ITabMarketParamList = {
   [ETabMarketRoutes.TabMarket]: { from?: EEnterWay } | undefined;
   [ETabMarketRoutes.MarketDetail]: {
     token: string;
+    /**
+     * Network the caller already knows the token lives on. Lets the trade
+     * actions resolve a networkId even when market data has not mapped
+     * that platform; entries that only know the CoinGecko id omit it.
+     */
+    networkId?: string;
   };
   [ETabMarketRoutes.MarketDetailV2]: {
     tokenAddress: string;

--- a/packages/shared/src/routes/tabMarket.ts
+++ b/packages/shared/src/routes/tabMarket.ts
@@ -1,3 +1,4 @@
+import type { IMarketPreferredToken } from '../../types/market';
 import type { EMarketBannerType } from '../../types/marketV2';
 import type { EEnterWay } from '../logger/scopes/dex';
 
@@ -14,13 +15,13 @@ export type ITabMarketParamList = {
   [ETabMarketRoutes.MarketDetail]: {
     token: string;
     /**
-     * Network the caller already knows the token lives on. Lets the trade
-     * actions resolve a networkId even when market data has not mapped
-     * that platform; entries that only know the CoinGecko id omit it.
-     * Deliberately not named `networkId`: the MarketDetail dispatcher
-     * treats that key as "render V2", which needs `network`/`tokenAddress`.
+     * The wallet asset the caller launched Market from. Lets the trade
+     * actions resolve the network and contract address even when market
+     * data has not mapped that platform; entries that only know the
+     * CoinGecko id omit it. Deliberately not keyed `networkId`: the
+     * MarketDetail dispatcher treats that key as "render V2".
      */
-    preferredNetworkId?: string;
+    preferredToken?: IMarketPreferredToken;
   };
   [ETabMarketRoutes.MarketDetailV2]: {
     tokenAddress: string;

--- a/packages/shared/src/utils/earnUtils.test.ts
+++ b/packages/shared/src/utils/earnUtils.test.ts
@@ -191,4 +191,59 @@ describe('earnUtils borrow address normalization', () => {
       ).toEqual({ networkId: 'evm--1' });
     });
   });
+
+  describe('getDisplaySymbol', () => {
+    it('prefers the server relabel when one is present', () => {
+      expect(
+        earnUtils.getDisplaySymbol({
+          symbol: 'vbUSDC',
+          displaySymbol: 'USDC for Katana (vbUSDC)',
+        }),
+      ).toBe('USDC for Katana (vbUSDC)');
+    });
+
+    it('falls back to symbol for the tokens that carry no relabel', () => {
+      expect(earnUtils.getDisplaySymbol({ symbol: 'USDC' })).toBe('USDC');
+      expect(
+        earnUtils.getDisplaySymbol({ symbol: 'USDC', displaySymbol: '' }),
+      ).toBe('USDC');
+    });
+
+    it('returns an empty string rather than throwing on a missing token', () => {
+      expect(earnUtils.getDisplaySymbol(undefined)).toBe('');
+      expect(earnUtils.getDisplaySymbol(null)).toBe('');
+      expect(earnUtils.getDisplaySymbol({})).toBe('');
+    });
+  });
+
+  describe('matchesSymbolKeyword', () => {
+    const token = {
+      symbol: 'vbUSDC',
+      displaySymbol: 'USDC for Katana (vbUSDC)',
+    };
+
+    it('still finds a relabelled token by the symbol users already know', () => {
+      expect(earnUtils.matchesSymbolKeyword(token, 'vbusdc')).toBe(true);
+    });
+
+    it('matches against the relabel too', () => {
+      expect(earnUtils.matchesSymbolKeyword(token, 'katana')).toBe(true);
+      expect(earnUtils.matchesSymbolKeyword(token, 'USDC FOR')).toBe(true);
+    });
+
+    it('does not match an unrelated keyword', () => {
+      expect(earnUtils.matchesSymbolKeyword(token, 'weth')).toBe(false);
+    });
+
+    it('treats a blank keyword as no filter', () => {
+      expect(earnUtils.matchesSymbolKeyword(token, '')).toBe(true);
+      expect(earnUtils.matchesSymbolKeyword(token, '   ')).toBe(true);
+      expect(earnUtils.matchesSymbolKeyword(undefined, '')).toBe(true);
+    });
+
+    it('does not match when the token has no labels', () => {
+      expect(earnUtils.matchesSymbolKeyword(undefined, 'usdc')).toBe(false);
+      expect(earnUtils.matchesSymbolKeyword({}, 'usdc')).toBe(false);
+    });
+  });
 });

--- a/packages/shared/src/utils/earnUtils.ts
+++ b/packages/shared/src/utils/earnUtils.ts
@@ -234,6 +234,42 @@ function convertEarnTokenToIToken(earnToken?: IEarnToken): IToken | undefined {
   };
 }
 
+/**
+ * Resolves the label a token should be shown under.
+ *
+ * `symbol` stays the protocol identifier — it is the request param, the route
+ * segment and the key the server matches on, so it must never be swapped for a
+ * label. `displaySymbol` is an optional server-supplied relabel (e.g. Katana's
+ * vbUSDC reads as "USDC for Katana (vbUSDC)") that only ever affects rendering,
+ * and is absent for almost every token.
+ *
+ * Use this for identity surfaces — list rows, search results, page titles.
+ * Do NOT use it as an amount unit: a relabel can be far longer than a symbol
+ * and would wreck "0.00 <symbol>" layouts.
+ */
+function getDisplaySymbol(
+  token?: { symbol?: string; displaySymbol?: string } | null,
+): string {
+  return token?.displaySymbol || token?.symbol || '';
+}
+
+/**
+ * Whether a keyword matches a token by either of its labels, so search still
+ * finds a relabelled token by the symbol users already know.
+ */
+function matchesSymbolKeyword(
+  token: { symbol?: string; displaySymbol?: string } | null | undefined,
+  keyword: string,
+): boolean {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  if (!normalizedKeyword) {
+    return true;
+  }
+  return [token?.symbol, token?.displaySymbol].some((label) =>
+    label?.toLowerCase().includes(normalizedKeyword),
+  );
+}
+
 function extractAmountFromText(text?: IEarnText): string {
   if (!text?.text) return '0';
 
@@ -331,6 +367,8 @@ export default {
   resolveEarnApproveType,
   resolveEarnAllowanceSpenderAddress,
   convertEarnTokenToIToken,
+  getDisplaySymbol,
+  matchesSymbolKeyword,
   extractAmountFromText,
   normalizeBorrowAddress,
   normalizeBorrowAddressParams,

--- a/packages/shared/types/earn.ts
+++ b/packages/shared/types/earn.ts
@@ -157,6 +157,12 @@ export interface IEarnAvailableAssetBadge {
 export interface IEarnAvailableAsset {
   name: string;
   symbol: string;
+  /**
+   * Server-supplied display relabel of `symbol`. Absent for almost every
+   * token. Render it via earnUtils.getDisplaySymbol; never use it as a
+   * lookup key, request param or route segment.
+   */
+  displaySymbol?: string;
   logoURI: string;
   apr: string;
   aprWithoutFee: string;
@@ -181,6 +187,12 @@ export interface IEarnAvailableAssetV2 {
   networkId: string;
   provider: string;
   symbol: string;
+  /**
+   * Server-supplied display relabel of `symbol`. Absent for almost every
+   * token. Render it via earnUtils.getDisplaySymbol; never use it as a
+   * lookup key, request param or route segment.
+   */
+  displaySymbol?: string;
   vault?: string;
   ptAddress?: string;
   enableBatch?: boolean;

--- a/packages/shared/types/market.ts
+++ b/packages/shared/types/market.ts
@@ -66,6 +66,19 @@ export interface IMarketDetailPlatformNetwork {
   tokenAddress?: string;
 }
 
+/**
+ * Identity of the wallet asset a caller launched Market from. Market data
+ * only knows a token per CoinGecko platform, so when the market service has
+ * not mapped that platform the trade actions rebuild the platform entry
+ * from this instead of guessing another chain. `tokenAddress` is the empty
+ * string for the native token.
+ */
+export interface IMarketPreferredToken {
+  networkId: string;
+  tokenAddress: string;
+  isNative?: boolean;
+}
+
 export interface IMarketDetailPlatform {
   [key: string]: IMarketDetailPlatformNetwork;
 }

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -582,6 +582,13 @@ export interface IEarnToken {
   logoURI: string;
   name: string;
   symbol: string;
+  /**
+   * Server-supplied display relabel of `symbol`. Absent for almost every
+   * token. Render it via earnUtils.getDisplaySymbol; never use it as a
+   * lookup key, request param or route segment.
+   */
+  displaySymbol?: string;
+
   totalSupply: string;
   riskLevel: number;
   coingeckoId: string;
@@ -1779,6 +1786,13 @@ export enum EBorrowActionsEnum {
 export type IStakeProtocolListItem = {
   // In the full-list (no symbol) case the server tags each row with its symbol (6.6.0+)
   symbol?: string;
+  /**
+   * Server-supplied display relabel of `symbol`. Absent for almost every
+   * token. Render it via earnUtils.getDisplaySymbol; never use it as a
+   * lookup key, request param or route segment.
+   */
+  displaySymbol?: string;
+
   provider: IStakeProviderInfo & {
     group: EStakeProtocolGroupEnum;
     category?: string | null;
@@ -1879,6 +1893,12 @@ export interface IEarnAccountToken {
   networkId: string;
   name: string;
   symbol: string;
+  /**
+   * Server-supplied display relabel of `symbol`. Absent for almost every
+   * token. Render it via earnUtils.getDisplaySymbol; never use it as a
+   * lookup key, request param or route segment.
+   */
+  displaySymbol?: string;
   logoURI: string;
   aprWithoutFee: string;
   profit: string;
@@ -1926,6 +1946,12 @@ export type IAvailableAsset = IEarnAvailableAsset & {
 export type IRecommendAsset = {
   name: string;
   symbol: string;
+  /**
+   * Server-supplied display relabel of `symbol`. Absent for almost every
+   * token. Render it via earnUtils.getDisplaySymbol; never use it as a
+   * lookup key, request param or route segment.
+   */
+  displaySymbol?: string;
   logoURI: string;
   protocols: Array<{
     networkId: string;


### PR DESCRIPTION
…rename

The server can now relabel a token with an optional `displaySymbol` alongside `symbol`. `symbol` stays the key it always was — the request param, the /earn/:network/:symbol/:provider segment, and what supportedSymbols and the staking config match on — so none of those change and older clients keep rendering `symbol` unaffected.

earnUtils.getDisplaySymbol resolves the label; matchesSymbolKeyword searches both, so a relabelled token is still found by the symbol users know. Applied to identity surfaces only: the available-assets lists, search, protocol token rows, recommendations and the two detail page titles. Amount units keep the short symbol, since a relabel can be far longer than a symbol and would break "0.00 <symbol>" layouts. Those rows grew a single-line clamp so a long label truncates instead of pushing the APR off the edge.

Katana vbUSDC is the first token to use it, reading as "USDC for Katana (vbUSDC)".