### PR TITLE
fix: make market chart toolbars horizontally scrollable ｜OK-61560

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -19909,6 +19909,7 @@
     "packages/kit/src/components/TokenSelectorFilter/utils.ts": 20406,
     "packages/kit/src/components/TradingHoursPanel/index.tsx": 23522,
     "packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx": 13553,
+    "packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewDesktopToolbarContext.ts": 1261,
     "packages/kit/src/components/TradingView/TradingViewChartControls/calendarControls/CalendarPanelPopover.tsx": 15974,
     "packages/kit/src/components/TradingView/TradingViewChartControls/calendarControls/CalendarPanelUtils.ts": 1328,
     "packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/ChartSettingsDialogContent.tsx": 18710,

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
@@ -523,6 +523,8 @@ export const TradingViewChartControls = memo(
         >
           <ToolbarContainer
             testID="trading-view-desktop-toolbar"
+            width={desktopToolbar ? '100%' : undefined}
+            minWidth={desktopToolbar ? 0 : undefined}
             {...(desktopToolbar
               ? {
                   horizontal: true,

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewChartControls.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, type ReactNode, memo, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ReactNode,
+  memo,
+  useContext,
+  useMemo,
+} from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -19,6 +25,7 @@ import { ChartTypeSelect } from './chartType/ChartTypeSelect';
 import { IndicatorPopover } from './indicatorSelector/NativeIndicatorSelector';
 import { TradingViewNativeIntervalSelector } from './intervalSelector/NativeIntervalSelector';
 import { PriceMarketCapSelect } from './priceMarketCap/PriceMarketCapSelect';
+import { TradingViewDesktopToolbarContext } from './TradingViewDesktopToolbarContext';
 import { HEADER_ICON_BUTTON_STYLE_PROPS } from './utils/NativeChartControlsShared';
 
 import type {
@@ -250,6 +257,7 @@ export const TradingViewChartControls = memo(
     onFullscreenToggle,
     onRightControlPress,
   }: ITradingViewChartControlsProps) => {
+    const desktopToolbar = useContext(TradingViewDesktopToolbarContext);
     const intl = useIntl();
     const isDesktopLayout = layoutMode === 'desktop';
     const hasCalendarControl = Boolean(
@@ -498,6 +506,8 @@ export const TradingViewChartControls = memo(
     ) : null;
 
     if (isDesktopLayout) {
+      const ToolbarContainer = desktopToolbar ? ScrollView : Stack;
+      const IntervalContainer = desktopToolbar ? Stack : ScrollView;
       return (
         <Stack
           bg={backgroundColor}
@@ -511,68 +521,95 @@ export const TradingViewChartControls = memo(
           justifyContent="center"
           zIndex={3}
         >
-          <XStack alignItems="center" width="100%" gap="$2">
-            {desktopFullscreenHeader}
-
+          <ToolbarContainer
+            testID="trading-view-desktop-toolbar"
+            {...(desktopToolbar
+              ? {
+                  horizontal: true,
+                  showsHorizontalScrollIndicator: false,
+                  contentContainerStyle: { flexGrow: 1 },
+                }
+              : {})}
+          >
             <XStack
-              testID="trading-view-chart-ready-controls"
-              flex={1}
-              minWidth={0}
-              gap="$2"
               alignItems="center"
-              opacity={isControlsReady ? 1 : 0}
-              pointerEvents={isControlsReady ? 'auto' : 'none'}
+              width={desktopToolbar ? undefined : '100%'}
+              minWidth={desktopToolbar ? '100%' : undefined}
+              flexGrow={1}
+              flexShrink={0}
+              gap="$2"
             >
-              <ScrollView
-                horizontal
-                flex={1}
+              {desktopFullscreenHeader}
+
+              <XStack
+                testID="trading-view-chart-ready-controls"
+                flexGrow={1}
+                flexShrink={desktopToolbar ? 0 : 1}
+                flexBasis={desktopToolbar ? 'auto' : 0}
                 minWidth={0}
-                showsHorizontalScrollIndicator={false}
+                gap="$2"
+                alignItems="center"
+                opacity={isControlsReady ? 1 : 0}
+                pointerEvents={isControlsReady ? 'auto' : 'none'}
               >
-                <XStack alignItems="center" gap="$2" flexShrink={0}>
-                  {intervalSelector}
+                <IntervalContainer
+                  {...(desktopToolbar
+                    ? {}
+                    : {
+                        horizontal: true,
+                        showsHorizontalScrollIndicator: false,
+                      })}
+                  flexGrow={1}
+                  flexShrink={desktopToolbar ? 0 : 1}
+                  flexBasis={desktopToolbar ? 'auto' : 0}
+                  minWidth={0}
+                >
+                  <XStack alignItems="center" gap="$2" flexShrink={0}>
+                    {intervalSelector}
 
-                  {intervalSelector && hasLeftChartTools ? (
-                    <ToolbarSeparator />
-                  ) : null}
+                    {intervalSelector && hasLeftChartTools ? (
+                      <ToolbarSeparator />
+                    ) : null}
 
-                  {hasLeftChartTools ? (
-                    <XStack gap="$0.5" alignItems="center" flexShrink={0}>
-                      {chartTypeControl}
-                      {indicatorControl}
-                      {calendarControl}
-                      {settingsControl}
-                    </XStack>
-                  ) : null}
+                    {hasLeftChartTools ? (
+                      <XStack gap="$0.5" alignItems="center" flexShrink={0}>
+                        {chartTypeControl}
+                        {indicatorControl}
+                        {calendarControl}
+                        {settingsControl}
+                      </XStack>
+                    ) : null}
 
-                  {(intervalSelector || hasLeftChartTools) &&
-                  undoRedoControls ? (
-                    <ToolbarSeparator />
-                  ) : null}
+                    {(intervalSelector || hasLeftChartTools) &&
+                    undoRedoControls ? (
+                      <ToolbarSeparator />
+                    ) : null}
 
-                  {undoRedoControls}
-                </XStack>
-              </ScrollView>
+                    {undoRedoControls}
+                  </XStack>
+                </IntervalContainer>
 
-              {priceMarketCapControl}
+                {priceMarketCapControl}
 
-              {priceMarketCapControl &&
-              (chartSwitchControl || fullscreenControl) ? (
-                <ToolbarSeparator />
-              ) : null}
+                {priceMarketCapControl &&
+                (chartSwitchControl || fullscreenControl) ? (
+                  <ToolbarSeparator />
+                ) : null}
+              </XStack>
+
+              <XStack gap="$2" alignItems="center" flexShrink={0}>
+                {chartSwitchControl}
+
+                {chartSwitchControl && fullscreenControl ? (
+                  <ToolbarSeparator />
+                ) : null}
+
+                {fullscreenControl}
+                {rightControl}
+                {desktopToolbar}
+              </XStack>
             </XStack>
-
-            <XStack gap="$2" alignItems="center" flexShrink={0}>
-              {chartSwitchControl}
-
-              {chartSwitchControl && fullscreenControl ? (
-                <ToolbarSeparator />
-              ) : null}
-
-              {fullscreenControl}
-              {rightControl}
-            </XStack>
-          </XStack>
+          </ToolbarContainer>
         </Stack>
       );
     }

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewDesktopToolbarContext.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/TradingViewDesktopToolbarContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { ReactNode } from 'react';
+
+export const TradingViewDesktopToolbarContext = createContext<ReactNode>(null);

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/MarketDetailProChartControls.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/MarketDetailProChartControls.tsx
@@ -14,6 +14,7 @@ export function MarketDetailProChartControls({
   testID,
   fullscreenTestID,
   top,
+  inline = false,
   chartMode,
   isChartSwitchDisabled,
   onChartSwitch,
@@ -23,6 +24,7 @@ export function MarketDetailProChartControls({
   testID: string;
   fullscreenTestID: string;
   top: number;
+  inline?: boolean;
   chartMode: ITradingViewChartMode;
   isChartSwitchDisabled?: boolean;
   onChartSwitch: () => void;
@@ -33,9 +35,10 @@ export function MarketDetailProChartControls({
   return (
     <XStack
       testID={testID}
-      position="absolute"
-      top={top}
-      right={0}
+      position={inline ? 'relative' : 'absolute'}
+      top={inline ? undefined : top}
+      right={inline ? undefined : 0}
+      flexShrink={0}
       alignItems="center"
       gap="$2"
       bg="$bgApp"

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.test.tsx
@@ -80,11 +80,14 @@ function MockProChart() {
   return <div data-testid="market-token-pro-chart">{toolbar}</div>;
 }
 
-function renderTokenDetailChart(marketAssetId?: string) {
+function renderTokenDetailChart(
+  marketAssetId?: string,
+  marketTradingView: ReactNode = <MockProChart />,
+) {
   return render(
     <TokenDetailChart
       marketAssetId={marketAssetId}
-      marketTradingView={<MockProChart />}
+      marketTradingView={marketTradingView}
       isChartFullscreen={false}
       chartMode="native"
       onChartSwitch={jest.fn()}
@@ -141,6 +144,25 @@ describe('TokenDetailChart', () => {
     fireEvent.click(view.getByTestId('market-token-chart-mode-simple'));
 
     expect(mockSetChartDisplayMode).toHaveBeenCalledWith({ mode: 'simple' });
+  });
+
+  it('allows returning to Simple mode when the Pro chart is unavailable', () => {
+    mockChartDisplayMode = 'pro';
+    const view = renderTokenDetailChart('bitcoin', null);
+
+    expect(view.queryByTestId('market-token-pro-chart')).toBeNull();
+    fireEvent.click(view.getByTestId('market-token-chart-mode-simple'));
+
+    expect(mockSetChartDisplayMode).toHaveBeenCalledWith({ mode: 'simple' });
+  });
+
+  it('renders only one mode switch when the Pro chart is available', () => {
+    mockChartDisplayMode = 'pro';
+    const view = renderTokenDetailChart('bitcoin');
+
+    expect(view.getAllByTestId('market-token-chart-mode-simple')).toHaveLength(
+      1,
+    );
   });
 
   it('localizes All and passes it to the simple chart', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.test.tsx
@@ -1,8 +1,10 @@
 /** @jest-environment jsdom */
 
-import type { ReactNode } from 'react';
+import { type ReactNode, useContext } from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
+
+import { TradingViewDesktopToolbarContext } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/TradingViewDesktopToolbarContext';
 
 import { TokenDetailChart } from './TokenDetailChart';
 
@@ -44,6 +46,7 @@ jest.mock('@onekeyhq/components', () => {
 
   return {
     Button,
+    ScrollView: Stack,
     Stack,
     XStack: Stack,
     YStack: Stack,
@@ -72,11 +75,16 @@ jest.mock('./MarketDetailProChartControls', () => ({
   ),
 }));
 
+function MockProChart() {
+  const toolbar = useContext(TradingViewDesktopToolbarContext);
+  return <div data-testid="market-token-pro-chart">{toolbar}</div>;
+}
+
 function renderTokenDetailChart(marketAssetId?: string) {
   return render(
     <TokenDetailChart
       marketAssetId={marketAssetId}
-      marketTradingView={<div data-testid="market-token-pro-chart" />}
+      marketTradingView={<MockProChart />}
       isChartFullscreen={false}
       chartMode="native"
       onChartSwitch={jest.fn()}

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
@@ -1,10 +1,17 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Button, Stack, XStack, YStack } from '@onekeyhq/components';
+import {
+  Button,
+  ScrollView,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import type { ITradingViewChartMode } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls';
+import { TradingViewDesktopToolbarContext } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/TradingViewDesktopToolbarContext';
 import {
   type IMarketDetailChartDisplayMode,
   useMarketDetailChartDisplayModePersistAtom,
@@ -33,7 +40,7 @@ function TokenChartModeControl({
   const intl = useIntl();
 
   return (
-    <XStack height={32} alignItems="center" gap="$0.5">
+    <XStack height={32} flexShrink={0} alignItems="center" gap="$0.5">
       <Button
         testID="market-token-chart-mode-simple"
         minWidth={62}
@@ -88,9 +95,39 @@ export function TokenDetailChart({
     useMarketDetailChartDisplayModePersistAtom();
   const [range, setRange] = useState<IStockSimpleChartRange>('1D');
   const isSimpleMode = mode === 'simple' && !isChartFullscreen;
-  const handleModeChange = (nextMode: IMarketDetailChartDisplayMode) => {
-    setChartDisplayMode({ mode: nextMode });
-  };
+  const handleModeChange = useCallback(
+    (nextMode: IMarketDetailChartDisplayMode) => {
+      setChartDisplayMode({ mode: nextMode });
+    },
+    [setChartDisplayMode],
+  );
+
+  const proToolbar = useMemo(
+    () =>
+      isChartFullscreen ? null : (
+        <MarketDetailProChartControls
+          inline
+          testID="market-token-chart-mode-control-pro"
+          top={MARKET_CHART_TOOLBAR_VERTICAL_INSET}
+          fullscreenTestID="trading-view-native-fullscreen-toggle"
+          chartMode={chartMode}
+          isChartSwitchDisabled={isChartSwitchDisabled}
+          onChartSwitch={onChartSwitch}
+          onEnterChartFullscreen={onEnterChartFullscreen}
+        >
+          <TokenChartModeControl mode={mode} onChange={handleModeChange} />
+        </MarketDetailProChartControls>
+      ),
+    [
+      isChartFullscreen,
+      chartMode,
+      isChartSwitchDisabled,
+      onChartSwitch,
+      onEnterChartFullscreen,
+      mode,
+      handleModeChange,
+    ],
+  );
 
   return (
     // Simple mode stacks a 40px toolbar, a 16px gap and the flexible chart
@@ -106,14 +143,22 @@ export function TokenDetailChart({
     >
       {isSimpleMode ? (
         <>
-          <XStack
+          <ScrollView
             testID="market-token-chart-toolbar"
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            width="100%"
             height={40}
-            py="$1"
-            alignItems="center"
-            justifyContent="space-between"
+            flexGrow={0}
+            flexShrink={0}
+            contentContainerStyle={{
+              flexGrow: 1,
+              py: '$1',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
           >
-            <XStack alignItems="center" gap="$0.5">
+            <XStack flexShrink={0} alignItems="center" gap="$0.5">
               {TOKEN_SIMPLE_CHART_RANGES.map((item) => {
                 const itemWidth = MARKET_SIMPLE_CHART_RANGE_WIDTHS[item];
                 return (
@@ -144,7 +189,7 @@ export function TokenDetailChart({
               })}
             </XStack>
             <TokenChartModeControl mode={mode} onChange={handleModeChange} />
-          </XStack>
+          </ScrollView>
           <StockSimpleChart
             marketAssetId={marketAssetId}
             range={range}
@@ -153,22 +198,11 @@ export function TokenDetailChart({
         </>
       ) : (
         <>
-          <Stack flex={1} minWidth={0} overflow="hidden">
-            {marketTradingView}
-          </Stack>
-          {isChartFullscreen ? null : (
-            <MarketDetailProChartControls
-              testID="market-token-chart-mode-control-pro"
-              top={MARKET_CHART_TOOLBAR_VERTICAL_INSET}
-              fullscreenTestID="trading-view-native-fullscreen-toggle"
-              chartMode={chartMode}
-              isChartSwitchDisabled={isChartSwitchDisabled}
-              onChartSwitch={onChartSwitch}
-              onEnterChartFullscreen={onEnterChartFullscreen}
-            >
-              <TokenChartModeControl mode={mode} onChange={handleModeChange} />
-            </MarketDetailProChartControls>
-          )}
+          <TradingViewDesktopToolbarContext.Provider value={proToolbar}>
+            <Stack flex={1} minWidth={0} overflow="hidden">
+              {marketTradingView}
+            </Stack>
+          </TradingViewDesktopToolbarContext.Provider>
         </>
       )}
     </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/components/TokenDetailChart.tsx
@@ -198,6 +198,26 @@ export function TokenDetailChart({
         </>
       ) : (
         <>
+          {(marketTradingView === null || marketTradingView === undefined) &&
+          proToolbar ? (
+            <ScrollView
+              testID="market-token-chart-fallback-toolbar"
+              horizontal
+              width="100%"
+              height={40}
+              flexGrow={0}
+              flexShrink={0}
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{
+                flexGrow: 1,
+                py: '$1',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+              }}
+            >
+              {proToolbar}
+            </ScrollView>
+          ) : null}
           <TradingViewDesktopToolbarContext.Provider value={proToolbar}>
             <Stack flex={1} minWidth={0} overflow="hidden">
               {marketTradingView}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-61560](https://onekeyhq.atlassian.net/browse/OK-61560)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Fix desktop Market chart toolbar options being clipped when space is limited and Pro mode controls overlapping the interval selector.

- Keep Simple mode intervals and mode buttons on a single horizontally scrollable row.
- Place Pro mode chart source, fullscreen, and mode controls in the same scrollable toolbar instead of an overlay.
- Preserve alignment when sufficient width is available.

## Validation

- Manual testing passed.
- All 6 component tests passed.
- Full commit checks passed before syncing remote changes. After syncing, the full type check reported errors in account/network selectors, including a missing dependency; no errors were reported in the changed toolbar files.

Issue: https://onekeyhq.atlassian.net/browse/OK-61560

[OK-61560]: https://onekeyhq.atlassian.net/browse/OK-61560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ