### PR TITLE
feat: report resource verification in firmware update results

### DIFF
--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.detect.test.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.detect.test.ts
@@ -2142,6 +2142,7 @@ describe('ServiceFirmwareUpdate workflow tracking', () => {
       workflowId,
       Object.assign(new Error('transfer failed'), {
         code: HardwareErrorCode.EmmcFileWriteFirmwareError,
+        payload: { params: { resourceVerification: 'failed' } },
       }),
     );
 
@@ -2159,9 +2160,57 @@ describe('ServiceFirmwareUpdate workflow tracking', () => {
         status: 'failed',
         failureType: 'transfer',
         errorCode: String(HardwareErrorCode.EmmcFileWriteFirmwareError),
+        resourceVerification: 'failed',
       }),
     );
   });
+
+  it.each([undefined, 'header-verified'] as const)(
+    'reports only the resource verification returned by the SDK (%s)',
+    async (resourceVerification) => {
+      jest
+        .mocked(firmwareUpdateWorkflowRunningAtom.get)
+        .mockResolvedValue(true);
+      jest.mocked(firmwareUpdateRetryAtom.get).mockResolvedValue(undefined);
+      const resultSpy = jest
+        .spyOn(defaultLogger.update.firmware, 'firmwareUpdateResult')
+        .mockImplementation((params) => params);
+      const service = new ServiceFirmwareUpdate({
+        backgroundApi: {} as IBackgroundApi,
+      });
+      const releaseResult = {
+        updateInfos: {},
+      } as ICheckAllFirmwareReleaseResult;
+      const workflowId = service.resetUpdateWorkflowTracking({
+        updateFlow: 'v2',
+        releaseResult,
+      });
+      service.recordUpdateWorkflowTransportType(
+        workflowId,
+        EHardwareTransportType.WEBUSB,
+      );
+      jest.spyOn(service, 'updateTasksResolve').mockResolvedValue(undefined);
+      service.updateTasks[1] = {
+        workflowId,
+        fn: jest
+          .fn()
+          .mockResolvedValue({ message: 'success', resourceVerification }),
+      };
+
+      await service.runUpdateTask({ id: 1 });
+      await service.completeUpdateWorkflow({
+        params: { backuped: true, usbConnected: true, releaseResult },
+      });
+
+      expect(resultSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'success', resourceVerification }),
+      );
+      service.resetUpdateWorkflowTracking({ updateFlow: 'v2', releaseResult });
+      expect(await service.getUpdateWorkflowTrackingInfo()).toEqual(
+        expect.objectContaining({ resourceVerification: undefined }),
+      );
+    },
+  );
 
   it('reports distinct transfer and total workflow durations', async () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);

--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
@@ -2045,6 +2045,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
         startedAt: number;
         retryCount: number;
         lastFailure: IOneKeyError | undefined;
+        resourceVerification?: 'header-verified' | 'failed';
       }
     | undefined;
 
@@ -2127,6 +2128,9 @@ class ServiceFirmwareUpdate extends ServiceBase {
       return false;
     }
     tracking.lastFailure = err;
+    if (get(err, 'payload.params.resourceVerification') === 'failed') {
+      tracking.resourceVerification = 'failed';
+    }
     return true;
   }
 
@@ -2151,6 +2155,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
       | ReturnType<typeof classifyFirmwareUpdateFailure>
       | undefined;
     lastErrorCode: string | undefined;
+    resourceVerification?: 'header-verified' | 'failed';
   }> {
     const tracking = this.updateWorkflowTracking;
     const now = Date.now();
@@ -2172,6 +2177,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
         ? classifyFirmwareUpdateFailure(tracking.lastFailure)
         : undefined,
       lastErrorCode: resolveFirmwareUpdateErrorCode(tracking?.lastFailure),
+      resourceVerification: tracking?.resourceVerification,
     };
   }
 
@@ -2540,6 +2546,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
         fromFirmwareType,
         toFirmwareType,
         status: 'success',
+        resourceVerification: trackingInfo.resourceVerification,
         retryCount: trackingInfo.retryCount,
         totalDurationMs: trackingInfo.totalDurationMs,
         transferredBytes: trackingInfo.transferredBytes,
@@ -2605,6 +2612,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
         fromFirmwareType: updateFirmwareInfo?.fromFirmwareType,
         toFirmwareType: updateFirmwareInfo?.toFirmwareType,
         status: 'failed',
+        resourceVerification: trackingInfo.resourceVerification,
         failureType: resultFailureType,
         errorCode:
           failureType === 'cancelled'
@@ -2951,6 +2959,13 @@ class ServiceFirmwareUpdate extends ServiceBase {
       const result = await task.fn({ id });
       if (!this.isUpdateWorkflowCurrent(task.workflowId)) {
         return;
+      }
+      if (
+        task.workflowId !== undefined &&
+        get(result, 'resourceVerification') === 'header-verified'
+      ) {
+        const tracking = this.getUpdateWorkflowTracking(task.workflowId);
+        if (tracking) tracking.resourceVerification = 'header-verified';
       }
       await this.updateTasksResolve({ id, data: result });
       serviceHardwareUtils.hardwareLog('runUpdateTask SUCCESS', result);

--- a/packages/shared/src/logger/scopes/update/scenes/firmware.ts
+++ b/packages/shared/src/logger/scopes/update/scenes/firmware.ts
@@ -83,6 +83,7 @@ export class FirmwareScene extends BaseScene {
     fromFirmwareType: EFirmwareType | undefined;
     toFirmwareType: EFirmwareType | undefined;
     status: 'success' | 'failed';
+    resourceVerification?: 'header-verified' | 'failed';
     failureType?: IFirmwareUpdateFailureType;
     errorCode?: string;
     retryCount?: number;


### PR DESCRIPTION
The existing firmware update result cannot distinguish overall update success from resource verification. Forward the SDK's optional `resourceVerification` into the existing `firmwareUpdateResult` local log and Mixpanel event.

- `header-verified`: the requested resource package headers matched the target packages in loader mode.
- `failed`: the SDK reported a resource write/read-back failure, including when the user leaves the retry screen.
- Absent: no resource verification result, for example when no resources were requested.

The result belongs to the current workflow and is cleared on a new workflow. This adds no per-file events or dependency upgrades. Merge and release together with the companion SDK change. Header verification does not attest full payload read-back or runtime resource mounting.

Companion SDK verification: https://github.com/OneKeyHQ/hardware-js-sdk/pull/927

Validation: 77 ServiceFirmwareUpdate detection/workflow tests passed; `yarn agent:check --profile commit` and local checks in `--profile pr` passed, including TypeScript. No physical-device run.
