### PR TITLE
fix: restore iOS device DevVendor development

### DIFF
--- a/.skillshare/skills/1k-dev-commands/references/mobile-dev-shell.md
+++ b/.skillshare/skills/1k-dev-commands/references/mobile-dev-shell.md
@@ -27,7 +27,18 @@ For iOS, the launcher reuses the sole booted simulator, or selects the sole
 available simulator when none are booted. Otherwise, an interactive terminal
 shows a numbered list with device names, runtime versions, states, and UDIDs.
 The selected simulator is booted if needed and awaited before app installation.
-An explicit `--device <UDID>` can also select a shutdown simulator.
+An explicit `--device <UDID>` can also select a shutdown simulator. When the
+explicit UDID belongs to a connected physical device, the command prepares the
+iOS DevVendor artifacts and delegates to a local signed Xcode Debug build. The
+physical-device path embeds the common HBC and manifest in the app instead of
+using a private Simulator DevSession. It owns an available Metro port, builds the
+signed app without letting Expo start another packager, installs it, and launches
+the device process with that exact port. This keeps physical-device development
+isolated when another worktree already owns port 8081. Use `--metro-port <port>`
+to request a specific free port; `--metro-url` remains limited to private
+DevSession launches. The physical-device path emits the same
+`[ONEKEY_RUN_SUMMARY] status=running` and `[ONEKEY_RUN_REPORT]` readiness signals
+as Simulator and Android launches.
 
 In non-interactive sessions with multiple candidates, do not guess. Resolve the
 requested UDID or serial and rerun with `--device <serial-or-UDID>`. The error

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -374,6 +374,34 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 #if DEBUG
   private lazy var devVendorBundleInfo = resolveDevVendorBundleInfo()
 
+  private func runtimeMetroPort() -> Int? {
+    guard
+      let value = ProcessInfo.processInfo.environment["RCT_METRO_PORT"],
+      let port = Int(value),
+      (1 ... 65_535).contains(port)
+    else {
+      return nil
+    }
+    return port
+  }
+
+  private func runtimeMetroBaseURL() -> URL? {
+    guard
+      let port = runtimeMetroPort(),
+      let ipPath = Bundle.main.path(forResource: "ip", ofType: "txt"),
+      let host = try? String(contentsOfFile: ipPath, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+      !host.isEmpty
+    else {
+      return nil
+    }
+    var components = URLComponents()
+    components.scheme = "http"
+    components.host = host
+    components.port = port
+    return components.url.flatMap { validatedMetroBaseURL($0.absoluteString) }
+  }
+
   private func explicitDevBackgroundHMRValue() -> Bool? {
     if let envValue = ProcessInfo.processInfo.environment["ONEKEY_DEV_BG_HMR"] {
       return ["1", "true", "yes", "on"].contains(
@@ -392,7 +420,14 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   }
 
   private func isDevBackgroundHMREnabled(fingerprint _: String) -> Bool {
-    return explicitDevBackgroundHMRValue() ?? false
+    if let explicitValue = explicitDevBackgroundHMRValue() {
+      return explicitValue
+    }
+#if targetEnvironment(simulator)
+    return false
+#else
+    return true
+#endif
   }
 
   private func resolveDevVendorBundleInfo() -> DevVendorBundleInfo? {
@@ -554,10 +589,19 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
     guard let commonURL, let manifestURL else {
       fatalError("Dev-vendor common HBC and manifest must be embedded together")
     }
+    let runtimeMetroURL = runtimeMetroBaseURL()
+    if
+      let runtimeMetroURL,
+      let host = runtimeMetroURL.host,
+      let port = runtimeMetroURL.port
+    {
+      RCTBundleURLProvider.sharedSettings().jsLocation = "\(host):\(port)"
+    }
     guard
-      let packagerURL = RCTBundleURLProvider.sharedSettings().jsBundleURL(
-        forBundleRoot: ".expo/.virtual-metro-entry"
-      ),
+      let packagerURL = runtimeMetroURL ??
+        RCTBundleURLProvider.sharedSettings().jsBundleURL(
+          forBundleRoot: ".expo/.virtual-metro-entry"
+        ),
       var baseComponents = URLComponents(url: packagerURL, resolvingAgainstBaseURL: false)
     else {
       // Without a reachable packager the plain Metro path fails the same way
@@ -571,6 +615,11 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
     baseComponents.path = ""
     baseComponents.query = nil
     baseComponents.fragment = nil
+    // The physical-device launcher owns Metro and injects its allocated port
+    // into the app process. Expo's Xcode build does not propagate --port.
+    if let port = runtimeMetroPort() {
+      baseComponents.port = port
+    }
     guard
       let metroBaseURLValue = baseComponents.url?.absoluteString,
       let metroBaseURL = validatedMetroBaseURL(metroBaseURLValue)
@@ -832,8 +881,16 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   }
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
-    // needed to return the correct URL for expo-dev-client.
-    bridge.bundleURL ?? bundleURL()
+#if DEBUG
+    // A reload may preserve Expo's full Metro URL on the bridge. Embedded
+    // DevVendor builds must always restart from common.hbc so the host can
+    // attach only the main/background deltas again.
+    if devVendorBundleInfo != nil {
+      return bundleURL()
+    }
+#endif
+    // Needed to return the correct URL for expo-dev-client.
+    return bridge.bundleURL ?? bundleURL()
   }
 
   override func bundleURL() -> URL? {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,6 +38,7 @@
     "dev-vendor:build": "node --expose-gc --max-old-space-size=8192 scripts/build-dev-vendor.js",
     "dev-vendor:check": "node scripts/build-dev-vendor.js --check",
     "dev-vendor:prepare": "node --expose-gc --max-old-space-size=8192 scripts/build-dev-vendor.js --prepare --platform all",
+    "dev-vendor:prepare:ios": "node --expose-gc --max-old-space-size=8192 scripts/build-dev-vendor.js --prepare --platform ios",
     "dev-vendor:registry:update": "node --expose-gc --max-old-space-size=8192 scripts/build-dev-vendor.js --update-registry --platform all",
     "metro-dev-prebundle:tag": "node scripts/metro-dev-prebundle.js tag",
     "metro-dev-prebundle:package": "node scripts/metro-dev-prebundle.js package",

--- a/apps/mobile/scripts/__tests__/native-dev-shell-devices.test.js
+++ b/apps/mobile/scripts/__tests__/native-dev-shell-devices.test.js
@@ -1,10 +1,17 @@
 /* eslint-disable onekey/no-raw-error */
+/* cspell:words devicectl */
 
 const { PassThrough } = require('stream');
 
 const {
+  getIosPhysicalAppProcessIds,
+  isAvailableIosPhysicalDevice,
+  launchIosPhysicalApp,
+  launchIosPhysicalDeviceDevelopment,
   promptIosSimulator,
+  resolveIosPhysicalBuildArtifact,
   resolveTargetDevice,
+  waitForIosPhysicalAppStartup,
 } = require('../native-dev-shell');
 
 function createSimulator(id, state = 'Shutdown') {
@@ -15,6 +22,7 @@ function createResolution(devices, overrides = {}) {
   const options = {
     chooseDevice: jest.fn(async (candidates) => candidates[1]),
     interactive: true,
+    isIosPhysicalDeviceAvailable: jest.fn(() => false),
     platform: 'ios',
     runCheckedCommand: jest.fn(),
     runForOutputCommand: jest.fn(() =>
@@ -90,6 +98,23 @@ describe('iOS simulator selection', () => {
     expect(options.chooseDevice).not.toHaveBeenCalled();
   });
 
+  it('routes an explicit physical device without running Simulator commands', async () => {
+    const options = createResolution([createSimulator('A')], {
+      isIosPhysicalDeviceAvailable: jest.fn(() => true),
+      requestedDevice: 'PHYSICAL-DEVICE',
+    });
+
+    await expect(resolveTargetDevice(options)).resolves.toEqual({
+      id: 'PHYSICAL-DEVICE',
+      name: 'PHYSICAL-DEVICE',
+      physical: true,
+    });
+    expect(options.isIosPhysicalDeviceAvailable).toHaveBeenCalledWith(
+      'PHYSICAL-DEVICE',
+    );
+    expect(options.runCheckedCommand).not.toHaveBeenCalled();
+  });
+
   it('lists shutdown devices and an explicit command in a non-interactive terminal', async () => {
     const options = createResolution(
       [createSimulator('A'), createSimulator('B')],
@@ -121,7 +146,353 @@ describe('iOS simulator selection', () => {
     await expect(resolveTargetDevice(options)).rejects.toThrow(
       'Device missing is not available',
     );
+    expect(options.isIosPhysicalDeviceAvailable).toHaveBeenCalledWith(
+      'missing',
+    );
     expect(options.runCheckedCommand).not.toHaveBeenCalled();
+  });
+
+  it('recognizes iOS physical devices through CoreDevice', () => {
+    const runForOutputCommand = jest.fn(() => '');
+
+    expect(
+      isAvailableIosPhysicalDevice('PHYSICAL-DEVICE', {
+        runForOutputCommand,
+      }),
+    ).toBe(true);
+    expect(runForOutputCommand).toHaveBeenCalledWith('xcrun', [
+      'devicectl',
+      'device',
+      'info',
+      'details',
+      '--device',
+      'PHYSICAL-DEVICE',
+      '--timeout',
+      '5',
+      '--quiet',
+    ]);
+
+    expect(
+      isAvailableIosPhysicalDevice('MISSING', {
+        runForOutputCommand: () => {
+          throw new Error('not found');
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('owns the physical-device Metro, build, install, launch, and run report', async () => {
+    const releaseDeviceLock = jest.fn();
+    const releaseMetroLock = jest.fn();
+    const releasePreparationLock = jest.fn();
+    const child = new PassThrough();
+    child.exitCode = null;
+    child.signalCode = null;
+    child.kill = jest.fn();
+    const runCheckedCommand = jest.fn();
+    const spawnMetroCommand = jest.fn(() => child);
+    const writeRunReportCommand = jest.fn(async () => {});
+    const printRunSummaryCommand = jest.fn();
+    const prewarmCommand = jest.fn(async () => {});
+    const launchAppCommand = jest.fn(() => ({ processId: 42 }));
+
+    await expect(
+      launchIosPhysicalDeviceDevelopment({
+        acquireMetroPortCommand: jest.fn(async () => ({
+          lock: { release: releaseMetroLock },
+          port: 8082,
+        })),
+        acquireNamedLockCommand: jest.fn(() => ({
+          release: releaseDeviceLock,
+        })),
+        acquirePreparationLockCommand: jest.fn(async () => ({
+          release: releasePreparationLock,
+        })),
+        deviceId: 'PHYSICAL-DEVICE',
+        launchAppCommand,
+        loadVendorManifestCommand: jest.fn(() => ({
+          fingerprint: 'a'.repeat(64),
+        })),
+        prepareVendorCommand: jest.fn(async ({ report }) => {
+          report.vendor = {
+            requested: 'auto',
+            source: 'local-cache',
+            status: 'ready',
+          };
+        }),
+        prewarmCommand,
+        printRunSummaryCommand,
+        resolveBuildArtifactCommand: jest.fn(() => '/tmp/OneKeyWallet.app'),
+        runCheckedCommand,
+        shell: 'auto',
+        spawnMetroCommand,
+        vendor: 'auto',
+        waitForAppStartupCommand: jest.fn(async () => {
+          child.exitCode = 0;
+          child.emit('exit', 0, null);
+        }),
+        waitForMetroCommand: jest.fn(async () => {}),
+        writeRunReportCommand,
+      }),
+    ).resolves.toBeUndefined();
+    expect(spawnMetroCommand).toHaveBeenCalledWith(
+      'yarn',
+      [
+        'workspace',
+        '@onekeyhq/mobile',
+        'native-bundle',
+        '--port',
+        '8082',
+        '--host',
+        '0.0.0.0',
+      ],
+      expect.objectContaining({
+        cwd: expect.any(String),
+        env: expect.objectContaining({
+          ONEKEY_DEV_BG_HMR: 'true',
+          ONEKEY_DEV_VENDOR: 'true',
+        }),
+        stdio: 'inherit',
+      }),
+    );
+    expect(runCheckedCommand).toHaveBeenCalledWith(
+      'xcodebuild',
+      expect.arrayContaining([
+        '-workspace',
+        'OneKeyWallet.xcworkspace',
+        '-configuration',
+        'Debug',
+        '-destination',
+        'id=PHYSICAL-DEVICE',
+        '-quiet',
+      ]),
+      expect.objectContaining({
+        cwd: expect.stringMatching(/apps\/mobile\/ios$/u),
+        env: expect.objectContaining({
+          ONEKEY_DEV_BG_HMR: 'true',
+          ONEKEY_DEV_VENDOR: 'true',
+          RCT_NO_LAUNCH_PACKAGER: 'true',
+        }),
+      }),
+    );
+    expect(runCheckedCommand).toHaveBeenCalledWith('xcrun', [
+      'devicectl',
+      'device',
+      'install',
+      'app',
+      '--device',
+      'PHYSICAL-DEVICE',
+      '--quiet',
+      '/tmp/OneKeyWallet.app',
+    ]);
+    expect(prewarmCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backgroundHMR: true,
+        embedded: true,
+        metroPort: 8082,
+      }),
+    );
+    expect(writeRunReportCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'finished' }),
+    );
+    expect(printRunSummaryCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'finished' }),
+    );
+    expect(releasePreparationLock).toHaveBeenCalledTimes(1);
+    expect(releasePreparationLock.mock.invocationCallOrder[0]).toBeGreaterThan(
+      runCheckedCommand.mock.invocationCallOrder[
+        runCheckedCommand.mock.invocationCallOrder.length - 1
+      ],
+    );
+    expect(releasePreparationLock.mock.invocationCallOrder[0]).toBeLessThan(
+      launchAppCommand.mock.invocationCallOrder[0],
+    );
+    expect(releaseMetroLock).toHaveBeenCalledTimes(1);
+    expect(releaseDeviceLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases physical-device locks when installation fails', async () => {
+    const releaseDeviceLock = jest.fn();
+    const releaseMetroLock = jest.fn();
+    const releasePreparationLock = jest.fn();
+    const child = new PassThrough();
+    child.exitCode = null;
+    child.signalCode = null;
+    child.kill = jest.fn();
+
+    await expect(
+      launchIosPhysicalDeviceDevelopment({
+        acquireMetroPortCommand: jest.fn(async () => ({
+          lock: { release: releaseMetroLock },
+          port: 8082,
+        })),
+        acquireNamedLockCommand: jest.fn(() => ({
+          release: releaseDeviceLock,
+        })),
+        acquirePreparationLockCommand: jest.fn(async () => ({
+          release: releasePreparationLock,
+        })),
+        deviceId: 'PHYSICAL-DEVICE',
+        loadVendorManifestCommand: jest.fn(() => ({
+          fingerprint: 'a'.repeat(64),
+        })),
+        prepareVendorCommand: jest.fn(async () => {}),
+        prewarmCommand: jest.fn(async () => {}),
+        printRunSummaryCommand: jest.fn(),
+        resolveBuildArtifactCommand: jest.fn(() => '/tmp/OneKeyWallet.app'),
+        runCheckedCommand: jest.fn((command, args) => {
+          if (command === 'xcrun' && args.includes('install')) {
+            throw new Error('install failed');
+          }
+        }),
+        shell: 'auto',
+        spawnMetroCommand: jest.fn(() => child),
+        vendor: 'auto',
+        waitForMetroCommand: jest.fn(async () => {}),
+        writeRunReportCommand: jest.fn(async () => {}),
+      }),
+    ).rejects.toThrow('install failed');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(releasePreparationLock).toHaveBeenCalledTimes(1);
+    expect(releaseMetroLock).toHaveBeenCalledTimes(1);
+    expect(releaseDeviceLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('injects the allocated Metro port when launching the physical app', () => {
+    const runDevicectlJsonCommand = jest.fn((createArgs) => {
+      expect(createArgs('/tmp/result.json')).toEqual([
+        'device',
+        'process',
+        'launch',
+        '--device',
+        'PHYSICAL-DEVICE',
+        '--terminate-existing',
+        '--environment-variables',
+        '{"RCT_METRO_PORT":"8082"}',
+        '--json-output',
+        '/tmp/result.json',
+        '--quiet',
+        'so.onekey.wallet',
+      ]);
+      return { result: { process: { processIdentifier: 42 } } };
+    });
+
+    expect(
+      launchIosPhysicalApp('PHYSICAL-DEVICE', 8082, {
+        runDevicectlJsonCommand,
+      }),
+    ).toEqual({ processId: 42 });
+  });
+
+  it('requires the launched physical app process to survive startup', async () => {
+    const wait = jest.fn(async () => {});
+    const readProcessIds = jest.fn(() => [42]);
+
+    await expect(
+      waitForIosPhysicalAppStartup({
+        deviceId: 'PHYSICAL-DEVICE',
+        pollIntervalMs: 1000,
+        processId: 42,
+        readProcessIds,
+        startupGraceMs: 2000,
+        wait,
+      }),
+    ).resolves.toBeUndefined();
+    expect(readProcessIds).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledTimes(2);
+  });
+
+  it('reads physical app processes from devicectl JSON', () => {
+    const runDevicectlJsonCommand = jest.fn((createArgs) => {
+      expect(createArgs('/tmp/result.json')).not.toContain('--filter');
+      return {
+        result: {
+          runningProcesses: [
+            {
+              executable:
+                'file:///private/var/containers/Bundle/Application/ID/OneKeyWallet.app/OneKeyWallet',
+              processIdentifier: 42,
+            },
+            {
+              executable: 'file:///usr/libexec/unrelated',
+              processIdentifier: 7,
+            },
+            {
+              executable:
+                'file:///private/var/containers/Bundle/Application/ID/OneKeyWallet.app/OneKeyWallet',
+              processIdentifier: 'invalid',
+            },
+          ],
+        },
+      };
+    });
+
+    expect(
+      getIosPhysicalAppProcessIds('PHYSICAL-DEVICE', {
+        runDevicectlJsonCommand,
+      }),
+    ).toEqual([42]);
+  });
+
+  it('resolves the physical iOS app from Xcode build settings', () => {
+    const runForOutputCommand = jest.fn(() =>
+      JSON.stringify([
+        {
+          buildSettings: {
+            TARGET_BUILD_DIR: '/tmp/Debug-iphoneos',
+            WRAPPER_NAME: 'OneKeyWallet.app',
+          },
+          target: 'OneKeyWallet',
+        },
+      ]),
+    );
+    expect(
+      resolveIosPhysicalBuildArtifact('PHYSICAL-DEVICE', {
+        fileSystem: { existsSync: () => true },
+        runForOutputCommand,
+      }),
+    ).toBe('/tmp/Debug-iphoneos/OneKeyWallet.app');
+    expect(runForOutputCommand).toHaveBeenCalledWith(
+      'xcodebuild',
+      expect.arrayContaining([
+        '-destination',
+        'id=PHYSICAL-DEVICE',
+        '-showBuildSettings',
+        '-json',
+      ]),
+      expect.objectContaining({
+        cwd: expect.stringMatching(/apps\/mobile\/ios$/u),
+      }),
+    );
+  });
+
+  it('rejects DevSession-only overrides for physical devices', async () => {
+    await expect(
+      launchIosPhysicalDeviceDevelopment({
+        deviceId: 'PHYSICAL-DEVICE',
+        metroUrl: 'http://192.168.1.2:8081',
+        shell: 'auto',
+        spawnCommand: jest.fn(),
+        vendor: 'auto',
+      }),
+    ).rejects.toThrow(
+      'does not support DevSession shell, vendor, or --metro-url overrides',
+    );
+  });
+
+  it('keeps the physical-device command on the prepared DevVendor path', () => {
+    const rootPackage = require('../../../../package.json');
+    const mobilePackage = require('../../package.json');
+
+    expect(rootPackage.scripts['app:ios:device']).toContain(
+      'dev-vendor:prepare:ios',
+    );
+    expect(rootPackage.scripts['app:ios:device']).toContain(
+      'ONEKEY_DEV_VENDOR=true ONEKEY_DEV_BG_HMR=true',
+    );
+    expect(mobilePackage.scripts['dev-vendor:prepare:ios']).toContain(
+      '--prepare --platform ios',
+    );
   });
 
   it('propagates simulator service failures instead of reporting an empty list', async () => {

--- a/apps/mobile/scripts/__tests__/native-dev-shell.test.js
+++ b/apps/mobile/scripts/__tests__/native-dev-shell.test.js
@@ -1,6 +1,7 @@
 const { spawnSync } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
+const net = require('net');
 const os = require('os');
 const path = require('path');
 
@@ -509,6 +510,23 @@ describe('native-dev-shell', () => {
     expect(url.searchParams.get('unstable_transformProfile')).toBe(
       'hermes-stable',
     );
+  });
+
+  it('prewarms an embedded physical-device runtime without a DevSession ID', () => {
+    const url = getNativeRuntimeBundleUrl({
+      backgroundHMR: true,
+      embedded: true,
+      fingerprint: 'a'.repeat(64),
+      metroPort: 8082,
+      platform: 'ios',
+      runtimeTarget: 'background',
+    });
+
+    expect(url.searchParams.get('resolver.devVendorEmbedded')).toBe('true');
+    expect(url.searchParams.get('resolver.devVendorBackgroundHMR')).toBe(
+      'true',
+    );
+    expect(url.searchParams.has('resolver.devSessionId')).toBe(false);
   });
 
   it('selects a Java 17 JDK for Android local shell builds', () => {
@@ -1639,6 +1657,25 @@ describe('native-dev-shell', () => {
     }
   });
 
+  it('does not allocate a port already bound on localhost', async () => {
+    const server = net.createServer();
+    await new Promise((resolve) => {
+      server.listen({ host: '127.0.0.1', port: 0 }, resolve);
+    });
+    try {
+      const address = server.address();
+      await expect(
+        acquireMetroPort({
+          deviceId: 'device-localhost-port',
+          requestedPort: String(address.port),
+          sessionId: 'session-localhost-port',
+        }),
+      ).rejects.toThrow('already in use');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
   it('serializes shared worktree preparation across device sessions', async () => {
     const consoleError = jest
       .spyOn(console, 'error')
@@ -1898,18 +1935,18 @@ describe('native-dev-shell', () => {
       "['workspace', '@onekeyhq/web-embed', 'prebundle:build']",
     );
     expect(nativeDevShell).not.toContain("['app:web-embed:build']");
-    expect(nativeDevShell.indexOf('await stagePrivateSession({')).toBeLessThan(
-      nativeDevShell.indexOf('preparationLock.release();'),
-    );
-    expect(nativeDevShell.indexOf('await waitForMetro(')).toBeLessThan(
-      nativeDevShell.indexOf('preparationLock.release();'),
-    );
-    expect(nativeDevShell.indexOf('preparationLock.release();')).toBeLessThan(
-      nativeDevShell.indexOf('await prewarmNativeRuntimeBundles({'),
-    );
     const launchSource = nativeDevShell.slice(
       nativeDevShell.indexOf('async function launchDevShell('),
       nativeDevShell.indexOf('\nasync function main()'),
+    );
+    expect(launchSource.indexOf('await stagePrivateSession({')).toBeLessThan(
+      launchSource.indexOf('preparationLock.release();'),
+    );
+    expect(launchSource.indexOf('await waitForMetro(')).toBeLessThan(
+      launchSource.indexOf('preparationLock.release();'),
+    );
+    expect(launchSource.indexOf('preparationLock.release();')).toBeLessThan(
+      launchSource.indexOf('await prewarmNativeRuntimeBundles({'),
     );
     expect(
       launchSource.indexOf('await prepareWebEmbedForDevSession(report)'),
@@ -2004,6 +2041,28 @@ describe('native-dev-shell', () => {
     expect(iosSource).toContain(
       'private lazy var devVendorBundleInfo = resolveDevVendorBundleInfo()',
     );
+    expect(iosProductionSource).toContain(
+      'if devVendorBundleInfo != nil {\n      return bundleURL()',
+    );
+    expect(iosProductionSource).toContain(
+      '#if targetEnvironment(simulator)\n    return false\n#else\n    return true',
+    );
+    expect(iosProductionSource).toContain(
+      'ProcessInfo.processInfo.environment["RCT_METRO_PORT"]',
+    );
+    expect(iosProductionSource).toContain(
+      'Bundle.main.path(forResource: "ip", ofType: "txt")',
+    );
+    expect(iosProductionSource).toContain(
+      'let runtimeMetroURL = runtimeMetroBaseURL()',
+    );
+    expect(iosProductionSource).toContain(
+      'RCTBundleURLProvider.sharedSettings().jsLocation = "\\(host):\\(port)"',
+    );
+    expect(iosProductionSource).toContain(
+      'let packagerURL = runtimeMetroURL ??',
+    );
+    expect(iosProductionSource).toContain('baseComponents.port = port');
     expect(iosSource).toContain('runtimeTarget: "main"');
     expect(iosSource).toContain('runtimeTarget: "background"');
   });

--- a/apps/mobile/scripts/native-dev-shell.js
+++ b/apps/mobile/scripts/native-dev-shell.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable onekey/no-raw-error */
-/* cspell:words POSTBUILD SIMCTL */
+/* cspell:words devicectl POSTBUILD SIMCTL */
 
 const { spawn, spawnSync } = require('child_process');
 const crypto = require('crypto');
@@ -42,6 +42,7 @@ const SESSION_RENEW_RETRY_INTERVAL_MS = 30_000;
 const SESSION_RENEW_FATAL_WINDOW_MS = 5 * 60 * 1000;
 const ANDROID_APP_STARTUP_TIMEOUT_MS = 10_000;
 const ANDROID_APP_STARTUP_POLL_INTERVAL_MS = 500;
+const IOS_PHYSICAL_APP_STARTUP_POLL_INTERVAL_MS = 1000;
 const NATIVE_APP_STARTUP_GRACE_MS = 1500;
 const IOS_APP_STARTUP_GRACE_MS = 15_000;
 const NATIVE_RUNTIME_PREWARM_TIMEOUT_MS = 10 * 60 * 1000;
@@ -109,6 +110,8 @@ function parseMetroBaseUrl(value) {
 }
 
 function getNativeRuntimeBundleUrl({
+  backgroundHMR = false,
+  embedded = false,
   fingerprint,
   metroPort,
   platform,
@@ -127,6 +130,11 @@ function getNativeRuntimeBundleUrl({
       ? `http://127.0.0.1:${String(metroPort)}/background.bundle`
       : `http://127.0.0.1:${String(metroPort)}/.expo/.virtual-metro-entry.bundle`,
   );
+  if (embedded && sessionId) {
+    throw new Error(
+      '[nativeDevShell] Embedded runtime prewarm cannot use a DevSession ID.',
+    );
+  }
   const values = {
     platform: targetPlatform,
     dev: 'true',
@@ -138,10 +146,14 @@ function getNativeRuntimeBundleUrl({
     'resolver.devVendor': 'true',
     'resolver.devVendorNative': 'true',
     'resolver.devVendorFingerprint': fingerprint,
-    'resolver.devSessionId': sessionId,
     'resolver.runtimeTarget': runtimeTarget,
     unstable_transformProfile: 'hermes-stable',
   };
+  if (sessionId) values['resolver.devSessionId'] = sessionId;
+  if (embedded) values['resolver.devVendorEmbedded'] = 'true';
+  if (backgroundHMR && runtimeTarget === 'background') {
+    values['resolver.devVendorBackgroundHMR'] = 'true';
+  }
   for (const [name, value] of Object.entries(values)) {
     url.searchParams.set(name, value);
   }
@@ -149,6 +161,8 @@ function getNativeRuntimeBundleUrl({
 }
 
 async function prewarmNativeRuntimeBundles({
+  backgroundHMR,
+  embedded,
   fetchImpl = globalThis.fetch,
   fingerprint,
   metroPort,
@@ -158,6 +172,8 @@ async function prewarmNativeRuntimeBundles({
 }) {
   for (const runtimeTarget of ['main', 'background']) {
     const url = getNativeRuntimeBundleUrl({
+      backgroundHMR,
+      embedded,
       fingerprint,
       metroPort,
       platform,
@@ -1058,6 +1074,28 @@ function parseIosSimulators(output) {
     );
 }
 
+function isAvailableIosPhysicalDevice(
+  deviceId,
+  { runForOutputCommand = runForOutput } = {},
+) {
+  try {
+    runForOutputCommand('xcrun', [
+      'devicectl',
+      'device',
+      'info',
+      'details',
+      '--device',
+      deviceId,
+      '--timeout',
+      '5',
+      '--quiet',
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function selectTargetDevice({ candidates, platform, requestedDevice }) {
   if (requestedDevice) {
     const selected = candidates.find(({ id }) => id === requestedDevice);
@@ -1129,6 +1167,7 @@ async function resolveTargetDevice({
   platform,
   requestedDevice,
   interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+  isIosPhysicalDeviceAvailable = isAvailableIosPhysicalDevice,
   chooseDevice = promptIosSimulator,
   runForOutputCommand = runForOutput,
   runCheckedCommand = runChecked,
@@ -1146,6 +1185,18 @@ async function resolveTargetDevice({
           ]),
         );
   let selected;
+  if (
+    platform === 'ios' &&
+    requestedDevice &&
+    !candidates.some(({ id }) => id === requestedDevice) &&
+    isIosPhysicalDeviceAvailable(requestedDevice)
+  ) {
+    selected = {
+      id: requestedDevice,
+      name: requestedDevice,
+      physical: true,
+    };
+  }
   if (platform === 'ios' && !requestedDevice) {
     const booted = candidates.filter(({ state }) => state === 'Booted');
     if (booted.length === 1) {
@@ -1155,7 +1206,7 @@ async function resolveTargetDevice({
     }
   }
   selected ??= selectTargetDevice({ candidates, platform, requestedDevice });
-  if (platform === 'ios') {
+  if (platform === 'ios' && !selected.physical) {
     // Wait for the selected simulator to finish booting, starting it if necessary.
     runCheckedCommand('xcrun', ['simctl', 'bootstatus', selected.id, '-b']);
     runCheckedCommand('open', [
@@ -1167,6 +1218,218 @@ async function resolveTargetDevice({
     ]);
   }
   return selected;
+}
+
+async function launchIosPhysicalDeviceDevelopment({
+  acquireMetroPortCommand = acquireMetroPort,
+  acquireNamedLockCommand = acquireNamedLock,
+  acquirePreparationLockCommand = acquireWorktreePreparationLock,
+  deviceId,
+  launchAppCommand = launchIosPhysicalApp,
+  loadVendorManifestCommand = loadVendorManifest,
+  metroPort,
+  metroUrl,
+  prepareVendorCommand = prepareVendor,
+  prewarmCommand = prewarmNativeRuntimeBundles,
+  printRunSummaryCommand = printRunSummary,
+  resolveBuildArtifactCommand = resolveIosPhysicalBuildArtifact,
+  runCheckedCommand = runChecked,
+  shell,
+  spawnMetroCommand = spawn,
+  vendor,
+  waitForAppStartupCommand = waitForIosPhysicalAppStartup,
+  waitForMetroCommand = waitForMetro,
+  writeRunReportCommand = writeRunReport,
+}) {
+  if (metroUrl || shell !== 'auto' || vendor !== 'auto') {
+    throw new Error(
+      '[nativeDevShell] iOS physical-device development does not support DevSession shell, vendor, or --metro-url overrides.',
+    );
+  }
+  const sessionId = createSessionId({ deviceId });
+  const deviceLock = acquireNamedLockCommand({
+    key: `ios\0${deviceId}\0${IOS_BUNDLE_ID}`,
+    kind: 'device',
+    owner: {
+      deviceId,
+      pid: process.pid,
+      sessionId,
+      worktreeId: WORKTREE_ID,
+    },
+  });
+  let child;
+  let metroLock;
+  let preparationLock;
+  let report;
+  try {
+    const metroAllocation = await acquireMetroPortCommand({
+      deviceId,
+      requestedPort: metroPort,
+      sessionId,
+    });
+    metroLock = metroAllocation.lock;
+    const resolvedMetroPort = metroAllocation.port;
+    const deviceMetroUrl = getDefaultMetroUrl('ios', resolvedMetroPort);
+    report = createRunReport({
+      deviceId,
+      metroPort: resolvedMetroPort,
+      metroUrl: deviceMetroUrl,
+      platform: 'ios',
+      sessionId,
+      shell,
+      vendor,
+    });
+    report.shell = {
+      requested: shell,
+      source: 'local-build',
+      status: 'building',
+    };
+    await writeRunReportCommand(report);
+    preparationLock = await acquirePreparationLockCommand({ report });
+    runCheckedCommand('yarn', ['copy:inject'], {
+      cwd: REPO_ROOT,
+      env: process.env,
+    });
+    await prepareVendorCommand({
+      platform: 'ios',
+      report,
+      vendor,
+    });
+    const vendorManifest = loadVendorManifestCommand('ios');
+    console.log(
+      `[nativeDevShell] Using launcher-owned Metro port ${resolvedMetroPort} with a local Xcode Debug build and embedded DevVendor artifacts for iOS physical device ${deviceId}.`,
+    );
+    child = spawnMetroCommand(
+      'yarn',
+      [
+        'workspace',
+        '@onekeyhq/mobile',
+        'native-bundle',
+        '--port',
+        String(resolvedMetroPort),
+        '--host',
+        '0.0.0.0',
+      ],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          ONEKEY_DEV_BG_HMR: 'true',
+          ONEKEY_DEV_VENDOR: 'true',
+        },
+        stdio: 'inherit',
+      },
+    );
+    let metroSpawnError;
+    let metroExit;
+    child.once('error', (error) => {
+      metroSpawnError = error;
+    });
+    const metroCompletion = new Promise((resolve) => {
+      child.once('exit', (code, signal) => {
+        metroExit = { code, signal };
+        resolve(metroExit);
+      });
+    });
+    await waitForMetroCommand(resolvedMetroPort, child, () => metroSpawnError);
+    await prewarmCommand({
+      backgroundHMR: true,
+      embedded: true,
+      fingerprint: vendorManifest.fingerprint,
+      metroPort: resolvedMetroPort,
+      platform: 'ios',
+    });
+    const iosDirectory = path.join(MOBILE_ROOT, 'ios');
+    runCheckedCommand(
+      'xcodebuild',
+      [
+        '-workspace',
+        'OneKeyWallet.xcworkspace',
+        '-configuration',
+        'Debug',
+        '-scheme',
+        'OneKeyWallet',
+        '-destination',
+        `id=${deviceId}`,
+        '-quiet',
+        'COCOAPODS_PARALLEL_CODE_SIGN=true',
+        'COMPILER_INDEX_STORE_ENABLE=NO',
+        '-allowProvisioningUpdates',
+        '-allowProvisioningDeviceRegistration',
+      ],
+      {
+        cwd: iosDirectory,
+        env: {
+          ...process.env,
+          ENABLE_NATIVE_BACKGROUND_THREAD: 'true',
+          ONEKEY_DEV_BG_HMR: 'true',
+          ONEKEY_DEV_VENDOR: 'true',
+          RCT_NO_LAUNCH_PACKAGER: 'true',
+          SENTRY_DISABLE_AUTO_UPLOAD: 'true',
+        },
+      },
+    );
+    const appPath = resolveBuildArtifactCommand(deviceId);
+    if (metroSpawnError || metroExit) {
+      throw new Error(
+        '[nativeDevShell] Metro exited while building the iOS physical-device app.',
+        { cause: metroSpawnError },
+      );
+    }
+    report.shell.status = 'installing';
+    await writeRunReportCommand(report);
+    runCheckedCommand('xcrun', [
+      'devicectl',
+      'device',
+      'install',
+      'app',
+      '--device',
+      deviceId,
+      '--quiet',
+      appPath,
+    ]);
+    preparationLock.release();
+    preparationLock = undefined;
+    report.shell.artifactPath = appPath;
+    report.shell.status = 'ready';
+    await writeRunReportCommand(report);
+    const nativeLaunch = launchAppCommand(deviceId, resolvedMetroPort);
+    report.launchedAt = new Date().toISOString();
+    await waitForAppStartupCommand({
+      deviceId,
+      processId: nativeLaunch.processId,
+    });
+    report.status = 'running';
+    await writeRunReportCommand(report);
+    printRunSummaryCommand(report);
+    const { code, signal } = await metroCompletion;
+    if (code !== 0 && signal !== 'SIGINT' && signal !== 'SIGTERM') {
+      throw new Error(
+        `[nativeDevShell] Metro exited with code ${String(code)} signal ${String(signal)}.`,
+      );
+    }
+    report.finishedAt = new Date().toISOString();
+    report.status = 'finished';
+    await writeRunReportCommand(report);
+    printRunSummaryCommand(report);
+  } catch (error) {
+    if (report) {
+      report.finishedAt = new Date().toISOString();
+      report.status = 'failed';
+      report.failure = getErrorMessage(error);
+      addFailureNotice(report, report.failure);
+      await writeRunReportCommand(report);
+      printRunSummaryCommand(report);
+    }
+    throw error;
+  } finally {
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM');
+    }
+    preparationLock?.release();
+    metroLock?.release();
+    deviceLock.release();
+  }
 }
 
 function assertTargetDeviceArchitecture({
@@ -1644,15 +1907,22 @@ async function acquireWorktreePreparationLock({
   }
 }
 
-function canListenOnPort(port) {
+function canListenOnHost(port, host) {
   return new Promise((resolve) => {
     const server = net.createServer();
     server.unref();
     server.once('error', () => resolve(false));
-    server.listen({ host: '0.0.0.0', port }, () => {
+    server.listen({ host, port }, () => {
       server.close(() => resolve(true));
     });
   });
+}
+
+async function canListenOnPort(port) {
+  return (
+    (await canListenOnHost(port, '127.0.0.1')) &&
+    (await canListenOnHost(port, '0.0.0.0'))
+  );
 }
 
 function parseMetroPort(value) {
@@ -1730,6 +2000,153 @@ function launchNativeApp(
     );
   }
   return { processId };
+}
+
+function resolveIosPhysicalBuildArtifact(
+  deviceId,
+  { fileSystem = fs, runForOutputCommand = runForOutput } = {},
+) {
+  const iosDirectory = path.join(MOBILE_ROOT, 'ios');
+  const buildSettings = JSON.parse(
+    runForOutputCommand(
+      'xcodebuild',
+      [
+        '-workspace',
+        'OneKeyWallet.xcworkspace',
+        '-configuration',
+        'Debug',
+        '-scheme',
+        'OneKeyWallet',
+        '-destination',
+        `id=${deviceId}`,
+        '-showBuildSettings',
+        '-json',
+      ],
+      { cwd: iosDirectory },
+    ),
+  );
+  const appBuildSettings = buildSettings.find(
+    ({ buildSettings: settings, target }) =>
+      target === 'OneKeyWallet' ||
+      settings?.WRAPPER_NAME === 'OneKeyWallet.app',
+  )?.buildSettings;
+  const targetBuildDirectory = appBuildSettings?.TARGET_BUILD_DIR;
+  const wrapperName = appBuildSettings?.WRAPPER_NAME;
+  if (
+    !path.isAbsolute(targetBuildDirectory || '') ||
+    !wrapperName?.endsWith('.app')
+  ) {
+    throw new Error(
+      '[nativeDevShell] Xcode did not report the iOS app build artifact.',
+    );
+  }
+  const appPath = path.join(targetBuildDirectory, wrapperName);
+  if (!fileSystem.existsSync(appPath)) {
+    throw new Error(
+      `[nativeDevShell] Built iOS app does not exist at ${appPath}.`,
+    );
+  }
+  return appPath;
+}
+
+function runDevicectlJson(
+  createArgs,
+  {
+    fileSystem = fs,
+    makeTemporaryDirectory = () =>
+      fileSystem.mkdtempSync(path.join(os.tmpdir(), 'onekey-devicectl-')),
+    runCheckedCommand = runChecked,
+  } = {},
+) {
+  const outputDirectory = makeTemporaryDirectory();
+  const outputPath = path.join(outputDirectory, 'result.json');
+  try {
+    runCheckedCommand('xcrun', ['devicectl', ...createArgs(outputPath)]);
+    return JSON.parse(fileSystem.readFileSync(outputPath, 'utf8'));
+  } finally {
+    fileSystem.rmSync(outputDirectory, { force: true, recursive: true });
+  }
+}
+
+function launchIosPhysicalApp(
+  deviceId,
+  metroPort,
+  { runDevicectlJsonCommand = runDevicectlJson } = {},
+) {
+  const result = runDevicectlJsonCommand((outputPath) => [
+    'device',
+    'process',
+    'launch',
+    '--device',
+    deviceId,
+    '--terminate-existing',
+    '--environment-variables',
+    JSON.stringify({ RCT_METRO_PORT: String(metroPort) }),
+    '--json-output',
+    outputPath,
+    '--quiet',
+    IOS_BUNDLE_ID,
+  ]);
+  const processId = result?.result?.process?.processIdentifier;
+  if (!Number.isSafeInteger(processId) || processId <= 0) {
+    throw new Error(
+      '[nativeDevShell] iOS physical-device launch returned no process ID.',
+    );
+  }
+  return { processId };
+}
+
+function getIosPhysicalAppProcessIds(
+  deviceId,
+  { runDevicectlJsonCommand = runDevicectlJson } = {},
+) {
+  const result = runDevicectlJsonCommand((outputPath) => [
+    'device',
+    'info',
+    'processes',
+    '--device',
+    deviceId,
+    '--json-output',
+    outputPath,
+    '--quiet',
+  ]);
+  return (result?.result?.runningProcesses || [])
+    .filter(({ executable }) =>
+      executable?.endsWith('/OneKeyWallet.app/OneKeyWallet'),
+    )
+    .map(({ processIdentifier }) => processIdentifier)
+    .filter((processId) => Number.isSafeInteger(processId) && processId > 0);
+}
+
+async function waitForIosPhysicalAppStartup({
+  deviceId,
+  pollIntervalMs = IOS_PHYSICAL_APP_STARTUP_POLL_INTERVAL_MS,
+  processId,
+  readProcessIds = getIosPhysicalAppProcessIds,
+  startupGraceMs = IOS_APP_STARTUP_GRACE_MS,
+  wait = (durationMs) =>
+    new Promise((resolve) => setTimeout(resolve, durationMs)),
+}) {
+  try {
+    if (!Number.isSafeInteger(processId) || processId <= 0) {
+      throw new Error(
+        '[nativeDevShell] iOS physical-device process ID is missing.',
+      );
+    }
+    for (let elapsed = 0; elapsed < startupGraceMs; elapsed += pollIntervalMs) {
+      await wait(pollIntervalMs);
+      if (!readProcessIds(deviceId).includes(processId)) {
+        throw new Error(
+          '[nativeDevShell] iOS physical-device app process exited.',
+        );
+      }
+    }
+  } catch (error) {
+    throw new Error(
+      '[nativeDevShell] ios physical-device app exited during startup.',
+      { cause: error },
+    );
+  }
 }
 
 async function waitForNativeAppStartup({
@@ -2377,6 +2794,16 @@ async function launchDevShell({
     platform,
     requestedDevice: device,
   });
+  if (platform === 'ios' && selectedDevice.physical) {
+    await launchIosPhysicalDeviceDevelopment({
+      deviceId: selectedDevice.id,
+      metroPort: requestedMetroPort,
+      metroUrl,
+      shell,
+      vendor,
+    });
+    return;
+  }
   assertTargetDeviceArchitecture({
     deviceId: selectedDevice.id,
     platform,
@@ -2606,11 +3033,15 @@ module.exports = {
   getAndroidPrivateSessionRenewalArgs,
   getAndroidLocalBuildEnvironment,
   getContractManifest,
+  getIosPhysicalAppProcessIds,
   getNativeRuntimeBundleUrl,
   getPlatformArtifact,
   getShellArtifactTag,
   getShellCompatibility,
+  isAvailableIosPhysicalDevice,
+  launchIosPhysicalApp,
   launchNativeApp,
+  launchIosPhysicalDeviceDevelopment,
   loadVendorManifest,
   parseAndroidDevices,
   parseArgs,
@@ -2625,8 +3056,10 @@ module.exports = {
   quoteAdbShellArgument,
   renewPrivateSession,
   resolveAndInstallShell,
+  resolveIosPhysicalBuildArtifact,
   resolveTargetDevice,
   selectTargetDevice,
+  waitForIosPhysicalAppStartup,
   waitForNativeAppStartup,
   waitForMetroCompletionWithSessionRenewal,
   writeContractManifest,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "app:build-bundle:ios": "yarn workspace @onekeyhq/mobile build-bundle:ios",
     "app:build-bundle:android": "yarn workspace @onekeyhq/mobile build-bundle:android",
     "app:ios": "yarn workspace @onekeyhq/mobile dev-shell --platform ios",
-    "app:ios:device": "yarn workspace @onekeyhq/mobile ios:device",
+    "app:ios:device": "yarn copy:inject && yarn workspace @onekeyhq/mobile dev-vendor:prepare:ios && cross-env ONEKEY_DEV_VENDOR=true ONEKEY_DEV_BG_HMR=true yarn workspace @onekeyhq/mobile ios:device",
     "app:ios:pod-install": "yarn workspace @onekeyhq/mobile ios:pod-install",
     "app:android": "yarn workspace @onekeyhq/mobile dev-shell --platform android",
     "app:android:device": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" yarn workspace @onekeyhq/mobile android:device",


### PR DESCRIPTION
## Summary

- recognize an explicitly requested connected iOS physical device through CoreDevice
- route physical-device development to the signed local Xcode Debug path
- prepare and enable the iOS DevVendor common HBC before running the device build
- document the physical-device behavior and cover it with focused tests

## Validation

- yarn agent:check --profile commit
- 3 focused Jest suites, 90 tests passed
- connected iPhone 17 Pro resolved through CoreDevice
- arm64 Debug iphoneos build succeeded and was Apple Development signed
- embedded common HBC SHA-256 matched the prepared DevVendor artifact; manifest matched byte-for-byte

## Device safety

The built app was not installed because it uses bundle ID so.onekey.wallet, which would replace the production OneKey 6.6.0 currently installed on the device. Runtime launch therefore remains unverified.
