### PR TITLE
fix: show refunded history fees (OK-57074)

### DIFF
--- a/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
@@ -51,6 +51,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IModalAssetDetailsParamList } from '@onekeyhq/shared/src/routes/assetDetails';
 import { EModalAssetDetailRoutes } from '@onekeyhq/shared/src/routes/assetDetails';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { getHistoryFeeDisplayValues } from '@onekeyhq/shared/src/utils/historyFeeUtils';
 import { getHistoryTxDetailInfo } from '@onekeyhq/shared/src/utils/historyUtils';
 import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import {
@@ -1315,42 +1316,63 @@ function HistoryDetails() {
     historyTx,
   });
 
-  const renderFeeInfo = useCallback(
-    () => (
+  const renderFeeInfo = useCallback(() => {
+    const gasFeeDisplayValues = getHistoryFeeDisplayValues({
+      gasFee: txInfo?.gasFee,
+      gasFeeFiatValue: txInfo?.gasFeeFiatValue,
+    });
+    const gasFeeTextColor = gasFeeDisplayValues.isRefunded
+      ? '$textSuccess'
+      : '$textSubdued';
+
+    return (
       <XStack alignItems="center">
+        {gasFeeDisplayValues.isRefunded ? (
+          <SizableText size="$bodyMd" color={gasFeeTextColor}>
+            +
+          </SizableText>
+        ) : null}
         <NumberSizeableTextWrapper
           formatter="balance"
           size="$bodyMd"
-          color="$textSubdued"
+          color={gasFeeTextColor}
           formatterOptions={{
             tokenSymbol: nativeToken?.symbol,
           }}
         >
-          {txInfo?.gasFee}
+          {gasFeeDisplayValues.gasFee}
         </NumberSizeableTextWrapper>
-        {!isNil(txInfo?.gasFeeFiatValue) ? (
-          <SizableText size="$bodyMd" color="$textSubdued" ml="$1">
+        {!isNil(gasFeeDisplayValues.gasFeeFiatValue) ? (
+          <SizableText size="$bodyMd" color={gasFeeTextColor} ml="$1">
             (
             <NumberSizeableTextWrapper
               formatter="value"
               formatterOptions={{ currency: settings.currencyInfo.symbol }}
               size="$bodyMd"
-              color="$textSubdued"
+              color={gasFeeTextColor}
             >
-              {txInfo?.gasFeeFiatValue ?? '0'}
+              {gasFeeDisplayValues.gasFeeFiatValue ?? '0'}
             </NumberSizeableTextWrapper>
             )
           </SizableText>
         ) : null}
+        {gasFeeDisplayValues.isRefunded ? (
+          <SizableText size="$bodyMd" color={gasFeeTextColor} ml="$1">
+            ·{' '}
+            {intl.formatMessage({
+              id: ETranslations.sui_rebate_refunded,
+            })}
+          </SizableText>
+        ) : null}
       </XStack>
-    ),
-    [
-      nativeToken?.symbol,
-      settings.currencyInfo.symbol,
-      txInfo?.gasFee,
-      txInfo?.gasFeeFiatValue,
-    ],
-  );
+    );
+  }, [
+    intl,
+    nativeToken?.symbol,
+    settings.currencyInfo.symbol,
+    txInfo?.gasFee,
+    txInfo?.gasFeeFiatValue,
+  ]);
 
   const renderHistoryDetails = useCallback(() => {
     // On the notification path no `historyTx` is passed in, so the detail is

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -41,6 +41,7 @@ import type {
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { getHistoryFeeDisplayValues } from '@onekeyhq/shared/src/utils/historyFeeUtils';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import {
   buildSwapOrderLongPendingWarningPayload,
@@ -1430,10 +1431,11 @@ const SwapHistoryDetailModal = () => {
       : false;
     const isSponsored =
       txHistory?.swapInfo?.isFreeNetworkFee === true && !isExternalAccount;
-    if (isSponsored) {
+    const gasFeeInNativeBN = new BigNumber(gasFeeInNative ?? '');
+    const isRefunded = gasFeeInNativeBN.isFinite() && gasFeeInNativeBN.lt(0);
+    if (isSponsored && !isRefunded) {
       return <SwapSponsoredNetworkFee />;
     }
-    const gasFeeInNativeBN = new BigNumber(gasFeeInNative ?? '');
     if (gasFeeInNativeBN.isNaN() || !gasFeeInNativeBN.isFinite()) {
       return (
         <SizableText size="$bodyMd" color="$textSubdued">
@@ -1441,7 +1443,6 @@ const SwapHistoryDetailModal = () => {
         </SizableText>
       );
     }
-    const gasFeeDisplay = gasFeeInNativeBN.toFixed();
     const nativePriceKey = getPrivateSendNetworkNativePriceKey(txHistory);
     let privateSendGasFeeFiatValue: string | undefined;
     if (isPrivateSendHistory && nativePriceKey) {
@@ -1461,30 +1462,50 @@ const SwapHistoryDetailModal = () => {
           targetCurrency: displayCurrencyId,
           value: gasFeeFiatValue,
         });
-    const finalGasFeeFiatValueBN = new BigNumber(finalGasFeeFiatValue ?? '');
+    const gasFeeDisplayValues = getHistoryFeeDisplayValues({
+      gasFee: gasFeeInNativeBN.toFixed(),
+      gasFeeFiatValue: finalGasFeeFiatValue,
+    });
+    const gasFeeTextColor = gasFeeDisplayValues.isRefunded
+      ? '$textSuccess'
+      : '$textSubdued';
+    const finalGasFeeFiatValueBN = new BigNumber(
+      gasFeeDisplayValues.gasFeeFiatValue ?? '',
+    );
     const shouldRenderGasFeeFiatValue =
       !finalGasFeeFiatValueBN.isNaN() && finalGasFeeFiatValueBN.isFinite();
     return (
-      <SizableText size="$bodyMd" color="$textSubdued">
+      <SizableText size="$bodyMd" color={gasFeeTextColor}>
+        {gasFeeDisplayValues.isRefunded ? '+' : null}
         <NumberSizeableText
           size="$bodyMd"
-          color="$textSubdued"
+          color={gasFeeTextColor}
           formatter="balance"
         >
-          {gasFeeDisplay}
+          {gasFeeDisplayValues.gasFee}
         </NumberSizeableText>
-        {` ${txHistory?.baseInfo.fromNetwork?.symbol ?? ''}`}(
+        {` ${txHistory?.baseInfo.fromNetwork?.symbol ?? ''}${
+          gasFeeDisplayValues.isRefunded ? ' ' : ''
+        }`}
+        (
         <NumberSizeableText
-          color="$textSubdued"
+          color={gasFeeTextColor}
           size="$bodyMd"
           formatter="value"
           formatterOptions={{
             currency: displayCurrencySymbol,
           }}
         >
-          {shouldRenderGasFeeFiatValue ? finalGasFeeFiatValue : '--'}
+          {shouldRenderGasFeeFiatValue
+            ? gasFeeDisplayValues.gasFeeFiatValue
+            : '--'}
         </NumberSizeableText>
         )
+        {gasFeeDisplayValues.isRefunded
+          ? ` · ${intl.formatMessage({
+              id: ETranslations.sui_rebate_refunded,
+            })}`
+          : null}
       </SizableText>
     );
   }, [
@@ -1492,6 +1513,7 @@ const SwapHistoryDetailModal = () => {
     displayCurrencyId,
     displayCurrencySymbol,
     historySourceCurrencyId,
+    intl,
     isPrivateSendHistory,
     privateSendTokenDisplayPriceMap,
     txHistory,

--- a/packages/shared/src/utils/historyFeeUtils.test.ts
+++ b/packages/shared/src/utils/historyFeeUtils.test.ts
@@ -1,0 +1,50 @@
+import { getHistoryFeeDisplayValues } from './historyFeeUtils';
+
+describe('getHistoryFeeDisplayValues', () => {
+  it('formats a negative net fee as a refund', () => {
+    expect(
+      getHistoryFeeDisplayValues({
+        gasFee: '-0.0008418',
+        gasFeeFiatValue: '-0.0012',
+      }),
+    ).toEqual({
+      gasFee: '0.0008418',
+      gasFeeFiatValue: '0.0012',
+      isRefunded: true,
+    });
+  });
+
+  it('keeps a regular fee unchanged', () => {
+    expect(
+      getHistoryFeeDisplayValues({
+        gasFee: '0.0008418',
+        gasFeeFiatValue: '0.0012',
+      }),
+    ).toEqual({
+      gasFee: '0.0008418',
+      gasFeeFiatValue: '0.0012',
+      isRefunded: false,
+    });
+  });
+
+  it('keeps missing fee data unchanged', () => {
+    expect(getHistoryFeeDisplayValues({})).toEqual({
+      gasFee: undefined,
+      gasFeeFiatValue: undefined,
+      isRefunded: false,
+    });
+  });
+
+  it('does not treat negative zero as a refund', () => {
+    expect(
+      getHistoryFeeDisplayValues({
+        gasFee: '-0',
+        gasFeeFiatValue: '-0',
+      }),
+    ).toEqual({
+      gasFee: '-0',
+      gasFeeFiatValue: '-0',
+      isRefunded: false,
+    });
+  });
+});

--- a/packages/shared/src/utils/historyFeeUtils.ts
+++ b/packages/shared/src/utils/historyFeeUtils.ts
@@ -1,0 +1,30 @@
+import BigNumber from 'bignumber.js';
+
+export function getHistoryFeeDisplayValues({
+  gasFee,
+  gasFeeFiatValue,
+}: {
+  gasFee?: string;
+  gasFeeFiatValue?: string;
+}) {
+  const gasFeeBN = new BigNumber(gasFee ?? '');
+  const isRefunded = gasFeeBN.isFinite() && gasFeeBN.lt(0);
+
+  if (!isRefunded) {
+    return {
+      gasFee,
+      gasFeeFiatValue,
+      isRefunded,
+    };
+  }
+
+  const gasFeeFiatValueBN = new BigNumber(gasFeeFiatValue ?? '');
+
+  return {
+    gasFee: gasFeeBN.abs().toFixed(),
+    gasFeeFiatValue: gasFeeFiatValueBN.isFinite()
+      ? gasFeeFiatValueBN.abs().toFixed()
+      : gasFeeFiatValue,
+    isRefunded,
+  };
+}


### PR DESCRIPTION
## Summary
- Detect negative net gas fees in Wallet and Swap history details.
- Render absolute native and fiat values with a plus sign, success color, and the localized Refunded label.
- Preserve existing behavior for non-negative, zero, missing, and sponsored-fee states.

## Issues
- Fixes OK-57074

## Test plan
- yarn jest packages/shared/src/utils/historyFeeUtils.test.ts --runInBand
- yarn tsc:only
- yarn agent:check --profile commit
- yarn agent:check --profile pr
- Desktop mock validation for Wallet and Swap history details; temporary runtime mock code removed afterward.

## Risk
- Frontend-only display change, activated only when the net gas fee is negative.