### PR TITLE
fix: native cold-start home first paint and home tab pane freeze timing(OK-61505, OK-62565)

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -19605,6 +19605,7 @@
     "packages/kit/src/components/AccountSelector/AllNetworksManagerTrigger.tsx": 18559,
     "packages/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger.tsx": 18328,
     "packages/kit/src/components/AccountSelector/LazyAccountSelectorCreateAddressButton.tsx": 16261,
+    "packages/kit/src/components/AccountSelector/LazyAllNetworksManagerTrigger.native.tsx": 17749,
     "packages/kit/src/components/AccountSelector/LazyAllNetworksManagerTrigger.tsx": 4243,
     "packages/kit/src/components/AccountSelector/NetworkSelectorTrigger/NetworkSelectorTrigger.tsx": 15497,
     "packages/kit/src/components/AccountSelector/NetworkSelectorTrigger/NetworkSelectorTriggerApproval.tsx": 12873,

--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -21434,6 +21434,7 @@
     "packages/kit/src/views/Home/pages/homeOverviewBalanceHold.ts": 9327,
     "packages/kit/src/views/Home/pages/homePageContentMaxWidth.ts": 17086,
     "packages/kit/src/views/Home/pages/homePageNoWalletContent.ts": 16343,
+    "packages/kit/src/views/Home/pages/homeTabFreeze.ts": 14618,
     "packages/kit/src/views/Home/pages/hooks/historyTopFreezeUtils.ts": 18767,
     "packages/kit/src/views/Home/pages/hooks/useFrozenTopHistoryData.native.ts": 17971,
     "packages/kit/src/views/Home/pages/hooks/useHistoryListLoadMore.ts": 6368,

--- a/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.runtimeLaunch.test.tsx
+++ b/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.runtimeLaunch.test.tsx
@@ -80,6 +80,7 @@ jest.mock('react-native', () => ({
 
 jest.mock('./bootstrapNativeStorage', () => ({
   bootstrapNativeStorage: () => mockBootstrapNativeStorage(),
+  hydrateColdStartSnapshotAfterRuntimeLaunch: () => undefined,
   waitForColdStartCriticalImagesBeforeMount: () => Promise.resolve(),
 }));
 

--- a/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.runtimeLaunch.test.tsx
+++ b/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.runtimeLaunch.test.tsx
@@ -80,6 +80,7 @@ jest.mock('react-native', () => ({
 
 jest.mock('./bootstrapNativeStorage', () => ({
   bootstrapNativeStorage: () => mockBootstrapNativeStorage(),
+  waitForColdStartCriticalImagesBeforeMount: () => Promise.resolve(),
 }));
 
 jest.mock('./nativeStorageBootstrapSplash', () => ({

--- a/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.test.tsx
+++ b/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.test.tsx
@@ -37,6 +37,7 @@ const mockRunJotaiMainHydration = jest.fn(
   async (initializeFromBackground: () => Promise<void>) =>
     initializeFromBackground(),
 );
+const mockHydrateColdStartSnapshotAfterRuntimeLaunch = jest.fn();
 const mockWaitForColdStartCriticalImagesResolvers: Array<() => void> = [];
 const mockWaitForColdStartCriticalImagesBeforeMount = jest.fn(
   () =>
@@ -112,6 +113,9 @@ jest.mock('react-native', () => ({
 jest.mock('./bootstrapNativeStorage', () => ({
   bootstrapNativeStorage: (options: { force?: boolean }) =>
     mockBootstrapNativeStorage(options),
+  hydrateColdStartSnapshotAfterRuntimeLaunch: () => {
+    mockHydrateColdStartSnapshotAfterRuntimeLaunch();
+  },
   waitForColdStartCriticalImagesBeforeMount: () =>
     mockWaitForColdStartCriticalImagesBeforeMount(),
 }));
@@ -295,6 +299,23 @@ describe('NativeStorageBootstrapRoot', () => {
       mockInitializeJotaiFromBackground.mock.invocationCallOrder[1],
     ).toBeLessThan(
       mockWaitForColdStartCriticalImagesBeforeMount.mock.invocationCallOrder[0],
+    );
+    // The snapshot is readable only after the runtime launch is acknowledged,
+    // and it must be hydrated before the jotai init that precedes the mount.
+    expect(mockHydrateColdStartSnapshotAfterRuntimeLaunch).toHaveBeenCalled();
+    expect(
+      mockForceDisableTravelModeForRecovery.mock.invocationCallOrder.at(-1),
+    ).toBeLessThan(
+      mockHydrateColdStartSnapshotAfterRuntimeLaunch.mock.invocationCallOrder.at(
+        -1,
+      ) as number,
+    );
+    expect(
+      mockHydrateColdStartSnapshotAfterRuntimeLaunch.mock.invocationCallOrder.at(
+        -1,
+      ),
+    ).toBeLessThan(
+      mockInitializeJotaiFromBackground.mock.invocationCallOrder[1],
     );
     expect(screen.queryByTestId('business-app')).toBeNull();
 

--- a/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.test.tsx
+++ b/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.test.tsx
@@ -37,6 +37,13 @@ const mockRunJotaiMainHydration = jest.fn(
   async (initializeFromBackground: () => Promise<void>) =>
     initializeFromBackground(),
 );
+const mockWaitForColdStartCriticalImagesResolvers: Array<() => void> = [];
+const mockWaitForColdStartCriticalImagesBeforeMount = jest.fn(
+  () =>
+    new Promise<void>((resolve) => {
+      mockWaitForColdStartCriticalImagesResolvers.push(resolve);
+    }),
+);
 
 jest.mock('@onekeyhq/shared/src/modules3rdParty/appRestart', () => ({
   appRestart: (options: unknown) => mockAppRestart(options),
@@ -105,6 +112,8 @@ jest.mock('react-native', () => ({
 jest.mock('./bootstrapNativeStorage', () => ({
   bootstrapNativeStorage: (options: { force?: boolean }) =>
     mockBootstrapNativeStorage(options),
+  waitForColdStartCriticalImagesBeforeMount: () =>
+    mockWaitForColdStartCriticalImagesBeforeMount(),
 }));
 
 jest.mock('./nativeStorageBootstrapSplash', () => ({
@@ -273,7 +282,27 @@ describe('NativeStorageBootstrapRoot', () => {
     expect(mockRunJotaiMainHydration).toHaveBeenCalledTimes(2);
     await act(async () => {
       mockJotaiInitResolvers[1]?.();
-      await Promise.resolve();
+      for (let index = 0; index < 5; index += 1) {
+        await Promise.resolve();
+      }
+    });
+    // First-paint images get their bounded head start after jotai hydration
+    // and before the business app mounts (OK-61505).
+    expect(mockWaitForColdStartCriticalImagesBeforeMount).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      mockInitializeJotaiFromBackground.mock.invocationCallOrder[1],
+    ).toBeLessThan(
+      mockWaitForColdStartCriticalImagesBeforeMount.mock.invocationCallOrder[0],
+    );
+    expect(screen.queryByTestId('business-app')).toBeNull();
+
+    await act(async () => {
+      mockWaitForColdStartCriticalImagesResolvers[0]?.();
+      for (let index = 0; index < 5; index += 1) {
+        await Promise.resolve();
+      }
     });
     expect(screen.getByTestId('business-app')).toBeTruthy();
   });

--- a/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.tsx
+++ b/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.tsx
@@ -19,7 +19,10 @@ import { callNativeStorage } from '@onekeyhq/shared/src/storage/nativeStorageBri
 import { getNativeStorageMigrationRecoveryTarget } from '@onekeyhq/shared/src/storage/nativeStorageTypes';
 import type { INativeStorageMigrationRecoveryTarget } from '@onekeyhq/shared/src/storage/nativeStorageTypes';
 
-import { bootstrapNativeStorage } from './bootstrapNativeStorage';
+import {
+  bootstrapNativeStorage,
+  waitForColdStartCriticalImagesBeforeMount,
+} from './bootstrapNativeStorage';
 import { runJotaiMainHydration } from './jotaiMainHydrationGate';
 import { hideNativeStorageBootstrapSplash } from './nativeStorageBootstrapSplash';
 
@@ -117,6 +120,13 @@ function startBootstrap(force = false) {
     }
     stage = 'jotai';
     await initializeJotaiFromBackground();
+    if (generation !== bootstrapGeneration) {
+      return false;
+    }
+    // The home header/banner images were started by bootstrapNativeStorage;
+    // give them a bounded chance to land in the memory cache before the
+    // first React frame lays them out (OK-61505).
+    await waitForColdStartCriticalImagesBeforeMount();
     return generation === bootstrapGeneration;
   })();
   const nextPromise = withNativeBootstrapTimeout(bootstrapWork)

--- a/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.tsx
+++ b/apps/mobile/src/backgroundThread/NativeStorageBootstrapRoot.tsx
@@ -21,6 +21,7 @@ import type { INativeStorageMigrationRecoveryTarget } from '@onekeyhq/shared/src
 
 import {
   bootstrapNativeStorage,
+  hydrateColdStartSnapshotAfterRuntimeLaunch,
   waitForColdStartCriticalImagesBeforeMount,
 } from './bootstrapNativeStorage';
 import { runJotaiMainHydration } from './jotaiMainHydrationGate';
@@ -118,14 +119,17 @@ function startBootstrap(force = false) {
     if (generation !== bootstrapGeneration) {
       return false;
     }
+    // Sync storage reads are masked until the runtime launch is acknowledged,
+    // so the cold-start snapshot can only be read from here on.
+    hydrateColdStartSnapshotAfterRuntimeLaunch();
     stage = 'jotai';
     await initializeJotaiFromBackground();
     if (generation !== bootstrapGeneration) {
       return false;
     }
-    // The home header/banner images were started by bootstrapNativeStorage;
-    // give them a bounded chance to land in the memory cache before the
-    // first React frame lays them out (OK-61505).
+    // The home header/banner images were started by the snapshot hydration
+    // above; give them a bounded chance to land in the memory cache before
+    // the first React frame lays them out (OK-61505).
     await waitForColdStartCriticalImagesBeforeMount();
     return generation === bootstrapGeneration;
   })();

--- a/apps/mobile/src/backgroundThread/bootstrapNativeStorage.ts
+++ b/apps/mobile/src/backgroundThread/bootstrapNativeStorage.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 
-let bootstrapGeneration = 0;
-
 // Upper bound on how long the app mount waits for the first-paint images
 // (home banner cards + header network logos) started by
 // `startColdStartImagePrewarm`. Disk-cached images decode well inside this
@@ -54,17 +52,20 @@ export async function waitForColdStartCriticalImagesBeforeMount() {
 export async function bootstrapNativeStorage({
   force = false,
 }: { force?: boolean } = {}) {
-  const generation = (bootstrapGeneration += 1);
   const { bootstrapNativeSyncStorageMirrors, refreshNativeSyncStorageMirrors } =
     require('@onekeyhq/shared/src/storage/instance/nativeSyncStorageMirror') as typeof import('@onekeyhq/shared/src/storage/instance/nativeSyncStorageMirror');
 
   await (force
     ? refreshNativeSyncStorageMirrors()
     : bootstrapNativeSyncStorageMirrors());
-  if (generation !== bootstrapGeneration) {
-    return;
-  }
+}
 
+// Reads the bg-proxied contextAtom snapshot into `__ONEKEY_CTX_ATOM_SNAPSHOT__`
+// and starts the cold-start image prewarm. Must run AFTER the travel-mode
+// runtime launch is acknowledged: until then every synchronous storage read
+// is masked (returns undefined), so reading the snapshot inside
+// `bootstrapNativeStorage` silently found nothing (OK-61505).
+export function hydrateColdStartSnapshotAfterRuntimeLaunch() {
   try {
     const { coldStartCacheStorage } =
       require('@onekeyhq/shared/src/storage/instance/syncStorageInstance') as typeof import('@onekeyhq/shared/src/storage/instance/syncStorageInstance');
@@ -74,6 +75,9 @@ export async function bootstrapNativeStorage({
       EAppSyncStorageKeys.onekey_jotai_context_atoms_snapshot,
     );
     if (!raw) {
+      writeBootstrapLog(
+        '[StartupTiming] bg-proxied contextAtom snapshot absent, cold-start image prewarm skipped',
+      );
       return;
     }
 
@@ -92,10 +96,7 @@ export async function bootstrapNativeStorage({
       (globalThis as any).__ONEKEY_PERPS_L2_BOOK_COLD_CACHE__ = perpsEntry[1];
     }
 
-    const { NativeLogger, LogLevel } =
-      require('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger') as typeof import('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger');
-    NativeLogger.write(
-      LogLevel.Info,
+    writeBootstrapLog(
       `[StartupTiming] bg-proxied contextAtom snapshot hydrated: ${Object.keys(snapshot).length} keys (+${Date.now() - ((globalThis as any).__ONEKEY_MAIN_ENTRY_START__ as number)}ms)`,
     );
 
@@ -109,5 +110,22 @@ export async function bootstrapNativeStorage({
     // A corrupt best-effort display cache must not turn a successful storage
     // migration into a startup failure.
     console.error('[NativeStorageBootstrap] cold-start cache ignored', error);
+    writeBootstrapLog(
+      `[NativeStorageBootstrap] cold-start cache ignored: ${
+        error instanceof Error
+          ? `${error.message}\n${error.stack ?? ''}`
+          : String(error)
+      }`,
+    );
+  }
+}
+
+function writeBootstrapLog(message: string) {
+  try {
+    const { NativeLogger, LogLevel } =
+      require('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger') as typeof import('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger');
+    NativeLogger.write(LogLevel.Info, message);
+  } catch {
+    // Logging is best-effort during bootstrap.
   }
 }

--- a/apps/mobile/src/backgroundThread/bootstrapNativeStorage.ts
+++ b/apps/mobile/src/backgroundThread/bootstrapNativeStorage.ts
@@ -2,6 +2,55 @@
 
 let bootstrapGeneration = 0;
 
+// Upper bound on how long the app mount waits for the first-paint images
+// (home banner cards + header network logos) started by
+// `startColdStartImagePrewarm`. Disk-cached images decode well inside this
+// window and usually finish during the jotai hydration that runs in between;
+// a cold disk cache (first launch, evicted entries) gives up and renders with
+// the skeleton as before.
+const COLD_START_CRITICAL_IMAGES_TIMEOUT_MS = 300;
+
+export async function waitForColdStartCriticalImagesBeforeMount() {
+  const startedAt = Date.now();
+  let status: 'done' | 'timeout' | 'error' = 'done';
+  let count = 0;
+  try {
+    const { waitForColdStartCriticalImages } =
+      require('@onekeyhq/kit/src/utils/coldStartImagePreload') as typeof import('@onekeyhq/kit/src/utils/coldStartImagePreload');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(
+        () => resolve('timeout'),
+        COLD_START_CRITICAL_IMAGES_TIMEOUT_MS,
+      );
+    });
+    const result = await Promise.race([
+      waitForColdStartCriticalImages(),
+      timeout,
+    ]);
+    clearTimeout(timer);
+    if (result === 'timeout') {
+      status = 'timeout';
+    } else {
+      count = result;
+    }
+  } catch {
+    status = 'error';
+  }
+  try {
+    const { NativeLogger, LogLevel } =
+      require('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger') as typeof import('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger');
+    NativeLogger.write(
+      LogLevel.Info,
+      `[StartupTiming] cold-start critical images ${status}: ${count} images, waited ${
+        Date.now() - startedAt
+      }ms (+${Date.now() - ((globalThis as any).__ONEKEY_MAIN_ENTRY_START__ as number)}ms)`,
+    );
+  } catch {
+    // Logging is best-effort during bootstrap.
+  }
+}
+
 export async function bootstrapNativeStorage({
   force = false,
 }: { force?: boolean } = {}) {
@@ -53,9 +102,9 @@ export async function bootstrapNativeStorage({
     const { warmCriticalIcons } =
       require('@onekeyhq/components/src/primitives/Icon') as typeof import('@onekeyhq/components/src/primitives/Icon');
     warmCriticalIcons();
-    const { prewarmColdStartImagesFromSnapshot } =
+    const { startColdStartImagePrewarm } =
       require('@onekeyhq/kit/src/utils/coldStartImagePreload') as typeof import('@onekeyhq/kit/src/utils/coldStartImagePreload');
-    void prewarmColdStartImagesFromSnapshot();
+    void startColdStartImagePrewarm();
   } catch (error) {
     // A corrupt best-effort display cache must not turn a successful storage
     // migration into a startup failure.

--- a/packages/kit/src/components/AccountSelector/LazyAllNetworksManagerTrigger.native.tsx
+++ b/packages/kit/src/components/AccountSelector/LazyAllNetworksManagerTrigger.native.tsx
@@ -1,0 +1,5 @@
+// Native ships a single bundle, so the lazy chunk buys nothing there and its
+// Suspense fallback (null) is one of the reasons the home header network
+// trigger paints later than its siblings on cold start (OK-61505). Resolve
+// the trigger statically; web keeps the split chunk.
+export { AllNetworksManagerTrigger as LazyAllNetworksManagerTrigger } from './AllNetworksManagerTrigger';

--- a/packages/kit/src/utils/coldStartImagePreload.test.ts
+++ b/packages/kit/src/utils/coldStartImagePreload.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/first */
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
 const mockPreloadImages: jest.Mock<Promise<boolean>, unknown[]> = jest.fn();
 
@@ -10,14 +11,41 @@ jest.mock('@onekeyhq/components/src/primitives/Image/preload', () => ({
   preloadImages: (...args: unknown[]) => mockPreloadImages(...args),
 }));
 
+const mockGetWithTimestamp: jest.Mock<
+  { data: unknown; updatedAt: number } | undefined,
+  [string]
+> = jest.fn();
+
+jest.mock('@onekeyhq/shared/src/utils/swrCacheUtils', () => {
+  const actual = jest.requireActual<
+    typeof import('@onekeyhq/shared/src/utils/swrCacheUtils')
+  >('@onekeyhq/shared/src/utils/swrCacheUtils');
+  return {
+    ...actual,
+    swrCacheUtils: {
+      ...actual.swrCacheUtils,
+      getWithTimestamp: (key: string) => mockGetWithTimestamp(key),
+    },
+  };
+});
+
 import {
+  HEADER_NETWORK_LOGO_SIZE,
   WALLET_BANNER_IMAGE_SIZE,
+  getColdStartCriticalImageItemsFromSnapshot,
   getColdStartImageUrisFromSnapshot,
   prewarmColdStartImagesFromSnapshot,
+  startColdStartImagePrewarm,
+  waitForColdStartCriticalImages,
 } from './coldStartImagePreload';
 
 const bannerUri = 'https://uni.onekey-asset.com/banner/smci.png';
 const tokenUri = 'https://uni.onekey-asset.com/icons/eth.png';
+const ethNetworkLogoUri = 'https://uni.onekey-asset.com/static/chain/eth.png';
+const btcNetworkLogoUri = 'https://uni.onekey-asset.com/static/chain/btc.png';
+const solNetworkLogoUri = 'https://uni.onekey-asset.com/static/chain/sol.png';
+const HD_WALLET_ID = 'hd-1';
+const INDEXED_ACCOUNT_ID = 'hd-1--0';
 
 const snapshot = {
   [`store-a::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.walletTopBannersAtom}`]: {
@@ -64,5 +92,172 @@ describe('coldStartImagePreload wallet banner images (OK-61505)', () => {
       }),
       expect.objectContaining({ uri: tokenUri, resizeWidth: 32 }),
     ]);
+  });
+});
+
+describe('coldStartImagePreload header network logos (OK-61505)', () => {
+  const activeAccountsKey = `store:accountSelector@home::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom}`;
+
+  beforeEach(() => {
+    mockPreloadImages.mockReset();
+    mockPreloadImages.mockResolvedValue(true);
+    mockGetWithTimestamp.mockReset();
+    mockGetWithTimestamp.mockReturnValue(undefined);
+  });
+
+  it('collects the single-network header logo at the header avatar size', () => {
+    const items = getColdStartCriticalImageItemsFromSnapshot({
+      ...snapshot,
+      [activeAccountsKey]: {
+        0: {
+          network: { id: 'evm--1', logoURI: ethNetworkLogoUri },
+          wallet: { id: HD_WALLET_ID },
+        },
+      },
+    });
+
+    expect(items).toEqual([
+      { uri: bannerUri, resizeWidth: WALLET_BANNER_IMAGE_SIZE },
+      { uri: ethNetworkLogoUri, resizeWidth: HEADER_NETWORK_LOGO_SIZE },
+    ]);
+    expect(mockGetWithTimestamp).not.toHaveBeenCalled();
+  });
+
+  it('collects the first two All Networks compat logos from the trigger swr snapshot', () => {
+    const compatKey = swrKeys.allNetworksCompatible({
+      walletId: HD_WALLET_ID,
+      networkId: 'onekeyall--0',
+      filterNetworksWithoutAccount: true,
+      indexedAccountId: INDEXED_ACCOUNT_ID,
+      withNetworksInfo: false,
+      enabledNetworkIdsKey: '',
+    });
+    mockGetWithTimestamp.mockImplementation((key) =>
+      key === compatKey
+        ? {
+            updatedAt: 1,
+            data: {
+              compatibleNetworks: [
+                { id: 'evm--1', logoURI: ethNetworkLogoUri },
+                { id: 'btc--0', logoURI: btcNetworkLogoUri },
+                { id: 'sol--101', logoURI: solNetworkLogoUri },
+              ],
+            },
+          }
+        : undefined,
+    );
+
+    const items = getColdStartCriticalImageItemsFromSnapshot({
+      [activeAccountsKey]: {
+        0: {
+          network: {
+            id: 'onekeyall--0',
+            isAllNetworks: true,
+            logoURI: 'https://uni.onekey-asset.com/static/chain/all.png',
+          },
+          wallet: { id: HD_WALLET_ID },
+          indexedAccount: { id: INDEXED_ACCOUNT_ID },
+        },
+      },
+    });
+
+    expect(items).toEqual([
+      { uri: ethNetworkLogoUri, resizeWidth: HEADER_NETWORK_LOGO_SIZE },
+      { uri: btcNetworkLogoUri, resizeWidth: HEADER_NETWORK_LOGO_SIZE },
+    ]);
+  });
+
+  it('skips All Networks compat logos for imported and watching wallets', () => {
+    const items = getColdStartCriticalImageItemsFromSnapshot({
+      [activeAccountsKey]: {
+        0: {
+          network: { id: 'onekeyall--0', isAllNetworks: true },
+          wallet: { id: 'imported' },
+        },
+      },
+    });
+
+    expect(items).toEqual([]);
+    expect(mockGetWithTimestamp).not.toHaveBeenCalled();
+  });
+
+  it('lists header logos at the header size ahead of token logos', () => {
+    const items = getColdStartImageUrisFromSnapshot({
+      ...snapshot,
+      [activeAccountsKey]: {
+        0: {
+          network: { id: 'evm--1', logoURI: ethNetworkLogoUri },
+          wallet: { id: HD_WALLET_ID },
+        },
+      },
+    });
+
+    expect(items).toEqual([
+      { uri: bannerUri, resizeWidth: WALLET_BANNER_IMAGE_SIZE },
+      { uri: ethNetworkLogoUri, resizeWidth: HEADER_NETWORK_LOGO_SIZE },
+      tokenUri,
+    ]);
+  });
+});
+
+describe('coldStartImagePreload first-paint prime (OK-61505)', () => {
+  beforeEach(() => {
+    mockPreloadImages.mockReset();
+    mockPreloadImages.mockResolvedValue(true);
+    mockGetWithTimestamp.mockReset();
+    mockGetWithTimestamp.mockReturnValue(undefined);
+  });
+
+  it('awaits the critical subset and fires the rest without waiting', async () => {
+    let resolveCritical: ((value: boolean) => void) | undefined;
+    mockPreloadImages
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveCritical = resolve;
+          }),
+      )
+      .mockImplementationOnce(() => new Promise<boolean>(() => {}));
+
+    const critical = startColdStartImagePrewarm({ snapshot });
+
+    expect(mockPreloadImages).toHaveBeenCalledTimes(2);
+    expect(mockPreloadImages.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        uri: bannerUri,
+        resizeWidth: WALLET_BANNER_IMAGE_SIZE,
+      }),
+    ]);
+    expect(mockPreloadImages.mock.calls[1][0]).toEqual([
+      expect.objectContaining({ uri: tokenUri, resizeWidth: 32 }),
+    ]);
+
+    let settled = false;
+    void critical.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveCritical?.(true);
+    await expect(critical).resolves.toBe(1);
+    await expect(waitForColdStartCriticalImages()).resolves.toBe(1);
+  });
+
+  it('resolves immediately when the snapshot has no critical images', async () => {
+    await expect(
+      startColdStartImagePrewarm({
+        snapshot: {
+          [`store-a::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.tokenListSlimColdCacheAtom}`]:
+            { compactMeta: { eth: { logoURI: tokenUri } } },
+        },
+      }),
+    ).resolves.toBe(0);
+    expect(mockPreloadImages).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reject when the native preload fails', async () => {
+    mockPreloadImages.mockRejectedValue(new Error('nitro unavailable'));
+    await expect(startColdStartImagePrewarm({ snapshot })).resolves.toBe(1);
   });
 });

--- a/packages/kit/src/utils/coldStartImagePreload.test.ts
+++ b/packages/kit/src/utils/coldStartImagePreload.test.ts
@@ -181,6 +181,36 @@ describe('coldStartImagePreload header network logos (OK-61505)', () => {
     expect(mockGetWithTimestamp).not.toHaveBeenCalled();
   });
 
+  it('reads only the home scene slot 0, even when other scenes come first', () => {
+    const items = getColdStartCriticalImageItemsFromSnapshot({
+      [`store:accountSelector@swap::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom}`]:
+        {
+          0: {
+            network: { id: 'btc--0', logoURI: btcNetworkLogoUri },
+            wallet: { id: HD_WALLET_ID },
+          },
+          1: {
+            network: { id: 'sol--101', logoURI: solNetworkLogoUri },
+            wallet: { id: HD_WALLET_ID },
+          },
+        },
+      [activeAccountsKey]: {
+        0: {
+          network: { id: 'evm--1', logoURI: ethNetworkLogoUri },
+          wallet: { id: HD_WALLET_ID },
+        },
+        1: {
+          network: { id: 'sol--101', logoURI: solNetworkLogoUri },
+          wallet: { id: HD_WALLET_ID },
+        },
+      },
+    });
+
+    expect(items).toEqual([
+      { uri: ethNetworkLogoUri, resizeWidth: HEADER_NETWORK_LOGO_SIZE },
+    ]);
+  });
+
   it('lists header logos at the header size ahead of token logos', () => {
     const items = getColdStartImageUrisFromSnapshot({
       ...snapshot,

--- a/packages/kit/src/utils/coldStartImagePreload.ts
+++ b/packages/kit/src/utils/coldStartImagePreload.ts
@@ -9,6 +9,7 @@ import {
   swrCacheUtils,
   swrKeys,
 } from '@onekeyhq/shared/src/utils/swrCacheUtils';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
   type ITokenSize,
@@ -58,6 +59,11 @@ const WALLET_BANNER_IMAGE_LIMIT = 8;
 // resize URL + decode thumbnail as the first paint.
 export const HEADER_NETWORK_LOGO_SIZE = s(24);
 const HEADER_NETWORK_LOGO_LIMIT = 6;
+// Cold-start scope key of the home account-selector store (see
+// jotaiContextStore.buildJotaiContextStoreId: `store:accountSelector@<scene>`),
+// the same key SplashProvider / HomeOverviewContainer read.
+const HOME_ACCOUNT_SELECTOR_COLD_START_SCOPE_KEY = `store:accountSelector@${EAccountSelectorSceneName.home}`;
+const HOME_ACCOUNT_SELECTOR_NUM = '0';
 // AllNetworksManagerTrigger shows at most this many network avatars.
 const HEADER_ALL_NETWORKS_AVATAR_LIMIT = 2;
 const WALLET_TOKEN_OWNER_LIMIT = 2;
@@ -327,20 +333,30 @@ function collectHeaderNetworkImageItems({
   snapshot: IColdStartSnapshot;
 }) {
   const seen = new Set<string>();
-  const add = (uri: unknown) =>
-    addPreloadItem({ items, seen, uri, resizeWidth: HEADER_NETWORK_LOGO_SIZE });
-  for (const value of getSnapshotValuesByColdStartKey({
-    snapshot,
-    coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom,
-  })) {
-    const activeAccounts = isRecord(value) ? Object.values(value) : [];
-    for (const activeAccount of activeAccounts) {
-      if (seen.size >= HEADER_NETWORK_LOGO_LIMIT) {
-        return;
-      }
-      collectHeaderNetworkImageItemsFromActiveAccount({ activeAccount, add });
+  const add = (uri: unknown) => {
+    if (seen.size < HEADER_NETWORK_LOGO_LIMIT) {
+      addPreloadItem({
+        items,
+        seen,
+        uri,
+        resizeWidth: HEADER_NETWORK_LOGO_SIZE,
+      });
     }
+  };
+  // Only the home scene's slot 0 paints in the header on the first frame;
+  // other account-selector scenes (swap, perps, ...) also persist this atom
+  // but must not spend the critical prewarm budget.
+  const value =
+    snapshot[
+      `${HOME_ACCOUNT_SELECTOR_COLD_START_SCOPE_KEY}::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom}`
+    ];
+  if (!isRecord(value)) {
+    return;
   }
+  collectHeaderNetworkImageItemsFromActiveAccount({
+    activeAccount: value[HOME_ACCOUNT_SELECTOR_NUM],
+    add,
+  });
 }
 
 function collectWalletTokenImageUris({

--- a/packages/kit/src/utils/coldStartImagePreload.ts
+++ b/packages/kit/src/utils/coldStartImagePreload.ts
@@ -2,8 +2,13 @@ import { preloadImages } from '@onekeyhq/components/src/primitives/Image/preload
 import { s } from '@onekeyhq/components/src/utils/scale';
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { getHyperliquidTokenImageUris } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  swrCacheUtils,
+  swrKeys,
+} from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
 import {
   type ITokenSize,
@@ -48,6 +53,13 @@ const COLD_START_IMAGE_PRELOAD_LIMIT = 96;
 // same resize URL + decode thumbnail as the first paint (cache-key match).
 export const WALLET_BANNER_IMAGE_SIZE = 56;
 const WALLET_BANNER_IMAGE_LIMIT = 8;
+// Logical size of the network avatar in the home header trigger (`$6`).
+// NetworkAvatar renders at this size, so the prewarm resolves to the same
+// resize URL + decode thumbnail as the first paint.
+export const HEADER_NETWORK_LOGO_SIZE = s(24);
+const HEADER_NETWORK_LOGO_LIMIT = 6;
+// AllNetworksManagerTrigger shows at most this many network avatars.
+const HEADER_ALL_NETWORKS_AVATAR_LIMIT = 2;
 const WALLET_TOKEN_OWNER_LIMIT = 2;
 const WALLET_TOKEN_LIMIT_PER_OWNER = 24;
 const SWAP_POSITION_OWNER_LIMIT = 3;
@@ -221,6 +233,116 @@ function collectWalletBannerImageItems({
   }
 }
 
+function addPreloadItem({
+  items,
+  seen,
+  uri,
+  resizeWidth,
+}: {
+  items: IImagePreloadItem[];
+  seen: Set<string>;
+  uri: unknown;
+  resizeWidth: number;
+}) {
+  if (
+    typeof uri === 'string' &&
+    REMOTE_IMAGE_URI_RE.test(uri) &&
+    !seen.has(uri)
+  ) {
+    seen.add(uri);
+    items.push({ uri, resizeWidth });
+  }
+}
+
+function getSnapshotString(value: unknown) {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function collectHeaderNetworkImageItemsFromActiveAccount({
+  activeAccount,
+  add,
+}: {
+  activeAccount: unknown;
+  add: (uri: unknown) => void;
+}) {
+  if (!isRecord(activeAccount) || !isRecord(activeAccount.network)) {
+    return;
+  }
+  const { network, wallet, indexedAccount } = activeAccount;
+  const networkId = getSnapshotString(network.id);
+  if (!networkId) {
+    return;
+  }
+  if (!networkUtils.isAllNetwork({ networkId })) {
+    // NetworkAvatar resolves the preset logo synchronously before the bg
+    // network lands, so warm that URL first.
+    add(networkUtils.getLocalNetworkInfo(networkId)?.logoURI);
+    add(network.logoURI);
+    return;
+  }
+  // Mirrors AllNetworksManagerTrigger: others wallets skip the compat query
+  // and render the static All Networks icon instead.
+  const walletId = isRecord(wallet) ? getSnapshotString(wallet.id) : undefined;
+  if (!walletId || accountUtils.isOthersWallet({ walletId })) {
+    return;
+  }
+  const compat = swrCacheUtils.getWithTimestamp<{
+    compatibleNetworks?: unknown;
+  }>(
+    swrKeys.allNetworksCompatible({
+      walletId,
+      networkId,
+      filterNetworksWithoutAccount: true,
+      indexedAccountId: isRecord(indexedAccount)
+        ? getSnapshotString(indexedAccount.id)
+        : undefined,
+      withNetworksInfo: false,
+      enabledNetworkIdsKey: '',
+    }),
+  )?.data;
+  const compatNetworks =
+    isRecord(compat) && Array.isArray(compat.compatibleNetworks)
+      ? compat.compatibleNetworks
+      : [];
+  for (const compatNetwork of compatNetworks.slice(
+    0,
+    HEADER_ALL_NETWORKS_AVATAR_LIMIT,
+  )) {
+    if (isRecord(compatNetwork)) {
+      add(compatNetwork.logoURI);
+    }
+  }
+}
+
+// Home header network trigger (OK-61505). Single-network mode paints the
+// active network logo, All Networks mode paints the first compat network
+// logos from the trigger's own swr snapshot. Both are remote CDN images
+// behind a blank placeholder, so a cold memory cache leaves a hole next to
+// the account name on the first frame.
+function collectHeaderNetworkImageItems({
+  items,
+  snapshot,
+}: {
+  items: IImagePreloadItem[];
+  snapshot: IColdStartSnapshot;
+}) {
+  const seen = new Set<string>();
+  const add = (uri: unknown) =>
+    addPreloadItem({ items, seen, uri, resizeWidth: HEADER_NETWORK_LOGO_SIZE });
+  for (const value of getSnapshotValuesByColdStartKey({
+    snapshot,
+    coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom,
+  })) {
+    const activeAccounts = isRecord(value) ? Object.values(value) : [];
+    for (const activeAccount of activeAccounts) {
+      if (seen.size >= HEADER_NETWORK_LOGO_LIMIT) {
+        return;
+      }
+      collectHeaderNetworkImageItemsFromActiveAccount({ activeAccount, add });
+    }
+  }
+}
+
 function collectWalletTokenImageUris({
   uris,
   snapshot,
@@ -374,22 +496,51 @@ function collectPerpsImageUris({
   }
 }
 
+// Images the home page paints on its very first frame: banner cards and the
+// header network trigger. Everything else in the snapshot is below the fold
+// or behind a tab and can finish loading after render.
+export function getColdStartCriticalImageItemsFromSnapshot(
+  snapshot = getColdStartSnapshot(),
+): IImagePreloadItem[] {
+  const items: IImagePreloadItem[] = [];
+  if (!snapshot) {
+    return items;
+  }
+  collectWalletBannerImageItems({ items, snapshot });
+  collectHeaderNetworkImageItems({ items, snapshot });
+  return items;
+}
+
+function collectColdStartImages(
+  snapshot: IColdStartSnapshot | undefined,
+  limit: number,
+) {
+  const uris = new Set<string>();
+  if (!snapshot) {
+    return { criticalItems: [], remainingUris: [] };
+  }
+  const criticalItems = getColdStartCriticalImageItemsFromSnapshot(snapshot);
+  collectWalletTokenImageUris({ uris, snapshot });
+  collectSwapImageUris({ uris, snapshot });
+  collectPerpsImageUris({ uris, snapshot });
+  return {
+    criticalItems: criticalItems.slice(0, limit),
+    remainingUris: [...uris].slice(
+      0,
+      Math.max(limit - criticalItems.length, 0),
+    ),
+  };
+}
+
 export function getColdStartImageUrisFromSnapshot(
   snapshot = getColdStartSnapshot(),
   limit = COLD_START_IMAGE_PRELOAD_LIMIT,
 ): IImagePreloadInput[] {
-  const bannerItems: IImagePreloadItem[] = [];
-  const uris = new Set<string>();
-  if (!snapshot) {
-    return [];
-  }
-
-  collectWalletBannerImageItems({ items: bannerItems, snapshot });
-  collectWalletTokenImageUris({ uris, snapshot });
-  collectSwapImageUris({ uris, snapshot });
-  collectPerpsImageUris({ uris, snapshot });
-
-  return [...bannerItems, ...uris].slice(0, limit);
+  const { criticalItems, remainingUris } = collectColdStartImages(
+    snapshot,
+    limit,
+  );
+  return [...criticalItems, ...remainingUris];
 }
 
 export function getPerpsTokenSelectorImageUrisFromItems({
@@ -465,6 +616,39 @@ export async function prewarmColdStartImagesFromSnapshot(
     getColdStartImageUrisFromSnapshot(options.snapshot, options.limit),
     options,
   );
+}
+
+let coldStartCriticalImagesTask: Promise<number> | undefined;
+
+// Two batches: the first-paint critical subset is awaitable through
+// `waitForColdStartCriticalImages`, the rest is fire-and-forget. Native calls
+// this from the storage bootstrap and awaits the critical batch (bounded)
+// before mounting the app, so the home header/banner images hit the memory
+// cache on their first layout instead of flashing a skeleton (OK-61505).
+export function startColdStartImagePrewarm({
+  snapshot = getColdStartSnapshot(),
+  limit = COLD_START_IMAGE_PRELOAD_LIMIT,
+}: {
+  snapshot?: IColdStartSnapshot;
+  limit?: number;
+} = {}): Promise<number> {
+  const { criticalItems, remainingUris } = collectColdStartImages(
+    snapshot,
+    limit,
+  );
+  const critical = prewarmImageUris(criticalItems, {
+    awaitPreload: true,
+    limit: criticalItems.length,
+  }).catch(() => 0);
+  if (remainingUris.length) {
+    void prewarmImageUris(remainingUris, { limit: remainingUris.length });
+  }
+  coldStartCriticalImagesTask = critical;
+  return critical;
+}
+
+export function waitForColdStartCriticalImages(): Promise<number> {
+  return coldStartCriticalImagesTask ?? startColdStartImagePrewarm();
 }
 
 export function prewarmPerpsTokenSelectorImages(

--- a/packages/kit/src/views/FiatCrypto/hooks/index.test.tsx
+++ b/packages/kit/src/views/FiatCrypto/hooks/index.test.tsx
@@ -3,7 +3,10 @@
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
   default: {
-    serviceFiatCrypto: { getTokensListWithNetworks: jest.fn() },
+    serviceFiatCrypto: {
+      getTokensListWithNetworks: jest.fn(),
+      isNetworkSupported: jest.fn(),
+    },
   },
 }));
 
@@ -17,7 +20,7 @@ jest.mock('@onekeyhq/kit/src/states/jotai/contexts/tokenList/cells', () => ({
 }));
 
 jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
-  const state: { options?: { swrKey?: string } } = {};
+  const state: { options?: { swrKey?: string; initResult?: unknown } } = {};
   (
     globalThis as unknown as {
       __fiatCryptoPromiseResultMock: typeof state;
@@ -36,13 +39,15 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
   };
 });
 
-import { useGetTokensListWithNetworks } from '.';
+import { useGetTokensListWithNetworks, useSupportNetworkId } from '.';
 
 import { renderHook } from '@testing-library/react-native';
 
 const promiseResultMock = (
   globalThis as unknown as {
-    __fiatCryptoPromiseResultMock: { options?: { swrKey?: string } };
+    __fiatCryptoPromiseResultMock: {
+      options?: { swrKey?: string; initResult?: unknown };
+    };
   }
 ).__fiatCryptoPromiseResultMock;
 
@@ -104,6 +109,29 @@ describe('useGetTokensListWithNetworks cache identity', () => {
         accountId: ACCOUNT_ID,
       }),
     );
+
+    expect(promiseResultMock.options?.swrKey).toBeUndefined();
+  });
+});
+
+describe('useSupportNetworkId cache identity (OK-61505)', () => {
+  beforeEach(() => {
+    promiseResultMock.options = undefined;
+  });
+
+  it('snapshots the buy/sell support flag per network and type', () => {
+    // The home Buy/Sell entry is fail-closed on this flag; without a
+    // snapshot every cold start paints it greyed until fiat-pay/list lands.
+    renderHook(() => useSupportNetworkId('sell', 'evm--1'));
+
+    expect(promiseResultMock.options?.swrKey).toBe(
+      'fiatCryptoNetSupport:v1:evm--1:sell',
+    );
+    expect(promiseResultMock.options?.initResult).toBe(false);
+  });
+
+  it('does not snapshot before the active network is known', () => {
+    renderHook(() => useSupportNetworkId('buy', undefined));
 
     expect(promiseResultMock.options?.swrKey).toBeUndefined();
   });

--- a/packages/kit/src/views/FiatCrypto/hooks/index.ts
+++ b/packages/kit/src/views/FiatCrypto/hooks/index.ts
@@ -35,6 +35,11 @@ export const useSupportNetworkId = (
     {
       initResult: false,
       debounced: 100,
+      // Last known answer paints on the first frame; the live check still
+      // runs and corrects it (OK-61505).
+      swrKey: networkId
+        ? swrKeys.fiatCryptoNetworkSupport({ networkId, type })
+        : undefined,
     },
   );
 

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -86,6 +86,7 @@ import {
   isWalletListResolvedNoWallet,
   shouldShowNoWalletContent,
 } from './homePageNoWalletContent';
+import { isHomeTabActive, useHomeTabFreeze } from './homeTabFreeze';
 import { NFTListContainerWithProvider } from './NFTListContainer';
 import { PerpsContainer } from './PerpsContainer';
 import { PortfolioContainerWithProvider } from './PortfolioContainer';
@@ -194,19 +195,27 @@ function HomeTabContentMaxWidth({ children }: { children: React.ReactNode }) {
 // Freezing the inactive panes drops that work back to the focused tab
 // only, which is what visibly happens already and matches the
 // freeze-on-blur strategy used at the outer tab-navigator level.
+//
+// Timing matters on native: a frozen pane renders nothing, and the pager
+// flips `focusedTab` half-way through its slide. Freezing the outgoing pane
+// at that instant blanks it mid-animation, and a target pane that is still
+// frozen cannot take the tab view's scroll-offset sync (the header then
+// snaps to the wrong collapse state once it thaws). So the pressed target
+// thaws on the tab press itself, and blur only freezes after a delay.
 function FreezeInactiveHomeTab({
   tabName,
+  pressedTabName,
   children,
 }: {
   tabName: string;
+  pressedTabName: string;
   children: React.ReactNode;
 }) {
   const focusedTab = useFocusedTab();
-  return (
-    <DelayedFreeze freeze={focusedTab ? focusedTab !== tabName : undefined}>
-      {children}
-    </DelayedFreeze>
+  const frozen = useHomeTabFreeze(
+    isHomeTabActive({ tabName, focusedTab, pressedTabName }),
   );
+  return <DelayedFreeze freeze={frozen}>{children}</DelayedFreeze>;
 }
 
 export function HomePageView({
@@ -919,7 +928,10 @@ export function HomePageView({
       >
         {pagerTabConfigs.map((tab) => (
           <Tabs.Tab key={tab.name} name={tab.name}>
-            <FreezeInactiveHomeTab tabName={tab.name}>
+            <FreezeInactiveHomeTab
+              tabName={tab.name}
+              pressedTabName={activeTabName}
+            >
               {platformEnv.isNative ||
               tab.id === EHomeWalletTab.Perps ||
               activeTabId === tab.id ||

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -968,9 +968,15 @@ export function HomePageView({
         switchToPerpsWebTab();
         return;
       }
-      const name = tabConfigs.find((i) => i.id === payload.id)?.name;
-      if (name) {
-        tabsRef.current?.jumpToTab(name);
+      const nextTab = tabConfigs.find((i) => i.id === payload.id);
+      if (nextTab) {
+        // Same press-ahead update as the tab bar: the target pane must thaw
+        // before the pager starts sliding towards it (see
+        // FreezeInactiveHomeTab).
+        setActiveTabName(nextTab.name);
+        setActiveTabId(nextTab.id);
+        lastDisplayableTabNameRef.current = nextTab.name;
+        tabsRef.current?.jumpToTab(nextTab.name);
       }
     },
     [perpTabShowWeb, switchToPerpsWebTab, tabConfigs],

--- a/packages/kit/src/views/Home/pages/homeTabFreeze.test.tsx
+++ b/packages/kit/src/views/Home/pages/homeTabFreeze.test.tsx
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import {
+  HOME_TAB_FREEZE_DELAY_MS,
+  isHomeTabActive,
+  useHomeTabFreeze,
+} from './homeTabFreeze';
+
+describe('isHomeTabActive', () => {
+  it('never freezes before the pager reports a focused tab', () => {
+    expect(
+      isHomeTabActive({ tabName: 'Perps', focusedTab: '', pressedTabName: '' }),
+    ).toBe(true);
+  });
+
+  it('keeps the focused tab and the pressed target active', () => {
+    expect(
+      isHomeTabActive({
+        tabName: 'Spot',
+        focusedTab: 'Spot',
+        pressedTabName: 'Perps',
+      }),
+    ).toBe(true);
+    // The tab-bar press lands before the pager flips focus; the target must
+    // be rendered while the pager slides towards it.
+    expect(
+      isHomeTabActive({
+        tabName: 'Perps',
+        focusedTab: 'Spot',
+        pressedTabName: 'Perps',
+      }),
+    ).toBe(true);
+    expect(
+      isHomeTabActive({
+        tabName: 'DeFi',
+        focusedTab: 'Spot',
+        pressedTabName: 'Perps',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('useHomeTabFreeze', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('unfreezes immediately and freezes only after the switch settles', () => {
+    const { result, rerender } = renderHook(
+      ({ isActive }: { isActive: boolean }) => useHomeTabFreeze(isActive),
+      { initialProps: { isActive: true } },
+    );
+    expect(result.current).toBe(false);
+
+    rerender({ isActive: false });
+    // Still visible while the pager slides away from it.
+    expect(result.current).toBe(false);
+    act(() => {
+      jest.advanceTimersByTime(HOME_TAB_FREEZE_DELAY_MS - 1);
+    });
+    expect(result.current).toBe(false);
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+
+    rerender({ isActive: true });
+    expect(result.current).toBe(false);
+  });
+
+  it('cancels a pending freeze when the tab regains focus in time', () => {
+    const { result, rerender } = renderHook(
+      ({ isActive }: { isActive: boolean }) => useHomeTabFreeze(isActive),
+      { initialProps: { isActive: true } },
+    );
+    rerender({ isActive: false });
+    act(() => {
+      jest.advanceTimersByTime(HOME_TAB_FREEZE_DELAY_MS / 2);
+    });
+    rerender({ isActive: true });
+    act(() => {
+      jest.advanceTimersByTime(HOME_TAB_FREEZE_DELAY_MS * 2);
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Home/pages/homeTabFreeze.test.tsx
+++ b/packages/kit/src/views/Home/pages/homeTabFreeze.test.tsx
@@ -71,6 +71,17 @@ describe('useHomeTabFreeze', () => {
     expect(result.current).toBe(false);
   });
 
+  it('freezes a pane that mounts inactive without waiting for the delay', () => {
+    const { result, rerender } = renderHook(
+      ({ isActive }: { isActive: boolean }) => useHomeTabFreeze(isActive),
+      { initialProps: { isActive: false } },
+    );
+    expect(result.current).toBe(true);
+
+    rerender({ isActive: true });
+    expect(result.current).toBe(false);
+  });
+
   it('cancels a pending freeze when the tab regains focus in time', () => {
     const { result, rerender } = renderHook(
       ({ isActive }: { isActive: boolean }) => useHomeTabFreeze(isActive),

--- a/packages/kit/src/views/Home/pages/homeTabFreeze.ts
+++ b/packages/kit/src/views/Home/pages/homeTabFreeze.ts
@@ -24,8 +24,10 @@ export function isHomeTabActive({
 
 // `true` while the pane should be frozen. Unfreezing is immediate; freezing
 // waits HOME_TAB_FREEZE_DELAY_MS so the pane survives the pager animation.
+// Panes that mount inactive were never visible, so they freeze right away
+// instead of paying a full render for nothing.
 export function useHomeTabFreeze(isActive: boolean) {
-  const [frozen, setFrozen] = useState(false);
+  const [frozen, setFrozen] = useState(() => !isActive);
   useEffect(() => {
     if (isActive) {
       setFrozen(false);

--- a/packages/kit/src/views/Home/pages/homeTabFreeze.ts
+++ b/packages/kit/src/views/Home/pages/homeTabFreeze.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+// How long an inactive home tab pane stays rendered after it loses focus.
+// The collapsible tab pager slides for ~300 ms and keeps re-syncing the new
+// tab's scroll offset for ~250 ms after the index flips (which happens at the
+// half-way point of the slide). Freezing before that leaves the pane the user
+// is sliding away from blank mid-animation.
+export const HOME_TAB_FREEZE_DELAY_MS = 500;
+
+export function isHomeTabActive({
+  tabName,
+  focusedTab,
+  pressedTabName,
+}: {
+  tabName: string;
+  focusedTab: string | undefined;
+  pressedTabName: string | undefined;
+}) {
+  if (!focusedTab) {
+    return true;
+  }
+  return focusedTab === tabName || pressedTabName === tabName;
+}
+
+// `true` while the pane should be frozen. Unfreezing is immediate; freezing
+// waits HOME_TAB_FREEZE_DELAY_MS so the pane survives the pager animation.
+export function useHomeTabFreeze(isActive: boolean) {
+  const [frozen, setFrozen] = useState(false);
+  useEffect(() => {
+    if (isActive) {
+      setFrozen(false);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setFrozen(true);
+    }, HOME_TAB_FREEZE_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [isActive]);
+  return isActive ? false : frozen;
+}

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -778,6 +778,7 @@ const NS = {
   earnAccount: 'earnAccount',
   earnProtocolDetail: 'earnProtocolDetail',
   fiatCryptoTokenList: 'fiatCryptoTokenList',
+  fiatCryptoNetworkSupport: 'fiatCryptoNetSupport',
   bulkSendAddressesInputSeed: 'bulkSendSeed',
   bulkCopyAddressesWallets: 'bulkCopyWallets',
   bulkCopyAddressesNetworkIds: 'bulkCopyNetIds',
@@ -1321,6 +1322,17 @@ export const swrKeys = {
     accountId?: string;
   }) =>
     [NS.fiatCryptoTokenList, 'v1', networkId, type, accountId ?? ''].join(':'),
+  // "Does this network have any buy/sell fiat token" flag behind the home
+  // Buy/Sell entry. The entry is fail-closed on it, so without a snapshot
+  // every cold start paints it disabled until fiat-pay/list returns
+  // (OK-61505). Network + type only: the bg check takes no account input.
+  fiatCryptoNetworkSupport: ({
+    networkId,
+    type,
+  }: {
+    networkId: string;
+    type: string;
+  }) => [NS.fiatCryptoNetworkSupport, 'v1', networkId, type].join(':'),
   bulkSendAddressesInputSeed: ({
     networkId,
     accountId,


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-61505](<https://onekeyhq.atlassian.net/browse/OK-61505>) [OK-62565](<https://onekeyhq.atlassian.net/browse/OK-62565>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary
- Native cold start: read the contextAtom snapshot after the travel-mode runtime launch is acknowledged, prime the first-paint home images (banner cards + header network logos) before the app mounts, and snapshot the fiat buy/sell support flag so the home entry paints enabled on the first frame (OK-61505).
- Native home header: resolve the All Networks trigger statically instead of through a lazy chunk (OK-61505).
- Home tabs: keep the outgoing pane rendered across the pager slide and thaw the pressed target on the tab press, so switching tabs no longer blanks the content area or snaps the collapsible header (OK-62565).

## Intent & Context
QA reopened OK-61505 on the 6.6 TestFlight build: after #13218 the tab row no longer reflowed, but on every cold start the banner image still showed a skeleton behind already-rendered text, the Buy/Sell entry painted later than Send/Receive, and the header network selector painted last. The guiding rule is that on a second launch every element already has a snapshot and must paint from it on the first frame.

OK-62565 reported slow in-page tab switches (especially to History) with a fully blank content area for up to ~2 s; the same mechanism also makes the collapsible header jump between collapsed and expanded when switching Spot/Perps.

## Root Cause
- **Snapshot never read at bootstrap.** Since the mobile travel mode landed (#13185), every synchronous storage read is masked (returns `undefined`) until `completeTravelModeRuntimeLaunchAcknowledgement` runs. `bootstrapNativeStorage` read the contextAtom snapshot before that step, so `__ONEKEY_CTX_ATOM_SNAPSHOT__`, `warmCriticalIcons`, and the banner prewarm from #13218 silently never ran on native. Provider hydration still worked through its storage fallback, which hid the breakage. Confirmed on the iOS simulator: the bootstrap log line never appeared and the image prime reported 0 images.
- **Image prime was fire-and-forget and gated in the wrong place.** `GlobalJotaiReady` only runs its prime when jotai is not yet ready; on native the app mounts after jotai hydration, so that gate never executed. `prewarmColdStartImagesFromSnapshot` also defaulted to `awaitPreload: false`. The native `OneKeyImage` shows the skeleton unless the SDWebImage memory cache already holds the key, so the images must be decoded before the first layout.
- **Buy/Sell entry.** `useSupportNetworkId` used `initResult: false` + a 100 ms debounce + an HTTP `fiat-pay/list` round trip with no swr snapshot, and the entry is fail-closed on it, so every cold start painted it disabled until the response landed.
- **Network selector.** In All Networks mode the header renders `LazyAllNetworksManagerTrigger` (dynamic import, `fallback = null`); the compat avatars are remote CDN logos that were not part of the cold-start prewarm.
- **Tab switch blank + header jump.** `FreezeInactiveHomeTab` freezes inactive panes with react-freeze (renders nothing). The collapsible tab view flips `focusedTab` half-way through the pager slide, so the outgoing pane vanished mid-animation while the incoming pane was still frozen; a frozen target list also ignores the tab view's scroll-offset sync, so the header snapped to the target's stale collapse state after it thawed. The half-way flip is upstream library behavior at every patch revision, not a #13218 regression.

## Design Decisions
- Snapshot hydration moved into `hydrateColdStartSnapshotAfterRuntimeLaunch`, called from `NativeStorageBootstrapRoot` between the runtime-launch acknowledgement and jotai init, with `[StartupTiming]` file-log lines for both the hydration and the image prime so device runs can be verified from `app-latest.log`.
- `startColdStartImagePrewarm` splits the prewarm into a critical batch (banner images at 56, header network logos at `s(24)` — matching the `$6` avatar size and therefore the same TOS resize URL and decode thumbnail) that is awaitable, and a fire-and-forget remainder. `waitForColdStartCriticalImagesBeforeMount` waits at most 300 ms; on a warm disk cache the batch finishes during jotai init (measured 0–1 ms of added wait), and a first-ever launch has no snapshot and therefore nothing to wait for.
- Header logos in All Networks mode are read from the trigger's own `allNetCompat` swr entry using the same key inputs as `AllNetworksManagerTrigger`, so the prewarmed URLs are exactly what the first frame requests.
- `LazyAllNetworksManagerTrigger.native.tsx` re-exports the static component; native ships a single bundle so the lazy chunk only added a Suspense fallback frame. Web keeps the split chunk. The module-id registry was updated for the new file.
- `useSupportNetworkId` gets `swrKeys.fiatCryptoNetworkSupport` keyed by network + type (the bg check takes no account input); the live check still runs and corrects the snapshot.
- `homeTabFreeze.ts`: the pressed target (already tracked as `activeTabName` on the tab-bar press) counts as active immediately, and blur freezes only after 500 ms, covering the ~300 ms slide plus the tab view's ~250 ms scroll-sync window. Swipe gestures still thaw the target at the half-way flip; that path is unchanged.

## Changes Detail
- `apps/mobile/src/backgroundThread/bootstrapNativeStorage.ts`, `NativeStorageBootstrapRoot.tsx` (+ tests): snapshot hydration after runtime launch, bounded critical-image wait before mount, file logging.
- `packages/kit/src/utils/coldStartImagePreload.ts` (+ test): header network logo collector, critical/remainder split, `startColdStartImagePrewarm` / `waitForColdStartCriticalImages`.
- `packages/kit/src/views/FiatCrypto/hooks/index.ts`, `packages/shared/src/utils/swrCacheUtils.ts` (+ test): fiat network-support swr key.
- `packages/kit/src/components/AccountSelector/LazyAllNetworksManagerTrigger.native.tsx`, `apps/mobile/bundle-registry/module-id-registry.json`: static native trigger.
- `packages/kit/src/views/Home/pages/HomePageView.tsx`, `homeTabFreeze.ts` (+ test): press-aware delayed freeze for home tab panes.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS/Android); the fiat swr key and tab freeze timing also apply to Desktop / Web / Extension home.
- **Risk Areas**: native bootstrap ordering (snapshot read now sits between runtime-launch acknowledgement and jotai init; a failure there is caught and logged, never fatal); the 300 ms mount wait on launches with a snapshot but a cold image disk cache; inactive home panes now stay mounted 500 ms longer after blur.

## Test plan
- [x] Unit tests: cold-start prewarm split and header logo collection, fiat swr key identity, bootstrap ordering, home tab freeze timing.
- [x] iOS simulator (iPhone 17 Pro) cold start, single-network and All Networks: banner images, enabled Buy/Sell entry, header network avatars and all five tabs present on the first painted frame; `app-latest.log` shows `snapshot hydrated: 14 keys` and `critical images done: 9–10 images, waited ≤1ms`.
- [x] iOS simulator tab switches Spot ⇄ Perps with expanded and collapsed header: both panes visible during the slide, no blank frame, header position unchanged, Spot list keeps its scroll offset.
- [ ] Device (iOS TestFlight) re-test of OK-61505 and the OK-62565 History switch on a slow JS thread.


[OK-61505]: https://onekeyhq.atlassian.net/browse/OK-61505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62565]: https://onekeyhq.atlassian.net/browse/OK-62565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ