### PR TITLE
fix: iPad onboarding v2 real-width breakpoints and recycled view autoresizing (OK-62575)

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -71,6 +71,13 @@ declare global {
   var $$onekeyDisabledSetTimeout: boolean | undefined;
   var $$onekeyDisabledSetInterval: boolean | undefined;
 
+  // Native-only bridge to the patched Tamagui media driver
+  // (patches/@tamagui+web+*.patch). See
+  // packages/components/src/hooks/nativeTabletRealWidthMedia.native.ts
+  var $$onekeyNativeMedia:
+    | { useRealWidth: boolean; refresh?: () => void }
+    | undefined;
+
   // defined in preload-html-head.js, check ext html bootstrap timeline:
   //      window.$$onekeyPerfTrace.timeline
   var $$onekeyPerfTrace: IOneKeyPerfTrace | undefined;

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -487,7 +487,19 @@ function DialogFrame({
               {...floatingPanelProps}
               zIndex={floatingPanelProps?.zIndex || zIndex}
             >
-              {renderDialogContent}
+              {platformEnv.isNative ? (
+                // Native only: the centered frame sits in an absolute-fill
+                // Stack, so Yoga measures its subtree in AtMost mode and any
+                // `flex: 1` child (e.g. ListItem's Pressable wrapper) collapses
+                // to zero height and overlaps its siblings. A ScrollView
+                // measures its content unconstrained (overflow: scroll), which
+                // restores content sizing and also lets tall content scroll.
+                <ScrollView bounces={false} keyboardShouldPersistTaps="handled">
+                  {renderDialogContent}
+                </ScrollView>
+              ) : (
+                renderDialogContent
+              )}
             </TMDialog.Content>
           </Stack>
         ) : null}

--- a/packages/components/src/hooks/index.tsx
+++ b/packages/components/src/hooks/index.tsx
@@ -20,3 +20,4 @@ export * from './useUpdateEffect';
 export * from './useVisibilityChange';
 export * from './useSplitView';
 export * from './useIsTablet';
+export * from './nativeTabletRealWidthMedia';

--- a/packages/components/src/hooks/index.web-only.tsx
+++ b/packages/components/src/hooks/index.web-only.tsx
@@ -19,3 +19,4 @@ export * from './useUpdateEffect';
 export * from './useVisibilityChange';
 export * from './useSplitView';
 export * from './useIsTablet';
+export * from './nativeTabletRealWidthMedia';

--- a/packages/components/src/hooks/nativeTabletRealWidthMedia.native.ts
+++ b/packages/components/src/hooks/nativeTabletRealWidthMedia.native.ts
@@ -1,0 +1,39 @@
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+// The patched Tamagui native media driver (patches/@tamagui+web+*.patch) clamps
+// tablets to phone breakpoints because tab pages live in a half-width
+// split-view pane. Full-screen surfaces such as onboarding v2 are not inside a
+// pane, so they hold real window-width breakpoints for their lifetime.
+// Ref-counted so overlapping holders never release early.
+let holders = 0;
+
+function syncNativeMedia(useRealWidth: boolean) {
+  const control =
+    globalThis.$$onekeyNativeMedia ??
+    (globalThis.$$onekeyNativeMedia = { useRealWidth: false });
+  if (control.useRealWidth === useRealWidth) {
+    return;
+  }
+  control.useRealWidth = useRealWidth;
+  control.refresh?.();
+}
+
+export function acquireNativeTabletRealWidthMedia() {
+  if (!platformEnv.isNativeIOSPad) {
+    return;
+  }
+  holders += 1;
+  if (holders === 1) {
+    syncNativeMedia(true);
+  }
+}
+
+export function releaseNativeTabletRealWidthMedia() {
+  if (!platformEnv.isNativeIOSPad) {
+    return;
+  }
+  holders = Math.max(0, holders - 1);
+  if (holders === 0) {
+    syncNativeMedia(false);
+  }
+}

--- a/packages/components/src/hooks/nativeTabletRealWidthMedia.ts
+++ b/packages/components/src/hooks/nativeTabletRealWidthMedia.ts
@@ -1,0 +1,5 @@
+// Only the native media driver clamps tablet breakpoints; see the .native.ts
+// variant. Other platforms already evaluate the real window width.
+export function acquireNativeTabletRealWidthMedia() {}
+
+export function releaseNativeTabletRealWidthMedia() {}

--- a/packages/kit/src/routes/Modal/Navigator.tsx
+++ b/packages/kit/src/routes/Modal/Navigator.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 import { useIsFocused } from '@react-navigation/native';
 
 import {
   EPageType,
   Theme,
+  acquireNativeTabletRealWidthMedia,
+  releaseNativeTabletRealWidthMedia,
   setGlassHeaderUIStyle,
   useThemeName,
 } from '@onekeyhq/components';
@@ -45,6 +47,17 @@ export function FullScreenPushNavigator() {
 }
 
 export function OnboardingNavigator() {
+  // Onboarding is full-screen (never inside a split-view pane), so iPad
+  // evaluates breakpoints against the real window width for as long as this
+  // root route lives. Layout effect, not passive: the switch must land before
+  // the first paint, otherwise iPad paints the phone layout and re-lays out
+  // everything mid-transition, which leaves animated views with stale frames.
+  useLayoutEffect(() => {
+    acquireNativeTabletRealWidthMedia();
+    return () => {
+      releaseNativeTabletRealWidthMedia();
+    };
+  }, []);
   // Onboarding forces a dark Theme for its content, so the iOS 26 glass header
   // bar must use the dark variant while onboarding is the foreground route —
   // otherwise it flashes the light variant (the app theme is usually light).

--- a/packages/kit/src/routes/Modal/Navigator.tsx
+++ b/packages/kit/src/routes/Modal/Navigator.tsx
@@ -47,17 +47,24 @@ export function FullScreenPushNavigator() {
 }
 
 export function OnboardingNavigator() {
+  const isFocused = useIsFocused();
   // Onboarding is full-screen (never inside a split-view pane), so iPad
-  // evaluates breakpoints against the real window width for as long as this
-  // root route lives. Layout effect, not passive: the switch must land before
-  // the first paint, otherwise iPad paints the phone layout and re-lays out
-  // everything mid-transition, which leaves animated views with stale frames.
+  // evaluates breakpoints against the real window width while this root route
+  // is in the foreground. The flag is global to the UI runtime, so it is held
+  // for the focused lifetime only: a V1 modal pushed on top, or the main tab
+  // tree after onboarding is replaced, must get the clamped breakpoints their
+  // narrower containers were designed for. Layout effect, not passive: the
+  // switch must land before the first paint, otherwise iPad paints the phone
+  // layout and re-lays out everything mid-transition.
   useLayoutEffect(() => {
+    if (!isFocused) {
+      return undefined;
+    }
     acquireNativeTabletRealWidthMedia();
     return () => {
       releaseNativeTabletRealWidthMedia();
     };
-  }, []);
+  }, [isFocused]);
   // Onboarding forces a dark Theme for its content, so the iOS 26 glass header
   // bar must use the dark variant while onboarding is the foreground route —
   // otherwise it flashes the light variant (the app theme is usually light).
@@ -71,7 +78,6 @@ export function OnboardingNavigator() {
   // tracks whoever is actually foreground; the unmount cleanup covers the
   // onboarding-replaced-by-main case where we never blur first.
   const appThemeName = useThemeName();
-  const isFocused = useIsFocused();
   const appGlassStyle = appThemeName === 'dark' ? 'dark' : 'light';
   if (platformEnv.isNativeIOS26Plus) {
     setGlassHeaderUIStyle(isFocused ? 'dark' : appGlassStyle);

--- a/patches/@onekeyfe+react-native-tab-view+3.0.78.patch
+++ b/patches/@onekeyfe+react-native-tab-view+3.0.78.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift b/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift
+index 0000000..0000000 100644
+--- a/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift
++++ b/node_modules/@onekeyfe/react-native-tab-view/ios/RCTTabViewContainerView.swift
+@@ -717,6 +717,10 @@
+       self.bottomAccessoryView = nil
+       return
+     }
++    // Fabric recycles this view for unrelated <View>s once it is unmounted.
++    // Leaving the flexible mask on would let UIKit autoresize it to whatever
++    // superview it lands in next (it showed up as page-sized "flakes").
++    child.autoresizingMask = []
+     childViews.remove(at: index)
+     rebuildViewControllers()
+   }

--- a/patches/@tamagui+web+1.108.0.patch
+++ b/patches/@tamagui+web+1.108.0.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js b/node_
 index 47addac..110de63 100644
 --- a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
 +++ b/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
-@@ -160,11 +160,98 @@ function unlisten() {
+@@ -160,22 +160,125 @@
    }), dispose.clear();
  }
  var setupVersion = -1;
@@ -11,6 +11,18 @@ index 47addac..110de63 100644
 +const ScreenOrientation = require('expo-screen-orientation');
 +const { Dimensions } = require('react-native');
 +const { ReactNativeDeviceUtils } = require('@onekeyfe/react-native-device-utils');
++
++// OneKey: full-screen surfaces (onboarding v2) opt out of the tablet clamp so
++// iPad evaluates breakpoints against the real window width. App code flips
++// `useRealWidth` and calls `refresh()`; see
++// packages/components/src/hooks/nativeTabletRealWidthMedia.native.ts.
++const nativeMediaControl =
++  globalThis.$$onekeyNativeMedia ||
++  (globalThis.$$onekeyNativeMedia = { useRealWidth: false });
++let mediaUpdaters = [];
++nativeMediaControl.refresh = function () {
++  mediaUpdaters.forEach((update) => update());
++};
 +
 +// Orientation constants from expo-screen-orientation
 +const ORIENTATION_LANDSCAPE_LEFT = 3;
@@ -55,6 +67,10 @@ index 47addac..110de63 100644
 +  if (isDualScreenDevice() && ReactNativeDeviceUtils.isSpanning()) {
 +    // DualScreen device in spanning mode: use half screen width for media queries
 +    callback({ shouldOverride: true, overrideWidth: getHalfScreenWidth() });
++  } else if (nativeMediaControl.useRealWidth) {
++    // Full-screen surface opted out of the tablet/Android clamp: keep the raw
++    // matchMedia result computed from the real window width.
++    callback({ shouldOverride: false, overrideWidth: null });
 +  } else if (ExpoDevice.deviceType === ExpoDevice.DeviceType.TABLET) {
 +    // Tablet: check if landscape (spanning layout)
 +    isLandscapeOrientation((isLandscape) => {
@@ -102,3 +118,16 @@ index 47addac..110de63 100644
      }, str = mediaObjectToString(mediaQueryConfig[key2], key2), getMatch = function() {
        return (0, import_matchMedia.matchMedia)(str);
      }, match = getMatch();
+     if (!match)
+       throw new Error("\u26A0\uFE0F No match");
+-    match.addListener(update), dispose.add(function() {
++    mediaUpdaters.push(update), match.addListener(update), dispose.add(function() {
+       match.removeListener(update);
+     }), update();
+   };
+   if (!(import_constants.isWeb && import_constants.isServer) && setupVersion !== mediaVersion) {
+-    setupVersion = mediaVersion, unlisten();
++    setupVersion = mediaVersion, unlisten(), mediaUpdaters = [];
+     for (var key in mediaQueryConfig) _loop(key);
+   }
+ }

--- a/patches/@tamagui+web+1.108.0.patch
+++ b/patches/@tamagui+web+1.108.0.patch
@@ -2,13 +2,12 @@ diff --git a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js b/node_
 index 47addac..110de63 100644
 --- a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
 +++ b/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
-@@ -160,22 +160,125 @@
+@@ -160,22 +160,116 @@
    }), dispose.clear();
  }
  var setupVersion = -1;
 +
 +const ExpoDevice = require('expo-device');
-+const ScreenOrientation = require('expo-screen-orientation');
 +const { Dimensions } = require('react-native');
 +const { ReactNativeDeviceUtils } = require('@onekeyfe/react-native-device-utils');
 +
@@ -24,10 +23,6 @@ index 47addac..110de63 100644
 +  mediaUpdaters.forEach((update) => update());
 +};
 +
-+// Orientation constants from expo-screen-orientation
-+const ORIENTATION_LANDSCAPE_LEFT = 3;
-+const ORIENTATION_LANDSCAPE_RIGHT = 4;
-+
 +// Check if device is a DualScreen device
 +let isDualScreen;
 +function isDualScreenDevice() {
@@ -37,13 +32,13 @@ index 47addac..110de63 100644
 +  return isDualScreen;
 +}
 +
-+// Check if current orientation is landscape using expo-screen-orientation
-+function isLandscapeOrientation(callback) {
-+  ScreenOrientation.getOrientationAsync().then((orientation) => {
-+    const isLandscape = orientation === ORIENTATION_LANDSCAPE_LEFT ||
-+                        orientation === ORIENTATION_LANDSCAPE_RIGHT;
-+    callback(isLandscape);
-+  });
++// Landscape is derived from the window size rather than an async orientation
++// query: every caller runs from a Dimensions/orientation change or from
++// refresh(), and a late async result could overwrite a mode switch made in
++// between (e.g. onboarding acquiring/releasing real-width breakpoints).
++function isLandscapeWindow() {
++  const { width, height } = Dimensions.get('window');
++  return width > height;
 +}
 +
 +const MAX_OVERRIDE_WIDTH = 767;
@@ -72,15 +67,11 @@ index 47addac..110de63 100644
 +    // matchMedia result computed from the real window width.
 +    callback({ shouldOverride: false, overrideWidth: null });
 +  } else if (ExpoDevice.deviceType === ExpoDevice.DeviceType.TABLET) {
-+    // Tablet: check if landscape (spanning layout)
-+    isLandscapeOrientation((isLandscape) => {
-+      if (isLandscape) {
-+        // Tablet landscape: use half screen width for media queries
-+        callback({ shouldOverride: true, overrideWidth: getHalfScreenWidth() });
-+      } else {
-+        // Tablet portrait: simulate md-level width (md=true, gtMd=false)
-+        callback({ shouldOverride: true, overrideWidth: getScreenWidth() });
-+      }
++    // Tablet landscape (split-view pane): half screen width; portrait: clamp to
++    // md-level width. Synchronous so refresh() settles mediaState before paint.
++    callback({
++      shouldOverride: true,
++      overrideWidth: isLandscapeWindow() ? getHalfScreenWidth() : getScreenWidth(),
 +    });
 +  } else if (import_constants.isAndroid) {
 +    // Non-spanning layout + Android: simulate md-level width

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -556,11 +556,23 @@ diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View
 index a99f103..27865c2 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
 +++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
-@@ -828,6 +828,19 @@ - (UIView *)currentContainerView
- }
+@@ -603,6 +603,12 @@
+ {
+   [super prepareForRecycle];
+ 
++  // Native containers (e.g. a UITabBarController host) may stamp a flexible
++  // autoresizingMask on child component views. This view is recycled for
++  // unrelated <View>s afterwards, and UIKit would autoresize it to whatever
++  // superview it lands in, so clear the mask with the rest of the UIKit state.
++  self.autoresizingMask = UIViewAutoresizingNone;
++
+   // If view was managed by animated, its props need to align with UIView's properties.
+   const auto &props = static_cast<const ViewProps &>(*_props);
+   if ([_propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN containsObject:@"transform"]) {
+@@ -829,6 +835,19 @@
  
  - (void)invalidateLayer
-+{
+ {
 +  // During modal transition, prevent backgroundColor and layer changes from being animated.
 +  extern BOOL RNSModalTransitionInProgress;
 +  if (RNSModalTransitionInProgress) {
@@ -573,9 +585,10 @@ index a99f103..27865c2 100644
 +}
 +
 +- (void)_invalidateLayerImpl
- {
++{
    CALayer *layer = self.layer;
  
+   if (CGSizeEqualToSize(layer.bounds.size, CGSizeZero)) {
 diff --git a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm b/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
 index 9f50554..23eaaa8 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62575](<https://onekeyhq.atlassian.net/browse/OK-62575>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary

Onboarding v2 on iPad rendered the phone (`md`) layout in every orientation, and once the desktop-style layout was enabled a set of native-only rendering bugs surfaced (overlapping list items in dialogs, page-sized coloured slabs in the confetti, CTA / step rows filling their container). This PR makes onboarding v2 evaluate breakpoints against the real window width on iPad and fixes the native issues that path exposed.

## Root causes

1. **iPad never reaches `gtMd`.** `patches/@tamagui+web+1.108.0.patch` clamps tablets to `MAX_OVERRIDE_WIDTH = 767` (landscape: `width / 2`, portrait: `min(width, 767)`) because tab pages live in a half-width split-view pane. Onboarding is full-screen, so the clamp is wrong there. `useMedia().gtMd` and every `$gtMd` prop were `false` on iPad regardless of orientation.
2. **Native centered `Dialog` path was dead code on native.** It sits in an absolute-fill `Stack`, so Yoga measures the subtree in AtMost mode and `ListItem`'s `Pressable` (`flex: 1`) collapses to zero height; rows overlap ("Pick your device" dialog).
3. **Recycled Fabric views kept a flexible `autoresizingMask`.** `@onekeyfe/react-native-tab-view` stamps `autoresizingMask = [.flexibleWidth, .flexibleHeight]` on its React child views. `RCTViewComponentView.prepareForRecycle` does not reset the mask, so after the home (split view + tabs) re-lays out under onboarding, those views enter the recycle pool and are reused by unrelated `<View>`s, which UIKit then autoresizes to whatever superview they land in. Confirmed with an lldb `recursiveDescription` dump: exactly the oversized views carried `autoresize = W+H`; Yoga sizes were correct.

## Changes

- `patches/@tamagui+web+1.108.0.patch`: adds `globalThis.$$onekeyNativeMedia.useRealWidth` bypass (dual-screen spanning branch unchanged) and a `refresh()` hook that re-evaluates every media key.
- `packages/components/src/hooks/nativeTabletRealWidthMedia{.native,}.ts`: ref-counted `acquire/releaseNativeTabletRealWidthMedia()`, active only on `isNativeIOSPad` (Android tablets intentionally excluded). Global type in `@types/globals.d.ts`.
- `packages/kit/src/routes/Modal/Navigator.tsx`: `OnboardingNavigator` acquires it in a layout effect, so the first painted frame of every onboarding v2 page is already `gtMd` (covers all entry points; several v2 pages use no shared shell).
- `packages/components/src/composite/Dialog/index.tsx`: native centered dialog wraps its content in a `ScrollView` (unconstrained measurement, and tall content can scroll). Native + `gtMd` only.
- `patches/@onekeyfe+react-native-tab-view+3.0.78.patch` (new): clear the child's `autoresizingMask` in `removeChild(atIndex:)`. Needs to be upstreamed to the package.
- `patches/react-native+0.81.5.patch`: `RCTViewComponentView.prepareForRecycle` resets `autoresizingMask` as defense in depth.

Native rebuild required (two native patches).

## Verification

iPad Pro 11-inch (M5) simulator, iOS 26.5, Debug build:
- GetStarted shows the three-card layout, Terms left-aligned, language selector with label.
- "Pick your device" → Other Brands dialog renders two distinct rows.
- Check & Update: genuine + firmware success, confetti, Continue — restarted the app 3 times × 3 full runs, no oversized views.
- iPhone behaviour unchanged (the bypass is a no-op below 768pt).

## Follow-ups

- Upstream the `removeChild` mask reset to `@onekeyfe/react-native-tab-view`.
- When porting to `x` (tamagui 2.7.7) the tablet clamp lives in `patches/@tamagui+react-native-media-driver+2.7.7.patch` (`getMediaDimensions()`); the bypass has to be applied there.
- The onboarding-time media switch still re-lays out the hidden home underneath; acceptable for now, revisit if it shows up in profiling.


[OK-62575]: https://onekeyhq.atlassian.net/browse/OK-62575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ