### PR TITLE
fix: resolve DeFi and Swap bugs (OK-62540, OK-62542, OK-62543, OK-62552, OK-62556)

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -23055,6 +23055,7 @@
     "packages/kit/src/views/Swap/components/SwapTxHistoryListCell.tsx": 13598,
     "packages/kit/src/views/Swap/components/TransactionLossNetworkFeeExceedDialog.tsx": 7797,
     "packages/kit/src/views/Swap/hooks/swapBroadcastSuccess.ts": 11528,
+    "packages/kit/src/views/Swap/hooks/swapNavigationUtils.ts": 1591,
     "packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts": 4525,
     "packages/kit/src/views/Swap/hooks/swapStockFiatValueUtils.ts": 24306,
     "packages/kit/src/views/Swap/hooks/swapStockPayTokenUtils.ts": 7275,

--- a/packages/kit/src/provider/Container/InAppNotification/index.tsx
+++ b/packages/kit/src/provider/Container/InAppNotification/index.tsx
@@ -43,6 +43,7 @@ import { useDebouncedCallback } from '../../../hooks/useDebounce';
 import { runAfterTokensDone } from '../../../hooks/useRunAfterTokensDone';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector/atoms';
 import { whenAppUnlocked } from '../../../utils/passwordUtils';
+import { isSwapApprovalFlowActive } from '../../../views/Swap/hooks/swapNavigationUtils';
 import { handleSwapNavigation } from '../../../views/Swap/hooks/useSwapNavigation';
 
 const InAppNotification = () => {
@@ -303,10 +304,22 @@ const InAppNotification = () => {
           });
         }
         handleSwapNavigation(
-          ({ isInSwapTab, isHasSwapModal, isSwapModalOnTheTop, hasModal }) => {
+          ({
+            isInSwapTab,
+            isInMarketEmbeddedSwap,
+            isHasSwapModal,
+            isSwapModalOnTheTop,
+            hasModal,
+          }) => {
             if (
-              (isInSwapTab && !hasModal) ||
-              (!isInSwapTab && isSwapModalOnTheTop && isHasSwapModal)
+              isSwapApprovalFlowActive({
+                isInSwapTab,
+                isInMarketEmbeddedSwap,
+                isHasSwapModal,
+                isSwapModalOnTheTop,
+                hasModal,
+                swapSource: swapApprovingTransactionRef.current?.swapSource,
+              })
             ) {
               if (swapApprovingTransactionRef.current) {
                 appEventBus.emit(EAppEventBusNames.SwapApprovingSuccess, {

--- a/packages/kit/src/provider/Container/InAppNotification/index.tsx
+++ b/packages/kit/src/provider/Container/InAppNotification/index.tsx
@@ -306,7 +306,7 @@ const InAppNotification = () => {
         handleSwapNavigation(
           ({
             isInSwapTab,
-            isInMarketEmbeddedSwap,
+            isInMarketDetail,
             isHasSwapModal,
             isSwapModalOnTheTop,
             hasModal,
@@ -314,11 +314,12 @@ const InAppNotification = () => {
             if (
               isSwapApprovalFlowActive({
                 isInSwapTab,
-                isInMarketEmbeddedSwap,
+                isInMarketDetail,
                 isHasSwapModal,
                 isSwapModalOnTheTop,
                 hasModal,
-                swapSource: swapApprovingTransactionRef.current?.swapSource,
+                marketSwapApprovalFlowId:
+                  swapApprovingTransactionRef.current?.marketSwapApprovalFlowId,
               })
             ) {
               if (swapApprovingTransactionRef.current) {

--- a/packages/kit/src/views/Borrow/components/CollateralSwitchCell.test.tsx
+++ b/packages/kit/src/views/Borrow/components/CollateralSwitchCell.test.tsx
@@ -166,6 +166,14 @@ const switchTestId = 'borrow-supplied-collateral-switch';
 const pendingSetCollateralTx = {
   stakingInfo: { tags: ['borrow:aave:setCollateral'] },
 };
+const scopedPendingSetCollateralTx = {
+  stakingInfo: {
+    tags: [
+      'borrow:aave:setCollateral',
+      'borrow:aave:setCollateral:v1:evm--1:0xmarket:0xusde',
+    ],
+  },
+};
 const successData = [
   {
     signedTx: { txid: '0xset-collateral' },
@@ -317,6 +325,12 @@ describe('CollateralSwitchCell settlement guard', () => {
         reserveAddress: '0xreserve',
         useAsCollateral: true,
         eModeId: 0,
+        stakingInfo: expect.objectContaining({
+          tags: expect.arrayContaining([
+            'borrow:aave:setCollateral',
+            'borrow:aave:setCollateral:v1:evm--1:0xmarket:0xreserve',
+          ]),
+        }),
       }),
     );
   });
@@ -368,6 +382,26 @@ describe('CollateralSwitchCell settlement guard', () => {
     );
 
     expect(getSwitch(view).props.disabled).toBe(true);
+  });
+
+  it('disables only the reserve matched by a scoped pending transaction', () => {
+    borrowContext.pendingTxs = [scopedPendingSetCollateralTx];
+
+    const matchingView = render(
+      <CollateralSwitchCell
+        item={createSuppliedAsset(true, '0xUsDe')}
+        eModeId={1}
+      />,
+    );
+    const siblingView = render(
+      <CollateralSwitchCell
+        item={createSuppliedAsset(true, '0xUsDt')}
+        eModeId={1}
+      />,
+    );
+
+    expect(getSwitch(matchingView).props.disabled).toBe(true);
+    expect(getSwitch(siblingView).props.disabled).toBe(false);
   });
 
   it('allows a successful preview that omits optional collateral eligibility', async () => {

--- a/packages/kit/src/views/Borrow/components/CollateralSwitchCell.tsx
+++ b/packages/kit/src/views/Borrow/components/CollateralSwitchCell.tsx
@@ -261,7 +261,13 @@ export function CollateralSwitchCell({
   );
   const confirmationScopeRef = useRef(renderedConfirmationScope);
   const pendingSetCollateral = market
-    ? hasPendingSetCollateral({ pendingTxs, provider: market.provider })
+    ? hasPendingSetCollateral({
+        pendingTxs,
+        provider: market.provider,
+        networkId: market.networkId,
+        marketAddress: market.marketAddress,
+        reserveAddress: item.reserveAddress,
+      })
     : false;
   const requiresEModeId =
     market?.provider.toLowerCase() === EBorrowProviderEnum.Aave;
@@ -535,6 +541,15 @@ export function CollateralSwitchCell({
               buildBorrowTag({
                 provider: market.provider,
                 action: 'setCollateral',
+              }),
+              buildBorrowTag({
+                provider: market.provider,
+                action: 'setCollateral',
+                setCollateralScope: {
+                  networkId: market.networkId,
+                  marketAddress: market.marketAddress,
+                  reserveAddress: item.reserveAddress,
+                },
               }),
             ],
           },

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.test.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.test.ts
@@ -1,10 +1,34 @@
+import { shouldUseAaveNativeGateway } from '../../borrowRepayPosition.utils';
 import {
+  isManagePositionRepayAll,
   isSamePositiveAmount,
   resolveBorrowRepayAllBalance,
   resolveRepayAllAmountValue,
 } from '../utils';
 
 describe('useManagePositionState utils', () => {
+  it.each(['evm--1', 'evm--8453'])(
+    'preserves Aave native repay-all on %s',
+    (networkId) => {
+      expect(
+        shouldUseAaveNativeGateway({
+          networkId,
+          providerName: 'aave',
+          reserveAddress: '',
+        }),
+      ).toBe(true);
+      expect(
+        isManagePositionRepayAll({
+          action: 'repay',
+          amount: '0.000057570716602455',
+          debtBalance: '0.000057570716602455',
+          maxAmountValue: '0.000057570716602455',
+          repayAllBalance: '0.000057570716602455',
+        }),
+      ).toBe(true);
+    },
+  );
+
   it('uses full debt balance instead of wallet max balance for repayAll', () => {
     const repayAllAmount = resolveRepayAllAmountValue({
       action: 'repay',

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.ts
@@ -4,14 +4,10 @@ import BigNumber from 'bignumber.js';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import {
-  isBorrowRepayAllAmount,
-  shouldDowngradeAaveNativeRepayAll,
-} from '@onekeyhq/kit/src/views/Borrow/components/borrowRepayPosition.utils';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
-import { isSamePositiveAmount, resolveRepayAllAmountValue } from '../utils';
+import { isManagePositionRepayAll, isSamePositiveAmount } from '../utils';
 
 import type { IManagePositionProps, IManagePositionState } from '../types';
 
@@ -104,56 +100,23 @@ export function useManagePositionState(props: IManagePositionProps): {
     });
   }, [props.action, amountValue, maxAmountValue]);
 
-  const repayAllAmountValue = useMemo(
+  const isRepayAll = useMemo(
     () =>
-      resolveRepayAllAmountValue({
+      isManagePositionRepayAll({
         action: props.action,
+        amount: amountValue,
+        debtBalance: props.debtBalance,
         maxAmountValue,
         repayAllBalance: props.repayAllBalance,
       }),
-    [props.action, maxAmountValue, props.repayAllBalance],
-  );
-
-  const shouldDowngradeRepayAll = useMemo(
-    () =>
-      shouldDowngradeAaveNativeRepayAll({
-        action: props.action,
-        networkId: props.networkId,
-        providerName: props.providerName,
-        reserveAddress: props.borrowReserveAddress,
-      }),
     [
       props.action,
-      props.borrowReserveAddress,
-      props.networkId,
-      props.providerName,
+      props.debtBalance,
+      props.repayAllBalance,
+      amountValue,
+      maxAmountValue,
     ],
   );
-
-  const isRepayAll = useMemo(() => {
-    if (props.action !== 'repay') return false;
-    if (shouldDowngradeRepayAll) return false;
-    if (
-      props.repayAllBalance === undefined &&
-      props.debtBalance !== undefined
-    ) {
-      return isBorrowRepayAllAmount({
-        amount: amountValue,
-        debtBalance: props.debtBalance,
-      });
-    }
-    return isSamePositiveAmount({
-      amount: amountValue,
-      targetAmount: repayAllAmountValue,
-    });
-  }, [
-    props.action,
-    props.debtBalance,
-    props.repayAllBalance,
-    amountValue,
-    repayAllAmountValue,
-    shouldDowngradeRepayAll,
-  ]);
 
   const state: Omit<
     IManagePositionState,

--- a/packages/kit/src/views/Borrow/components/ManagePosition/utils.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/utils.ts
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js';
 
+import { isBorrowRepayAllAmount } from '@onekeyhq/kit/src/views/Borrow/components/borrowRepayPosition.utils';
+
 import type { IManagePositionProps } from './types';
 
 type IBorrowRepayAllReserveAsset = {
@@ -66,6 +68,33 @@ export function resolveRepayAllAmountValue({
   return action === 'repay'
     ? (repayAllBalance ?? maxAmountValue)
     : maxAmountValue;
+}
+
+export function isManagePositionRepayAll({
+  action,
+  amount,
+  debtBalance,
+  maxAmountValue,
+  repayAllBalance,
+}: {
+  action: IManagePositionProps['action'];
+  amount: string;
+  debtBalance?: string;
+  maxAmountValue: string;
+  repayAllBalance?: string;
+}) {
+  if (action !== 'repay') return false;
+  if (repayAllBalance === undefined && debtBalance !== undefined) {
+    return isBorrowRepayAllAmount({ amount, debtBalance });
+  }
+  return isSamePositiveAmount({
+    amount,
+    targetAmount: resolveRepayAllAmountValue({
+      action,
+      maxAmountValue,
+      repayAllBalance,
+    }),
+  });
 }
 
 export function resolveBorrowRepayAllBalance({

--- a/packages/kit/src/views/Borrow/components/borrowRepayPosition.utils.ts
+++ b/packages/kit/src/views/Borrow/components/borrowRepayPosition.utils.ts
@@ -236,27 +236,6 @@ export function buildAaveNativeGatewayReceiveToken({
   } as IToken;
 }
 
-export function shouldDowngradeAaveNativeRepayAll({
-  action,
-  networkId,
-  providerName,
-  reserveAddress,
-}: {
-  action?: string;
-  networkId?: string;
-  providerName?: string;
-  reserveAddress?: string;
-}) {
-  return (
-    action === 'repay' &&
-    shouldUseAaveNativeGateway({
-      networkId,
-      providerName,
-      reserveAddress,
-    })
-  );
-}
-
 export function resolveBorrowTokenApproveSpenderAddress({
   providerName,
   marketAddress,

--- a/packages/kit/src/views/Borrow/components/collateralControls.utils.test.ts
+++ b/packages/kit/src/views/Borrow/components/collateralControls.utils.test.ts
@@ -155,6 +155,27 @@ describe('hasPendingSetCollateral', () => {
     ).toBe(false);
   });
 
+  it('isolates a native reserve with an empty address from sibling rows', () => {
+    const nativeTag = 'borrow:aave:setCollateral:v1:evm--1:0xmarket:';
+
+    expect(
+      hasPendingSetCollateral({
+        pendingTxs: [tx(['borrow:aave:setCollateral', nativeTag])],
+        provider: 'aave',
+        ...scope,
+        reserveAddress: '',
+      }),
+    ).toBe(true);
+    expect(
+      hasPendingSetCollateral({
+        pendingTxs: [tx(['borrow:aave:setCollateral', nativeTag])],
+        provider: 'aave',
+        ...scope,
+        reserveAddress: '0xusdt',
+      }),
+    ).toBe(false);
+  });
+
   it('normalizes EVM market and reserve address casing', () => {
     expect(
       hasPendingSetCollateral({

--- a/packages/kit/src/views/Borrow/components/collateralControls.utils.test.ts
+++ b/packages/kit/src/views/Borrow/components/collateralControls.utils.test.ts
@@ -103,7 +103,7 @@ describe('getCollateralSwitchState', () => {
     ).toBe(true);
   });
 
-  it('a provider-level pending setCollateral tx disables the row', () => {
+  it('a matching pending setCollateral tx disables the row', () => {
     expect(
       getCollateralSwitchState({
         usageAsCollateral: true,
@@ -117,21 +117,68 @@ describe('getCollateralSwitchState', () => {
 
 describe('hasPendingSetCollateral', () => {
   const tx = (tags?: string[]) => ({ stakingInfo: { tags } });
+  const scope = {
+    networkId: 'evm--1',
+    marketAddress: '0xmarket',
+    reserveAddress: '0xusde',
+  };
 
-  it('matches a pending setCollateral tx for the provider', () => {
+  it('matches a reserve-scoped pending setCollateral tx', () => {
     expect(
       hasPendingSetCollateral({
-        pendingTxs: [tx(['Borrow', 'borrow:aave:setCollateral'])],
+        pendingTxs: [
+          tx([
+            'Borrow',
+            'borrow:aave:setCollateral',
+            'borrow:aave:setCollateral:v1:evm--1:0xmarket:0xusde',
+          ]),
+        ],
         provider: 'aave',
+        ...scope,
       }),
     ).toBe(true);
   });
 
-  it('matches case-insensitively on provider (tag builder lowercases)', () => {
+  it('does not match another reserve from the same provider', () => {
+    expect(
+      hasPendingSetCollateral({
+        pendingTxs: [
+          tx([
+            'borrow:aave:setCollateral',
+            'borrow:aave:setCollateral:v1:evm--1:0xmarket:0xusde',
+          ]),
+        ],
+        provider: 'Aave',
+        ...scope,
+        reserveAddress: '0xusdt',
+      }),
+    ).toBe(false);
+  });
+
+  it('normalizes EVM market and reserve address casing', () => {
+    expect(
+      hasPendingSetCollateral({
+        pendingTxs: [
+          tx([
+            'borrow:aave:setCollateral',
+            'borrow:aave:setCollateral:v1:evm--1:0xmarket:0xusde',
+          ]),
+        ],
+        provider: 'Aave',
+        ...scope,
+        marketAddress: '0xMaRkEt',
+        reserveAddress: '0xUsDe',
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the provider-wide lock for a legacy pending tx', () => {
     expect(
       hasPendingSetCollateral({
         pendingTxs: [tx(['borrow:aave:setCollateral'])],
-        provider: 'Aave',
+        provider: 'aave',
+        ...scope,
+        reserveAddress: '0xusdt',
       }),
     ).toBe(true);
   });
@@ -145,14 +192,19 @@ describe('hasPendingSetCollateral', () => {
           tx(undefined),
         ],
         provider: 'aave',
+        ...scope,
       }),
     ).toBe(false);
   });
 
   it('is false with no pending txs', () => {
-    expect(hasPendingSetCollateral({ pendingTxs: [], provider: 'aave' })).toBe(
-      false,
-    );
+    expect(
+      hasPendingSetCollateral({
+        pendingTxs: [],
+        provider: 'aave',
+        ...scope,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/kit/src/views/Borrow/components/collateralControls.utils.ts
+++ b/packages/kit/src/views/Borrow/components/collateralControls.utils.ts
@@ -1,4 +1,7 @@
-import { buildBorrowTag } from '@onekeyhq/kit/src/views/Staking/utils/utils';
+import {
+  buildBorrowTag,
+  parseBorrowTag,
+} from '@onekeyhq/kit/src/views/Staking/utils/utils';
 
 // Pure predicates for the Borrow collateral/borrowable controls.
 // Client composes server-owned flags without duplicating health-factor math.
@@ -100,16 +103,42 @@ export function getCollateralSettlementRefreshDecision({
   return 'retry';
 }
 
-// buildBorrowTag carries provider+action only (no reserve identity), so this
-// check is provider-scoped by construction: any pending setCollateral tx
-// disables ALL of that provider's switches until data refreshes.
 export function hasPendingSetCollateral({
   pendingTxs,
   provider,
+  networkId,
+  marketAddress,
+  reserveAddress,
 }: {
   pendingTxs: { stakingInfo: { tags?: string[] } }[];
   provider: string;
+  networkId: string;
+  marketAddress: string;
+  reserveAddress: string;
 }): boolean {
-  const tag = buildBorrowTag({ provider, action: 'setCollateral' });
-  return pendingTxs.some((tx) => tx.stakingInfo.tags?.includes(tag));
+  const providerTag = buildBorrowTag({ provider, action: 'setCollateral' });
+  const reserveTag = buildBorrowTag({
+    provider,
+    action: 'setCollateral',
+    setCollateralScope: { networkId, marketAddress, reserveAddress },
+  });
+
+  return pendingTxs.some((tx) => {
+    const tags = tx.stakingInfo.tags ?? [];
+    const hasReserveScopedTag = tags.some((tag) => {
+      const parsed = parseBorrowTag(tag);
+      return (
+        parsed?.provider === provider.toLowerCase() &&
+        parsed.action === 'setCollateral' &&
+        parsed.setCollateralScope !== undefined
+      );
+    });
+
+    // Older pending entries do not identify the reserve. Keep their original
+    // provider-wide lock until they settle; newly created entries use the
+    // exact reserve tag and no longer affect sibling switches.
+    return hasReserveScopedTag
+      ? tags.includes(reserveTag)
+      : tags.includes(providerTag);
+  });
 }

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBarLayout.test.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBarLayout.test.ts
@@ -29,16 +29,17 @@ describe('buildStackedBarSegments', () => {
     expect(out[1]).toMatchObject({ key: 'b', flexBasis: 40 });
   });
 
-  it('formats the legend label as integer percent (no decimal)', () => {
+  it('uses the same one-decimal percentage as the tooltip', () => {
     const out = buildStackedBarSegments([slice('a', 12.7)]);
-    expect(out[0].label).toBe('13%');
+    expect(out[0].label).toBe('12.7%');
   });
 
-  it('rounds half-down values toward the nearest integer', () => {
-    const out = buildStackedBarSegments([slice('a', 12.4), slice('b', 12.5)]);
-    expect(out[0].label).toBe('12%');
-    // Math.round behavior: .5 rounds up.
-    expect(out[1].label).toBe('13%');
+  it('preserves small non-zero allocation labels', () => {
+    const out = buildStackedBarSegments([
+      slice('main', 99.8),
+      slice('others', 0.2, '$gray9', 0.04),
+    ]);
+    expect(out.map((segment) => segment.label)).toEqual(['99.8%', '0.2%']);
   });
 
   it('exposes colorToken and netWorth on the segment', () => {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBarLayout.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBarLayout.ts
@@ -1,3 +1,5 @@
+import { formatPortfolioPercent } from './formatPortfolioPercent';
+
 import type { IPortfolioSlice } from './DeFiPortfolioStats';
 
 export type IStackedBarSegment = {
@@ -6,8 +8,7 @@ export type IStackedBarSegment = {
    * the source of truth for the tooltip's one-decimal percent string. */
   flexBasis: number;
   colorToken: string;
-  /** Integer-percent label for legend use, e.g. "13%". Tooltip uses
-   * one-decimal precision via formatPortfolioPercent instead. */
+  /** Display label shared with the tooltip, e.g. "12.7%". */
   label: string;
   /** Source slice label, exposed for tooltips. */
   sliceLabel: string;
@@ -18,12 +19,6 @@ export type IStackedBarSegment = {
   networkIds: string[];
 };
 
-function formatLegendPercentLabel(p: number): string {
-  // Integer percent for legend density. The tooltip carries the
-  // one-decimal precision.
-  return `${Math.round(p)}%`;
-}
-
 export function buildStackedBarSegments(
   slices: IPortfolioSlice[],
 ): IStackedBarSegment[] {
@@ -31,7 +26,7 @@ export function buildStackedBarSegments(
     key: s.key,
     flexBasis: s.percent,
     colorToken: s.colorToken,
-    label: formatLegendPercentLabel(s.percent),
+    label: formatPortfolioPercent(s.percent, s.netWorth),
     sliceLabel: s.label,
     netWorth: s.netWorth,
     networkIds: s.networkIds,

--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
@@ -21,6 +21,7 @@ import {
   useTheme,
 } from '@onekeyhq/components';
 import type { IInputProps, IStackProps } from '@onekeyhq/components';
+import type { TamaguiElement } from '@onekeyhq/components/src/shared/tamagui';
 import { webFontFamily } from '@onekeyhq/components/src/utils/webFontFamily';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { NUMBER_FORMATTER } from '@onekeyhq/shared/src/utils/numberUtils';
@@ -161,6 +162,26 @@ const normalizeAutoSizeNativeColor = (color?: string): string | undefined => {
   return `#${aa}${rrggbb}`;
 };
 
+const getStableLayoutWidth = (
+  event: LayoutChangeEvent,
+  layoutTarget: TamaguiElement | null,
+): number => {
+  const measuredWidth = event.nativeEvent.layout.width;
+  if (platformEnv.isNative) {
+    return measuredWidth;
+  }
+
+  // React Native Web measures onLayout with getBoundingClientRect(), so an
+  // ancestor's entry scale leaks into the reported width. offsetWidth keeps
+  // auto-sizing tied to the transform-independent layout box.
+  const offsetWidth = (
+    layoutTarget as unknown as { offsetWidth?: unknown } | null
+  )?.offsetWidth;
+  return typeof offsetWidth === 'number' && offsetWidth > 0
+    ? offsetWidth
+    : measuredWidth;
+};
+
 export type ISendAmountAutoSizeInputRef = {
   focus: () => void;
   blur: () => void;
@@ -222,6 +243,7 @@ function SendAutoSizeAmountInputComponent(
   const placeholderColor = normalizeAutoSizeNativeColor(theme.textDisabled.val);
 
   const [layoutWidth, setLayoutWidth] = useState(0);
+  const layoutTargetRef = useRef<TamaguiElement | null>(null);
   const autoSizeInputRef = useRef<IAutoSizeInputRef | null>(null);
   const [forcedNativeText, setForcedNativeText] = useState<string | null>(null);
   const forceWriteBackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -312,7 +334,9 @@ function SendAutoSizeAmountInputComponent(
 
   const handleInputLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      const nextWidth = Math.round(event.nativeEvent.layout.width);
+      const nextWidth = Math.round(
+        getStableLayoutWidth(event, layoutTargetRef.current),
+      );
       if (nextWidth > 0) {
         setLayoutWidth((prev) => (prev === nextWidth ? prev : nextWidth));
       }
@@ -434,6 +458,7 @@ function SendAutoSizeAmountInputComponent(
 
   return (
     <Stack
+      ref={layoutTargetRef}
       alignItems="center"
       width="100%"
       {...rest}

--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
@@ -20,8 +20,7 @@ import {
   useMedia,
   useTheme,
 } from '@onekeyhq/components';
-import type { IInputProps, IStackProps } from '@onekeyhq/components';
-import type { TamaguiElement } from '@onekeyhq/components/src/shared/tamagui';
+import type { IElement, IInputProps, IStackProps } from '@onekeyhq/components';
 import { webFontFamily } from '@onekeyhq/components/src/utils/webFontFamily';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { NUMBER_FORMATTER } from '@onekeyhq/shared/src/utils/numberUtils';
@@ -164,7 +163,7 @@ const normalizeAutoSizeNativeColor = (color?: string): string | undefined => {
 
 const getStableLayoutWidth = (
   event: LayoutChangeEvent,
-  layoutTarget: TamaguiElement | null,
+  layoutTarget: IElement | null,
 ): number => {
   const measuredWidth = event.nativeEvent.layout.width;
   if (platformEnv.isNative) {
@@ -243,7 +242,7 @@ function SendAutoSizeAmountInputComponent(
   const placeholderColor = normalizeAutoSizeNativeColor(theme.textDisabled.val);
 
   const [layoutWidth, setLayoutWidth] = useState(0);
-  const layoutTargetRef = useRef<TamaguiElement | null>(null);
+  const layoutTargetRef = useRef<IElement | null>(null);
   const autoSizeInputRef = useRef<IAutoSizeInputRef | null>(null);
   const [forcedNativeText, setForcedNativeText] = useState<string | null>(null);
   const forceWriteBackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(

--- a/packages/kit/src/views/Staking/utils/utils.test.ts
+++ b/packages/kit/src/views/Staking/utils/utils.test.ts
@@ -95,4 +95,27 @@ describe('borrow set-collateral tags', () => {
       },
     });
   });
+
+  it('round-trips an empty native reserve address', () => {
+    const tag = buildBorrowTag({
+      provider: 'Aave',
+      action: 'setCollateral',
+      setCollateralScope: {
+        networkId: 'evm--1',
+        marketAddress: '0xAbCd',
+        reserveAddress: '',
+      },
+    });
+
+    expect(tag).toBe('borrow:aave:setCollateral:v1:evm--1:0xabcd:');
+    expect(parseBorrowTag(tag)).toEqual({
+      provider: 'aave',
+      action: 'setCollateral',
+      setCollateralScope: {
+        networkId: 'evm--1',
+        marketAddress: '0xabcd',
+        reserveAddress: '',
+      },
+    });
+  });
 });

--- a/packages/kit/src/views/Staking/utils/utils.test.ts
+++ b/packages/kit/src/views/Staking/utils/utils.test.ts
@@ -65,3 +65,34 @@ describe('borrow claim tags', () => {
     });
   });
 });
+
+describe('borrow set-collateral tags', () => {
+  it('preserves the provider-level tag when no reserve scope is provided', () => {
+    expect(buildBorrowTag({ provider: 'Aave', action: 'setCollateral' })).toBe(
+      'borrow:aave:setCollateral',
+    );
+  });
+
+  it('round-trips a versioned reserve scope and normalizes EVM addresses', () => {
+    const tag = buildBorrowTag({
+      provider: 'Aave',
+      action: 'setCollateral',
+      setCollateralScope: {
+        networkId: 'evm--1',
+        marketAddress: '0xAbCd',
+        reserveAddress: '0xDeF0',
+      },
+    });
+
+    expect(tag).toBe('borrow:aave:setCollateral:v1:evm--1:0xabcd:0xdef0');
+    expect(parseBorrowTag(tag)).toEqual({
+      provider: 'aave',
+      action: 'setCollateral',
+      setCollateralScope: {
+        networkId: 'evm--1',
+        marketAddress: '0xabcd',
+        reserveAddress: '0xdef0',
+      },
+    });
+  });
+});

--- a/packages/kit/src/views/Staking/utils/utils.ts
+++ b/packages/kit/src/views/Staking/utils/utils.ts
@@ -110,7 +110,7 @@ export const buildBorrowTag = ({
 };
 
 function decodeBorrowTagPart(value: string | undefined): string | undefined {
-  if (!value) {
+  if (value === undefined) {
     return undefined;
   }
   try {
@@ -166,7 +166,7 @@ export const parseBorrowTag = (
     parts[2] === 'setCollateral' &&
     setCollateralScopeNetworkId &&
     setCollateralScopeMarketAddress &&
-    setCollateralScopeReserveAddress
+    setCollateralScopeReserveAddress !== undefined
       ? normalizeBorrowSetCollateralScope({
           networkId: setCollateralScopeNetworkId,
           marketAddress: setCollateralScopeMarketAddress,

--- a/packages/kit/src/views/Staking/utils/utils.ts
+++ b/packages/kit/src/views/Staking/utils/utils.ts
@@ -5,6 +5,7 @@ import type { IEarnStakeType } from '@onekeyhq/shared/types/staking';
 
 const NATIVE_EARN_WRAPPED_ETH_SYMBOL = 'WETH';
 const BORROW_CLAIM_SCOPE_VERSION = 'v1';
+const BORROW_SET_COLLATERAL_SCOPE_VERSION = 'v1';
 
 function isNativeEarnEthSymbol(symbol?: string) {
   return symbol?.toUpperCase() === 'ETH';
@@ -26,8 +27,10 @@ export const buildLocalTxStatusSyncId = ({
   return baseTag;
 };
 
-// Borrow tag format:
-// borrow:{provider}:{action}[:claimIds[:v1:{networkId}:{marketAddress}]]
+// Borrow tag formats:
+// borrow:{provider}:{action}
+// borrow:{provider}:claim:{claimIds}[:v1:{networkId}:{marketAddress}]
+// borrow:{provider}:setCollateral:v1:{networkId}:{marketAddress}:{reserveAddress}
 export type IBorrowAction =
   | 'supply'
   | 'borrow'
@@ -42,6 +45,10 @@ export type IBorrowClaimScope = {
   marketAddress: string;
 };
 
+export type IBorrowSetCollateralScope = IBorrowClaimScope & {
+  reserveAddress: string;
+};
+
 export function normalizeBorrowMarketAddress({
   networkId,
   marketAddress,
@@ -51,16 +58,33 @@ export function normalizeBorrowMarketAddress({
     : marketAddress;
 }
 
+export function normalizeBorrowSetCollateralScope({
+  networkId,
+  marketAddress,
+  reserveAddress,
+}: IBorrowSetCollateralScope): IBorrowSetCollateralScope {
+  return {
+    networkId,
+    marketAddress: normalizeBorrowMarketAddress({ networkId, marketAddress }),
+    reserveAddress: normalizeBorrowMarketAddress({
+      networkId,
+      marketAddress: reserveAddress,
+    }),
+  };
+}
+
 export const buildBorrowTag = ({
   provider,
   action,
   claimIds,
   claimScope,
+  setCollateralScope,
 }: {
   provider: string;
   action: IBorrowAction;
   claimIds?: string[];
   claimScope?: IBorrowClaimScope;
+  setCollateralScope?: IBorrowSetCollateralScope;
 }): string => {
   const base = `borrow:${provider.toLowerCase()}:${action}`;
   if (action === 'claim' && claimIds?.length) {
@@ -72,6 +96,15 @@ export const buildBorrowTag = ({
       )}:${encodeURIComponent(marketAddress)}`;
     }
     return claimTag;
+  }
+  if (action === 'setCollateral' && setCollateralScope) {
+    const normalizedScope =
+      normalizeBorrowSetCollateralScope(setCollateralScope);
+    return `${base}:${BORROW_SET_COLLATERAL_SCOPE_VERSION}:${encodeURIComponent(
+      normalizedScope.networkId,
+    )}:${encodeURIComponent(
+      normalizedScope.marketAddress,
+    )}:${encodeURIComponent(normalizedScope.reserveAddress)}`;
   }
   return base;
 };
@@ -94,6 +127,7 @@ export const parseBorrowTag = (
   action: IBorrowAction;
   claimIds?: string[];
   claimScope?: IBorrowClaimScope;
+  setCollateralScope?: IBorrowSetCollateralScope;
 } | null => {
   if (!tag.startsWith('borrow:')) return null;
   const parts = tag.split(':');
@@ -116,11 +150,37 @@ export const parseBorrowTag = (
           }),
         }
       : undefined;
+  const setCollateralScopeNetworkId =
+    parts[3] === BORROW_SET_COLLATERAL_SCOPE_VERSION
+      ? decodeBorrowTagPart(parts[4])
+      : undefined;
+  const setCollateralScopeMarketAddress =
+    parts[3] === BORROW_SET_COLLATERAL_SCOPE_VERSION
+      ? decodeBorrowTagPart(parts[5])
+      : undefined;
+  const setCollateralScopeReserveAddress =
+    parts[3] === BORROW_SET_COLLATERAL_SCOPE_VERSION
+      ? decodeBorrowTagPart(parts[6])
+      : undefined;
+  const setCollateralScope =
+    parts[2] === 'setCollateral' &&
+    setCollateralScopeNetworkId &&
+    setCollateralScopeMarketAddress &&
+    setCollateralScopeReserveAddress
+      ? normalizeBorrowSetCollateralScope({
+          networkId: setCollateralScopeNetworkId,
+          marketAddress: setCollateralScopeMarketAddress,
+          reserveAddress: setCollateralScopeReserveAddress,
+        })
+      : undefined;
   return {
     provider: parts[1],
     action: parts[2] as IBorrowAction,
-    claimIds: parts[3]?.split(','),
+    ...(parts[2] === 'claim' && parts[3]
+      ? { claimIds: parts[3].split(',') }
+      : {}),
     ...(claimScope ? { claimScope } : {}),
+    ...(setCollateralScope ? { setCollateralScope } : {}),
   };
 };
 

--- a/packages/kit/src/views/Swap/hooks/swapNavigationUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapNavigationUtils.test.ts
@@ -1,14 +1,11 @@
-import { ETabMarketRoutes } from '@onekeyhq/shared/src/routes';
-import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
-
 import {
-  isMarketEmbeddedSwapRoute,
   isSwapApprovalFlowActive,
+  registerMarketSwapApprovalFlow,
 } from './swapNavigationUtils';
 
 const baseNavigationContext = {
   isInSwapTab: false,
-  isInMarketEmbeddedSwap: false,
+  isInMarketDetail: false,
   isHasSwapModal: false,
   isSwapModalOnTheTop: false,
   hasModal: false,
@@ -35,49 +32,61 @@ describe('isSwapApprovalFlowActive', () => {
     ).toBe(true);
   });
 
-  it('treats a Market approval as active behind its transaction modal', () => {
+  it('treats a mounted Market embedded approval flow as active', () => {
+    const unregister = registerMarketSwapApprovalFlow('market-flow-1');
     expect(
       isSwapApprovalFlowActive({
         ...baseNavigationContext,
-        isInMarketEmbeddedSwap: true,
+        isInMarketDetail: true,
         hasModal: true,
-        swapSource: ESwapSource.MARKET,
+        marketSwapApprovalFlowId: 'market-flow-1',
       }),
     ).toBe(true);
+    unregister();
   });
 
-  it('does not treat an unrelated Swap approval as active on Market', () => {
+  it('does not treat a Market modal approval as an embedded flow', () => {
     expect(
       isSwapApprovalFlowActive({
         ...baseNavigationContext,
-        isInMarketEmbeddedSwap: true,
+        isInMarketDetail: true,
         hasModal: true,
-        swapSource: ESwapSource.TAB,
       }),
     ).toBe(false);
   });
 
-  it('allows recovery after leaving the originating Market flow', () => {
+  it('allows recovery after the originating Market flow unmounts', () => {
+    const unregister = registerMarketSwapApprovalFlow('market-flow-1');
+    unregister();
     expect(
       isSwapApprovalFlowActive({
         ...baseNavigationContext,
         hasModal: true,
-        swapSource: ESwapSource.MARKET,
+        marketSwapApprovalFlowId: 'market-flow-1',
       }),
     ).toBe(false);
   });
-});
 
-describe('isMarketEmbeddedSwapRoute', () => {
-  it.each([
-    ETabMarketRoutes.MarketDetail,
-    ETabMarketRoutes.MarketDetailV2,
-    ETabMarketRoutes.MarketNativeDetail,
-  ])('recognizes the Market route that owns embedded Swap: %s', (routeName) => {
-    expect(isMarketEmbeddedSwapRoute(routeName)).toBe(true);
+  it('does not let another mounted Market flow consume the approval', () => {
+    const unregister = registerMarketSwapApprovalFlow('market-flow-2');
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        isInMarketDetail: true,
+        marketSwapApprovalFlowId: 'market-flow-1',
+      }),
+    ).toBe(false);
+    unregister();
   });
 
-  it('does not treat the Market home as an active embedded Swap flow', () => {
-    expect(isMarketEmbeddedSwapRoute(ETabMarketRoutes.TabMarket)).toBe(false);
+  it('allows recovery after switching away from a cached Market detail', () => {
+    const unregister = registerMarketSwapApprovalFlow('market-flow-1');
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        marketSwapApprovalFlowId: 'market-flow-1',
+      }),
+    ).toBe(false);
+    unregister();
   });
 });

--- a/packages/kit/src/views/Swap/hooks/swapNavigationUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapNavigationUtils.test.ts
@@ -1,0 +1,83 @@
+import { ETabMarketRoutes } from '@onekeyhq/shared/src/routes';
+import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
+
+import {
+  isMarketEmbeddedSwapRoute,
+  isSwapApprovalFlowActive,
+} from './swapNavigationUtils';
+
+const baseNavigationContext = {
+  isInSwapTab: false,
+  isInMarketEmbeddedSwap: false,
+  isHasSwapModal: false,
+  isSwapModalOnTheTop: false,
+  hasModal: false,
+};
+
+describe('isSwapApprovalFlowActive', () => {
+  it('keeps the existing active Swap page behavior', () => {
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        isInSwapTab: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the existing topmost Swap modal behavior', () => {
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        isHasSwapModal: true,
+        isSwapModalOnTheTop: true,
+        hasModal: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('treats a Market approval as active behind its transaction modal', () => {
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        isInMarketEmbeddedSwap: true,
+        hasModal: true,
+        swapSource: ESwapSource.MARKET,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat an unrelated Swap approval as active on Market', () => {
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        isInMarketEmbeddedSwap: true,
+        hasModal: true,
+        swapSource: ESwapSource.TAB,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows recovery after leaving the originating Market flow', () => {
+    expect(
+      isSwapApprovalFlowActive({
+        ...baseNavigationContext,
+        hasModal: true,
+        swapSource: ESwapSource.MARKET,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isMarketEmbeddedSwapRoute', () => {
+  it.each([
+    ETabMarketRoutes.MarketDetail,
+    ETabMarketRoutes.MarketDetailV2,
+    ETabMarketRoutes.MarketNativeDetail,
+  ])('recognizes the Market route that owns embedded Swap: %s', (routeName) => {
+    expect(isMarketEmbeddedSwapRoute(routeName)).toBe(true);
+  });
+
+  it('does not treat the Market home as an active embedded Swap flow', () => {
+    expect(isMarketEmbeddedSwapRoute(ETabMarketRoutes.TabMarket)).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Swap/hooks/swapNavigationUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapNavigationUtils.ts
@@ -1,33 +1,36 @@
-import { ETabMarketRoutes } from '@onekeyhq/shared/src/routes';
-import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
-
 export type ISwapNavigationContext = {
   isInSwapTab: boolean;
-  isInMarketEmbeddedSwap: boolean;
+  isInMarketDetail: boolean;
   isHasSwapModal: boolean;
   isSwapModalOnTheTop: boolean;
   hasModal: boolean;
 };
 
-export function isMarketEmbeddedSwapRoute(routeName?: string) {
-  return (
-    routeName === ETabMarketRoutes.MarketDetail ||
-    routeName === ETabMarketRoutes.MarketDetailV2 ||
-    routeName === ETabMarketRoutes.MarketNativeDetail
-  );
+const activeMarketSwapApprovalFlowIds = new Set<string>();
+
+export function registerMarketSwapApprovalFlow(flowId: string) {
+  activeMarketSwapApprovalFlowIds.add(flowId);
+  return () => {
+    activeMarketSwapApprovalFlowIds.delete(flowId);
+  };
+}
+
+export function isMarketSwapApprovalFlowMounted(flowId?: string) {
+  return Boolean(flowId && activeMarketSwapApprovalFlowIds.has(flowId));
 }
 
 export function isSwapApprovalFlowActive({
   isInSwapTab,
-  isInMarketEmbeddedSwap,
+  isInMarketDetail,
   isHasSwapModal,
   isSwapModalOnTheTop,
   hasModal,
-  swapSource,
-}: ISwapNavigationContext & { swapSource?: ESwapSource }) {
+  marketSwapApprovalFlowId,
+}: ISwapNavigationContext & { marketSwapApprovalFlowId?: string }) {
   return (
     (isInSwapTab && !hasModal) ||
     (!isInSwapTab && isSwapModalOnTheTop && isHasSwapModal) ||
-    (isInMarketEmbeddedSwap && swapSource === ESwapSource.MARKET)
+    (isInMarketDetail &&
+      isMarketSwapApprovalFlowMounted(marketSwapApprovalFlowId))
   );
 }

--- a/packages/kit/src/views/Swap/hooks/swapNavigationUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapNavigationUtils.ts
@@ -1,0 +1,33 @@
+import { ETabMarketRoutes } from '@onekeyhq/shared/src/routes';
+import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
+
+export type ISwapNavigationContext = {
+  isInSwapTab: boolean;
+  isInMarketEmbeddedSwap: boolean;
+  isHasSwapModal: boolean;
+  isSwapModalOnTheTop: boolean;
+  hasModal: boolean;
+};
+
+export function isMarketEmbeddedSwapRoute(routeName?: string) {
+  return (
+    routeName === ETabMarketRoutes.MarketDetail ||
+    routeName === ETabMarketRoutes.MarketDetailV2 ||
+    routeName === ETabMarketRoutes.MarketNativeDetail
+  );
+}
+
+export function isSwapApprovalFlowActive({
+  isInSwapTab,
+  isInMarketEmbeddedSwap,
+  isHasSwapModal,
+  isSwapModalOnTheTop,
+  hasModal,
+  swapSource,
+}: ISwapNavigationContext & { swapSource?: ESwapSource }) {
+  return (
+    (isInSwapTab && !hasModal) ||
+    (!isInSwapTab && isSwapModalOnTheTop && isHasSwapModal) ||
+    (isInMarketEmbeddedSwap && swapSource === ESwapSource.MARKET)
+  );
+}

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -84,6 +84,7 @@ import {
 } from '@onekeyhq/shared/types/staking';
 import type {
   ESwapCancelLimitOrderSource,
+  ESwapSource,
   IFetchBuildTxResponse,
   IFetchLimitOrderRes,
   IFetchQuoteResult,
@@ -215,6 +216,7 @@ type IEstimateNetworkFeeOptions = {
 
 type IUseSwapBuildTxOptions = {
   onSwapBroadcast?: () => void | Promise<void>;
+  swapSource?: ESwapSource;
 };
 
 type ISwapSignAndSendProgressEvent = {
@@ -265,6 +267,7 @@ function getSwapCreateFrom({
  */
 export function useSwapBuildTx({
   onSwapBroadcast,
+  swapSource,
 }: IUseSwapBuildTxOptions = {}) {
   const onSwapBroadcastRef = useRef(onSwapBroadcast);
   onSwapBroadcastRef.current = onSwapBroadcast;
@@ -4061,6 +4064,7 @@ export function useSwapBuildTx({
                           ...pre,
                           swapApprovingTransaction: {
                             txId: approveSendTx?.txid,
+                            swapSource,
                             swapType:
                               getSwapExecutionTypeFromQuoteResult(
                                 quoteResultFinal,
@@ -4268,6 +4272,7 @@ export function useSwapBuildTx({
       swapActionState.approveUnLimit,
       intl,
       setInAppNotificationAtom,
+      swapSource,
       fromUserAddress,
       fromAccountId,
       wrappedTx,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -84,7 +84,6 @@ import {
 } from '@onekeyhq/shared/types/staking';
 import type {
   ESwapCancelLimitOrderSource,
-  ESwapSource,
   IFetchBuildTxResponse,
   IFetchLimitOrderRes,
   IFetchQuoteResult,
@@ -216,7 +215,7 @@ type IEstimateNetworkFeeOptions = {
 
 type IUseSwapBuildTxOptions = {
   onSwapBroadcast?: () => void | Promise<void>;
-  swapSource?: ESwapSource;
+  marketSwapApprovalFlowId?: string;
 };
 
 type ISwapSignAndSendProgressEvent = {
@@ -267,7 +266,7 @@ function getSwapCreateFrom({
  */
 export function useSwapBuildTx({
   onSwapBroadcast,
-  swapSource,
+  marketSwapApprovalFlowId,
 }: IUseSwapBuildTxOptions = {}) {
   const onSwapBroadcastRef = useRef(onSwapBroadcast);
   onSwapBroadcastRef.current = onSwapBroadcast;
@@ -4064,7 +4063,7 @@ export function useSwapBuildTx({
                           ...pre,
                           swapApprovingTransaction: {
                             txId: approveSendTx?.txid,
-                            swapSource,
+                            marketSwapApprovalFlowId,
                             swapType:
                               getSwapExecutionTypeFromQuoteResult(
                                 quoteResultFinal,
@@ -4272,7 +4271,7 @@ export function useSwapBuildTx({
       swapActionState.approveUnLimit,
       intl,
       setInAppNotificationAtom,
-      swapSource,
+      marketSwapApprovalFlowId,
       fromUserAddress,
       fromAccountId,
       wrappedTx,

--- a/packages/kit/src/views/Swap/hooks/useSwapNavigation.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapNavigation.ts
@@ -1,7 +1,9 @@
 import { rootNavigationRef } from '@onekeyhq/components';
-import { EModalSwapRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
-
-import { isMarketEmbeddedSwapRoute } from './swapNavigationUtils';
+import {
+  EModalSwapRoutes,
+  ETabMarketRoutes,
+  ETabRoutes,
+} from '@onekeyhq/shared/src/routes';
 
 import type { ISwapNavigationContext } from './swapNavigationUtils';
 
@@ -15,9 +17,10 @@ export const handleSwapNavigation = (
     const isInSwapTab = tabRoute?.name === ETabRoutes.Swap;
     const tabSubRouteIndex = tabRoute?.state?.index ?? 0;
     const tabSubRouteName = tabRoute?.state?.routes?.[tabSubRouteIndex]?.name;
-    const isInMarketEmbeddedSwap =
-      tabRoute?.name === ETabRoutes.Market &&
-      isMarketEmbeddedSwapRoute(tabSubRouteName);
+    const isInMarketDetail =
+      tabSubRouteName === ETabMarketRoutes.MarketDetail ||
+      tabSubRouteName === ETabMarketRoutes.MarketDetailV2 ||
+      tabSubRouteName === ETabMarketRoutes.MarketNativeDetail;
     const hasModal = (state?.routes?.length || 0) > 1;
     let isHasSwapModal = false;
     let isSwapModalOnTheTop = false;
@@ -52,7 +55,7 @@ export const handleSwapNavigation = (
     if (callback) {
       callback({
         isInSwapTab,
-        isInMarketEmbeddedSwap,
+        isInMarketDetail,
         isHasSwapModal,
         isSwapModalOnTheTop,
         hasModal,

--- a/packages/kit/src/views/Swap/hooks/useSwapNavigation.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapNavigation.ts
@@ -1,19 +1,23 @@
 import { rootNavigationRef } from '@onekeyhq/components';
 import { EModalSwapRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 
+import { isMarketEmbeddedSwapRoute } from './swapNavigationUtils';
+
+import type { ISwapNavigationContext } from './swapNavigationUtils';
+
 export const handleSwapNavigation = (
-  callback: (params: {
-    isInSwapTab: boolean;
-    isHasSwapModal: boolean;
-    isSwapModalOnTheTop: boolean;
-    hasModal: boolean;
-  }) => void,
+  callback: (params: ISwapNavigationContext) => void,
 ) => {
   const state = rootNavigationRef.current?.getRootState();
   if (state) {
     const tabIndex = state?.routes?.[0]?.state?.index || 0;
     const tabRoute = state?.routes?.[0]?.state?.routes?.[tabIndex];
     const isInSwapTab = tabRoute?.name === ETabRoutes.Swap;
+    const tabSubRouteIndex = tabRoute?.state?.index ?? 0;
+    const tabSubRouteName = tabRoute?.state?.routes?.[tabSubRouteIndex]?.name;
+    const isInMarketEmbeddedSwap =
+      tabRoute?.name === ETabRoutes.Market &&
+      isMarketEmbeddedSwapRoute(tabSubRouteName);
     const hasModal = (state?.routes?.length || 0) > 1;
     let isHasSwapModal = false;
     let isSwapModalOnTheTop = false;
@@ -48,6 +52,7 @@ export const handleSwapNavigation = (
     if (callback) {
       callback({
         isInSwapTab,
+        isInMarketEmbeddedSwap,
         isHasSwapModal,
         isSwapModalOnTheTop,
         hasModal,

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -220,7 +220,10 @@ const SwapMainLoad = ({
     beginGasAccountReviewSession,
     endGasAccountReviewSession,
     markCurrentGasAccountReviewSubmitted,
-  } = useSwapBuildTx({ onSwapBroadcast });
+  } = useSwapBuildTx({
+    onSwapBroadcast,
+    swapSource: swapInitParams?.swapSource,
+  });
   const rebuildReviewWithSlippage = useCallback(
     (slippagePercentage: number) =>
       rebuildSwapWithSlippage({ slippagePercentage }),

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -81,6 +81,7 @@ import {
   EModalSwapRoutes,
   type IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
+import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
@@ -118,6 +119,7 @@ import {
 import { useMarketPresetSettings } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useMarketPresetSettings';
 import { ESwapDirection } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import TransactionLossNetworkFeeExceedDialog from '../../components/TransactionLossNetworkFeeExceedDialog';
+import { registerMarketSwapApprovalFlow } from '../../hooks/swapNavigationUtils';
 import { useMarketPresetSwapOverridesEffect } from '../../hooks/useMarketPresetSwapOverridesEffect';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
 import { useSwapBuildTx } from '../../hooks/useSwapBuiltTx';
@@ -192,6 +194,13 @@ const SwapMainLoad = ({
   const isMarketEmbeddedSwap =
     Boolean(singleSwapBridgeHeader) &&
     swapInitParams?.swapSource === ESwapSource.MARKET;
+  const [marketSwapApprovalFlowId] = useState(() => generateUUID());
+  useEffect(() => {
+    if (isMarketEmbeddedSwap) {
+      return registerMarketSwapApprovalFlow(marketSwapApprovalFlowId);
+    }
+    return undefined;
+  }, [isMarketEmbeddedSwap, marketSwapApprovalFlowId]);
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalSwapParamList>>();
   const isFocused = useRouteIsFocused();
@@ -222,7 +231,9 @@ const SwapMainLoad = ({
     markCurrentGasAccountReviewSubmitted,
   } = useSwapBuildTx({
     onSwapBroadcast,
-    swapSource: swapInitParams?.swapSource,
+    marketSwapApprovalFlowId: isMarketEmbeddedSwap
+      ? marketSwapApprovalFlowId
+      : undefined,
   });
   const rebuildReviewWithSlippage = useCallback(
     (slippagePercentage: number) =>

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -387,6 +387,7 @@ export interface ISwapOrderHash {
 export interface ISwapApproveTransaction {
   fromToken: ISwapToken;
   toToken: ISwapToken;
+  swapSource?: ESwapSource;
   protocol: EProtocolOfExchange;
   swapType: ESwapTabSwitchType;
   unSupportReceiveAddressDifferent?: boolean;

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -387,7 +387,7 @@ export interface ISwapOrderHash {
 export interface ISwapApproveTransaction {
   fromToken: ISwapToken;
   toToken: ISwapToken;
-  swapSource?: ESwapSource;
+  marketSwapApprovalFlowId?: string;
   protocol: EProtocolOfExchange;
   swapType: ESwapTabSwitchType;
   unSupportReceiveAddressDifferent?: boolean;


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62540](<https://onekeyhq.atlassian.net/browse/OK-62540>) [OK-62542](<https://onekeyhq.atlassian.net/browse/OK-62542>) [OK-62543](<https://onekeyhq.atlassian.net/browse/OK-62543>) [OK-62552](<https://onekeyhq.atlassian.net/browse/OK-62552>) [OK-62556](<https://onekeyhq.atlassian.net/browse/OK-62556>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary

- stabilize DeFi redeem amount sizing and align portfolio legend/tooltip percentages
- suppress the approval recovery action only for the exact, currently active Market-embedded Swap flow
- scope Aave collateral pending state to the affected market/reserve, including native reserves with an empty address
- preserve Aave native repay-all semantics on Ethereum and Base so the service can refresh debt and apply its repayment buffer

## Issues

- Fixes [OK-62540](https://onekeyhq.atlassian.net/browse/OK-62540)
- Fixes [OK-62542](https://onekeyhq.atlassian.net/browse/OK-62542)
- Fixes [OK-62543](https://onekeyhq.atlassian.net/browse/OK-62543)
- Fixes [OK-62552](https://onekeyhq.atlassian.net/browse/OK-62552)
- Fixes [OK-62556](https://onekeyhq.atlassian.net/browse/OK-62556)

## Runtime verification

### Desktop (Electron, single JS runtime)

- OK-62540: exercised a real Morpho WETH redeem form at 25% and Max; the input layout box remained 498 px and the amount/font did not jump during the entry transform.
- OK-62542: verified the real DeFi portfolio legend renders decimal values consistently (48.1%, 44.2%, 7.7%); the small 0.2% case is covered by the shared formatter/layout tests.
- OK-62543: opened the real ETH Market detail with embedded Swap. The exact mounted flow stays in place, a different flow gets the recovery action, switching away is treated as inactive, and returning/unmounting clears the flow.
- OK-62552: injected one controlled Aave Core USDe pending collateral transaction. USDe was disabled while sibling USDT and WBTC switches remained interactive.
- OK-62556: exercised the real Aave Base native ETH debt and Max repay preview; the full raw debt amount was selected and “My borrow” previewed to 0.

### iOS simulator (split main/bg runtimes)

- OK-62540: exercised the real Morpho WETH redeem form at 25% and Max; native sizing remained stable.
- OK-62542: exercised the compact DeFi list (the allocation legend is desktop/table-layout only by design); shared formatter tests cover the 0.2% consistency case.
- OK-62543: in the main UI runtime, controlled flow checks passed for matching ID, mismatched ID, inactive route, unmount, and the existing topmost Swap-modal path.
- OK-62552: injected one controlled Aave Core USDe pending collateral transaction. React DevTools confirmed USDe `disabled=true` and WBTC `disabled=false` on the same screen.
- OK-62556: exercised the real Aave Base native ETH debt and Max repay preview; “My borrow” previewed to 0.

No transaction was confirmed, signed, or broadcast during QA.

## Automated verification

- 10 focused Jest suites, 123 tests passed.
- `yarn agent:check --profile commit` passed: lint, format, TypeScript, native storage, agent context, and background API contract.
- `yarn agent:check --profile pr` engineering checks passed: 25 CI checks passed, 0 failed/pending/gate-blocked, and 0 active unresolved review threads. Its remaining `REVIEW_REQUIRED` status is the expected branch-protection requirement for another human reviewer.

## Review report

- Two independent static-only reviews plus the final owner review covered correctness, architecture/package boundaries, cross-platform runtime behavior, security/privacy, performance, maintainability, reuse, and common AI-generated-code failure modes.
- Fixed during review: missing mobile module-registry entry, Market route/source false positives, native empty-reserve tag parsing, inactive cached Market-flow handling, and a private component type import.
- No schema or migration change, generated translation change, new dependency, secret/logging exposure, or justified lodash replacement opportunity.

Ready for review.


[OK-62540]: https://onekeyhq.atlassian.net/browse/OK-62540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62542]: https://onekeyhq.atlassian.net/browse/OK-62542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62543]: https://onekeyhq.atlassian.net/browse/OK-62543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62552]: https://onekeyhq.atlassian.net/browse/OK-62552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62556]: https://onekeyhq.atlassian.net/browse/OK-62556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ