### PR TITLE
fix: sync web tab page on route focus (OK-62544)

### DIFF
--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -348,6 +348,24 @@ export function Container({
   const ref = useRef<Element>(null);
   const listContainerRef = useRef<Element>(null);
 
+  const syncFocusedTabPosition = useCallback(() => {
+    const listContainer = listContainerRef.current;
+    if (!listContainer) {
+      return;
+    }
+    const index = tabNamesRef.current.findIndex(
+      (name) => name === focusedTab.value,
+    );
+    const width = listContainer.clientWidth || ref.current?.clientWidth || 0;
+    if (index < 0 || !width) {
+      return;
+    }
+    listContainer.scrollTo({
+      left: width * index,
+      behavior: 'instant',
+    });
+  }, [focusedTab]);
+
   const stickyHeaderHeight = useRef(0);
   const handlerStickyHeaderLayout = useCallback((event: LayoutChangeEvent) => {
     stickyHeaderHeight.current = event.nativeEvent.layout.height;
@@ -689,11 +707,9 @@ export function Container({
           (name) => name === focusedTab.value,
         );
       },
-      syncCurrentPage: () => {
-        // no-op on web, only needed for native PagerView
-      },
+      syncCurrentPage: syncFocusedTabPosition,
     }),
-    [focusedTab, onTabPress],
+    [focusedTab, onTabPress, syncFocusedTabPosition],
   );
 
   // Memoised args for renderHeader/renderTabBar. tabNames identity may


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62544](<https://onekeyhq.atlassian.net/browse/OK-62544>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary

- implement the web `Tabs.Container.syncCurrentPage()` contract
- realign the physical pager position with the current focused tab when a route regains focus
- prevent the Home DeFi tab from staying highlighted while the pager remains on an empty inactive page after DApp account sync

Issue: https://onekeyhq.atlassian.net/browse/OK-62544

## Verification

- reproduced and verified the OK-62544 Desktop flow with real account switching and no product mocks
- passed the Account #3 DeFi -> Morpho -> Browser -> Account #1 sync -> Home return flow for 3 consecutive runs
- passed Browser-return checks for Portfolio, DeFi, NFT, and History tabs
- confirmed focused and visible pager indices remain aligned after the container width changes
- `yarn agent:check --profile commit`
- `git diff --check`


[OK-62544]: https://onekeyhq.atlassian.net/browse/OK-62544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ