### PR TITLE
fix: refresh wallet token list on off-tab account switch(OK-62678)

### DIFF
--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -21384,6 +21384,7 @@
     "packages/kit/src/views/Home/components/TokenListBlock/buildHomeTokenListCacheIngestRound.ts": 2900,
     "packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts": 7735,
     "packages/kit/src/views/Home/components/TokenListBlock/index.ts": 1645,
+    "packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.ts": 2687,
     "packages/kit/src/views/Home/components/TokenListBlock/selectHardwarePortfolioTokens.ts": 23848,
     "packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts": 9900,
     "packages/kit/src/views/Home/components/Upgrade/Upgrade.tsx": 1178,

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -127,6 +128,7 @@ import type {
   ITokenFiat,
 } from '@onekeyhq/shared/types/token';
 
+import { HomeStickyHeaderContext } from '../HomeStickyHeaderContext';
 import { RichBlock } from '../RichBlock/RichBlock';
 
 import {
@@ -144,6 +146,7 @@ import {
   shouldReportWalletAssetStatusSnapshot,
 } from './assetStatusAnalytics';
 import { buildHomeTokenListCacheIngestRound } from './buildHomeTokenListCacheIngestRound';
+import { resolveOffTabTokenListRefreshOnMount } from './offTabRefresh';
 import { PortfolioSyncButton } from './PortfolioSyncButton';
 import {
   countFundedHardwarePortfolioTokens,
@@ -3245,6 +3248,29 @@ function TokenListBlock({
     refreshSingleNetworkTokenListByTarget,
     showLpTokensOnly,
   ]);
+
+  // The fetch above is gated on this tab being focused, and an account switch
+  // remounts the whole home tab container. When that happens while another
+  // home tab is active, nothing fetches the new owner until the user returns,
+  // leaving the always-visible header worth on a skeleton. The off-tab
+  // network-switch path (RefreshTokenList with refreshByProvidedAccounts,
+  // emitted by HomePageView) cannot cover this: it fires before the remounted
+  // list has subscribed. Refresh the mounted owner explicitly instead.
+  const activeHomeTabId = useContext(HomeStickyHeaderContext)?.activeTabId;
+  useEffect(() => {
+    const target = resolveOffTabTokenListRefreshOnMount({
+      accountId: account?.id,
+      networkId: network?.id,
+      indexedAccountId: indexedAccount?.id,
+      activeTabId: activeHomeTabId,
+    });
+    if (target) {
+      void refreshSingleNetworkTokenListByTarget(target);
+    }
+    // Owner-keyed on purpose: re-running on tab changes would refetch on
+    // every tab switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account?.id, network?.id]);
 
   useEffect(() => {
     if (isEmptyAccount) {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -86,6 +86,7 @@ import {
   POLLING_INTERVAL_FOR_TOKEN,
 } from '@onekeyhq/shared/src/consts/walletConsts';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
+import { isRequestCanceledError } from '@onekeyhq/shared/src/errors/utils/errorUtils';
 import {
   EAppEventBusNames,
   type IAppEventBusPayload,
@@ -3095,22 +3096,19 @@ function TokenListBlock({
 
       let emittedRefreshing = false;
       try {
-        // Multi-derive (merge-derive) HD accounts need the parallel
-        // per-derivation fetch that only `run` performs; the single-account
-        // fast path below would apply partial data, so skip them. Others
-        // accounts (imported/watch-only) are always single-address even on
-        // merge-derive networks, so they can safely use the fast path here.
+        // Multi-derive (merge-derive) HD accounts aggregate every derivation
+        // of the indexed account, mirroring the parallel fetch in `run`.
+        // Others accounts (imported/watch-only) are always single-address
+        // even on merge-derive networks, so they take the single fetch.
         const targetVaultSettings =
           await backgroundApiProxy.serviceNetwork.getVaultSettings({
             networkId,
           });
-        if (
-          targetVaultSettings?.mergeDeriveAssetsEnabled &&
-          !accountUtils.isOthersAccount({ accountId })
-        ) {
-          return;
-        }
         if (!isLatest()) return;
+        const mergeDeriveTarget =
+          !!targetVaultSettings?.mergeDeriveAssetsEnabled &&
+          !accountUtils.isOthersAccount({ accountId }) &&
+          !!indexedAccountId;
 
         appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
           isRefreshing: true,
@@ -3129,48 +3127,94 @@ function TokenListBlock({
         });
         if (!isLatest()) return;
 
-        const r = await backgroundApiProxy.serviceToken.fetchAccountTokens({
-          accountId,
-          mergeTokens: true,
-          networkId,
-          flag: 'home-token-list',
-          saveToLocal: true,
-          indexedAccountId,
-          ...walletTokenFilterParams,
-        });
+        const fetchTargetAccountTokens = (targetAccountId: string) =>
+          backgroundApiProxy.serviceToken.fetchAccountTokens({
+            accountId: targetAccountId,
+            mergeTokens: true,
+            networkId,
+            flag: 'home-token-list',
+            saveToLocal: true,
+            indexedAccountId,
+            ...walletTokenFilterParams,
+          });
+
+        let responses: IFetchAccountTokensResp[];
+        if (mergeDeriveTarget) {
+          const { networkAccounts } =
+            await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
+              {
+                networkId,
+                indexedAccountId,
+                excludeEmptyAccount: true,
+              },
+            );
+          if (!isLatest()) return;
+          responses = await Promise.all(
+            networkAccounts.map((networkAccount) =>
+              fetchTargetAccountTokens(networkAccount.account?.id ?? ''),
+            ),
+          );
+        } else {
+          responses = [await fetchTargetAccountTokens(accountId)];
+        }
 
         // A newer switch superseded this fetch; drop the stale body so it
         // can't clobber the latest network's data.
         if (!isLatest()) return;
 
-        const accountWorth = sumTokenGroupsFiatValueIgnoringUnavailable(r);
+        const accountWorth: Record<string, string> = {};
+        let createAtNetworkWorth = '0';
+        if (mergeDeriveTarget) {
+          responses.forEach((item) => {
+            if (item.accountId && item.networkId) {
+              accountWorth[
+                accountUtils.buildAccountValueKey({
+                  accountId: item.accountId,
+                  networkId: item.networkId,
+                })
+              ] = sumTokenGroupsFiatValueIgnoringUnavailable(item);
+            }
+          });
+        } else {
+          createAtNetworkWorth = sumTokenGroupsFiatValueIgnoringUnavailable(
+            responses[0],
+          );
+          accountWorth[
+            accountUtils.buildAccountValueKey({ accountId, networkId })
+          ] = createAtNetworkWorth;
+        }
         updateAccountOverviewState({ isRefreshing: false, initialized: true });
         updateAccountWorth({
-          accountId,
+          // Merge-derive worth is keyed by the indexed account, like `run`.
+          accountId: mergeDeriveTarget ? indexedAccountId : accountId,
           initialized: true,
-          worth: {
-            [accountUtils.buildAccountValueKey({ accountId, networkId })]:
-              accountWorth,
-          },
-          createAtNetworkWorth: accountWorth,
+          worth: accountWorth,
+          createAtNetworkWorth,
           merge: false,
         });
 
-        if (r.allTokens) {
-          // Keep the broader local token directory in sync, like `run` does;
-          // `saveToLocal` only persists the per-account token cache.
-          const mergedTokens = r.allTokens.data;
+        // Keep the broader local token directory in sync, like `run` does;
+        // `saveToLocal` only persists the per-account token cache.
+        responses.forEach((item) => {
+          const mergedTokens = item.allTokens?.data;
           if (mergedTokens && mergedTokens.length) {
             void backgroundApiProxy.serviceToken.updateLocalTokens({
               networkId,
               tokens: mergedTokens,
             });
           }
-        }
-        updateTokenListState({ initialized: true, isRefreshing: false });
+        });
+        // This path only refreshes the header worth; the token rows are not
+        // ingested into the owner's cells, so the list must stay uninitialized
+        // (skeleton) until the focused `run` fills it. Marking it initialized
+        // here would surface EmptyToken on return.
       } catch (e) {
-        if (!(e instanceof CanceledError)) {
-          throw e;
+        // Cancel errors that crossed the main <-> bg RPC boundary are rebuilt
+        // as plain Errors, so `instanceof CanceledError` alone misses them.
+        // Callers fire-and-forget this refresh; never let a non-cancel error
+        // escape as an unhandled rejection.
+        if (!isRequestCanceledError(e)) {
+          console.error(e);
         }
       } finally {
         if (emittedRefreshing) {
@@ -3183,12 +3227,7 @@ function TokenListBlock({
         }
       }
     },
-    [
-      walletTokenFilterParams,
-      updateAccountOverviewState,
-      updateAccountWorth,
-      updateTokenListState,
-    ],
+    [walletTokenFilterParams, updateAccountOverviewState, updateAccountWorth],
   );
 
   useEffect(() => {
@@ -3267,6 +3306,13 @@ function TokenListBlock({
     if (target) {
       void refreshSingleNetworkTokenListByTarget(target);
     }
+    // The sequence guard is per instance, and an account switch remounts this
+    // block. Invalidate this owner's in-flight explicit refresh on owner change
+    // or unmount so a late stage of it (vault settings, abort, worth write)
+    // cannot abort or overwrite the successor instance's fetch.
+    return () => {
+      explicitRefreshSeqRef.current += 1;
+    };
     // Owner-keyed on purpose: re-running on tab changes would refetch on
     // every tab switch.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.test.ts
@@ -1,0 +1,84 @@
+import { EHomeWalletTab } from '@onekeyhq/shared/types/wallet';
+
+import { resolveOffTabTokenListRefreshOnMount } from './offTabRefresh';
+
+/*
+yarn jest packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.test.ts
+*/
+
+const owner = {
+  accountId: 'hd-1--m/44/60/0/0/1',
+  networkId: 'evm--1',
+  indexedAccountId: 'hd-1--1',
+};
+
+describe('resolveOffTabTokenListRefreshOnMount', () => {
+  it('refreshes the mounted owner while another home tab is active', () => {
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        ...owner,
+        activeTabId: EHomeWalletTab.NFT,
+      }),
+    ).toEqual(owner);
+  });
+
+  it('forwards an Others account without an indexed account', () => {
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        accountId: 'watching--evm--0xabc',
+        networkId: 'evm--1',
+        indexedAccountId: undefined,
+        activeTabId: EHomeWalletTab.History,
+      }),
+    ).toEqual({
+      accountId: 'watching--evm--0xabc',
+      networkId: 'evm--1',
+      indexedAccountId: undefined,
+    });
+  });
+
+  it('does nothing on the spot tab, where the list fetches on focus', () => {
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        ...owner,
+        activeTabId: EHomeWalletTab.Portfolio,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does nothing before the active tab is known', () => {
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        ...owner,
+        activeTabId: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does nothing for All Networks, which the fan-out hook refreshes', () => {
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        ...owner,
+        networkId: 'onekeyall--0',
+        activeTabId: EHomeWalletTab.NFT,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does nothing while the owner has no account or network', () => {
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        ...owner,
+        accountId: undefined,
+        activeTabId: EHomeWalletTab.NFT,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveOffTabTokenListRefreshOnMount({
+        ...owner,
+        networkId: undefined,
+        activeTabId: EHomeWalletTab.NFT,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.ts
@@ -1,0 +1,38 @@
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import { EHomeWalletTab } from '@onekeyhq/shared/types/wallet';
+
+export interface IOffTabTokenListRefreshTarget {
+  accountId: string;
+  networkId: string;
+  indexedAccountId?: string;
+}
+
+// The wallet (spot) token list fetches only while its tab is focused, and it
+// is remounted for every account switch. When that happens while another
+// home tab is active, nothing fetches the new owner until the user returns,
+// so the always-visible header worth stays on a skeleton. Resolve the
+// explicit single-network refresh the freshly mounted list should run for
+// its owner instead. All Networks is left to the fan-out hook, which is not
+// gated on the inner tab.
+export function resolveOffTabTokenListRefreshOnMount({
+  accountId,
+  networkId,
+  indexedAccountId,
+  activeTabId,
+}: {
+  accountId: string | undefined;
+  networkId: string | undefined;
+  indexedAccountId: string | undefined;
+  activeTabId: EHomeWalletTab | undefined;
+}): IOffTabTokenListRefreshTarget | undefined {
+  if (!activeTabId || activeTabId === EHomeWalletTab.Portfolio) {
+    return undefined;
+  }
+  if (!accountId || !networkId) {
+    return undefined;
+  }
+  if (networkUtils.isAllNetwork({ networkId })) {
+    return undefined;
+  }
+  return { accountId, networkId, indexedAccountId };
+}

--- a/packages/shared/src/errors/utils/errorUtils.test.ts
+++ b/packages/shared/src/errors/utils/errorUtils.test.ts
@@ -1,4 +1,7 @@
+import { CanceledError } from 'axios';
+
 import {
+  isRequestCanceledError,
   markOneKeyIdFailureServerLogged,
   toPlainErrorObject,
   wasOneKeyIdFailureServerLogged,
@@ -28,5 +31,29 @@ describe('OneKey ID failure server log marker', () => {
 
     expect(error.data).toBe(42);
     expect(wasOneKeyIdFailureServerLogged(error)).toBe(false);
+  });
+});
+
+describe('isRequestCanceledError', () => {
+  it('detects a live axios CanceledError', () => {
+    expect(isRequestCanceledError(new CanceledError('canceled'))).toBe(true);
+  });
+
+  it('detects a cancel error rebuilt from its serialized RPC form', () => {
+    const plain = toPlainErrorObject(new CanceledError('canceled'));
+    const rebuilt = Object.assign(new Error(plain.message), {
+      name: plain.name,
+      code: plain.code,
+    });
+
+    expect(rebuilt).not.toBeInstanceOf(CanceledError);
+    expect(isRequestCanceledError(rebuilt)).toBe(true);
+    expect(isRequestCanceledError({ code: 'ERR_CANCELED' })).toBe(true);
+  });
+
+  it('ignores other errors and non-objects', () => {
+    expect(isRequestCanceledError(new Error('boom'))).toBe(false);
+    expect(isRequestCanceledError(undefined)).toBe(false);
+    expect(isRequestCanceledError('canceled')).toBe(false);
   });
 });

--- a/packages/shared/src/errors/utils/errorUtils.ts
+++ b/packages/shared/src/errors/utils/errorUtils.ts
@@ -269,8 +269,27 @@ function logCurrentCallStack(name?: string) {
   }
 }
 
+/**
+ * Detects an axios request cancellation, including cancel errors that crossed
+ * the main <-> background RPC boundary. Those are rebuilt as plain Errors on
+ * the receiving runtime, so `instanceof CanceledError` / `axios.isCancel`
+ * miss them; only the serialized `name` / `code` survive.
+ */
+export function isRequestCanceledError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const e = error as { name?: string; code?: string; __CANCEL__?: boolean };
+  return (
+    e.__CANCEL__ === true ||
+    e.name === 'CanceledError' ||
+    e.code === 'ERR_CANCELED'
+  );
+}
+
 const errorUtils = {
   autoPrintErrorIgnore,
+  isRequestCanceledError,
   normalizeErrorProps,
   safeConsoleLogError,
   toPlainErrorObject,


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62678](<https://onekeyhq.atlassian.net/browse/OK-62678>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary
- Switching account while a non-spot home tab (History / NFT / DeFi / Perps) is active left the always-visible header total on a skeleton until the user returned to the spot tab.
- The wallet token list now refreshes its freshly mounted owner itself when it mounts (or re-renders a new owner) while another home tab is active.
- Adds a small pure resolver (`offTabRefresh.ts`) with unit tests.

## Intent & Context
Jira OK-62678 (reported today, priority Highest): "在非现货 tab 下切换账户，总资产一直 loading 不加载，切回去就能恢复加载". Reproduced on desktop dev via CDP: on the History/NFT tab, switching to an account whose worth is not cached left the header skeleton for 10 s+ with zero `serviceToken.fetchAccountTokens` calls; pressing the spot tab fired the fetch ~1.2 s later and the header rendered. Accounts that already have a confirmed/cached balance show that value instead of a skeleton, which is why QA only sees it on accounts without cache.

## Root Cause
- An account switch changes the `Tabs.Container` key (wallet + indexedAccountId), so the whole tab pane tree remounts and `TokenListBlock` mounts inside a non-focused `Tabs.Tab`.
- Its token fetch is a `usePromiseResult` with `overrideIsFocused: isPageFocused && isFocused` (inner-tab focus). The runner sees `triggerByDeps && !isFocused`, flags `isDepsChangedOnBlur` and skips; the run only happens when the spot tab regains focus. `HomeOverviewContainer` has no fetch of its own and only reads `accountWorthAtom`, so nothing writes the new owner's worth.
- The off-tab *network* switch was already special-cased in `HomePageView` (#11937, OK-55826) via `RefreshTokenList` + `refreshByProvidedAccounts`, but account switches were not.
- Not a regression from #13281 (`FreezeInactiveHomeTab` timing): `DelayedFreeze` still commits the first render, and the same focus gate / remount key exist on `release/v6.5.2`.

## Design Decisions
- First attempt extended the `HomePageView` network-switch effect to account changes. It failed live: on an account switch the old listeners unsubscribe at +250 ms, the emit lands at +256 ms, and the remounted `TokenListBlock` / `DeFiListBlock` subscribe only at ~+430 ms, so the event is lost. A fire-and-forget bus emit cannot reach a component that is being remounted in the same interaction.
- Chosen approach: `TokenListBlock` reads `activeTabId` from `HomeStickyHeaderContext` and, in an effect keyed on `account.id` / `network.id`, calls the existing `refreshSingleNetworkTokenListByTarget` when another tab is active. `DelayedFreeze` allows one committed render before freezing, so the mount effect runs; the result is written through the context action into `accountWorthAtom`, which the header reads regardless of tab focus. The DeFi cache-only hook already bypasses the focus gate (`shouldAlwaysFetch`).
- All Networks is excluded on purpose: the fan-out hook is gated on route focus only and already runs off-tab.
- The effect is owner-keyed, not tab-keyed, so tab switches never refetch. The on-tab path is untouched (`activeTabId === Portfolio` → no-op). `refreshSingleNetworkTokenListByTarget`'s sequence guard dedups any overlap with the network-switch event path.

## Changes Detail
- `packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.ts`: `resolveOffTabTokenListRefreshOnMount` — returns the single-network refresh target when the active home tab is not the spot tab, the owner is complete, and the network is not All Networks.
- `packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.test.ts`: 6 unit tests (off-tab owner, Others account without indexed account, spot tab, unknown tab, All Networks, incomplete owner).
- `packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx`: owner-keyed effect that runs the resolver against `HomeStickyHeaderContext.activeTabId` and calls `refreshSingleNetworkTokenListByTarget`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Extension / Mobile (same home tab container on all)
- **Risk Areas**: one extra single-network token fetch when the list mounts off-tab; merge-derive networks (BTC etc. on HD accounts) still bail inside `refreshSingleNetworkTokenListByTarget`, the same limitation as the existing network-switch path.

## Test plan
- [x] `yarn jest packages/kit/src/views/Home/components/TokenListBlock/offTabRefresh.test.ts` (6/6) and Home pages/TokenListBlock suites (18 suites, 157 tests)
- [x] `yarn agent:check --profile commit` green
- [x] Desktop dev (CDP): History tab → switch to an account without cached worth → `fetchAccountTokens` fires at ~0.4 s, header settles by ~0.9 s (before: skeleton 10 s+, no fetch)
- [x] Desktop dev: off-tab network switch still refreshes via the existing event path (single fetch); on-tab account switch unchanged (single fetch)
- [ ] Device QA: iOS/Android — on History/NFT/DeFi tab switch to a newly created account, header total loads without returning to 现货


[OK-62678]: https://onekeyhq.atlassian.net/browse/OK-62678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ