### PR TITLE
fix: prevent iOS image crash and simulator startup failure ｜OK-62654

### DIFF
--- a/apps/mobile/scripts/__tests__/native-dev-shell.test.js
+++ b/apps/mobile/scripts/__tests__/native-dev-shell.test.js
@@ -593,14 +593,7 @@ describe('native-dev-shell', () => {
         wait,
       }),
     ).resolves.toBeUndefined();
-    expect(iosOutput).toHaveBeenCalledWith('xcrun', [
-      'simctl',
-      'spawn',
-      'SIMULATOR-A',
-      '/bin/kill',
-      '-0',
-      '4321',
-    ]);
+    expect(iosOutput).toHaveBeenCalledWith('/bin/kill', ['-0', '4321']);
     expect(wait).toHaveBeenCalledTimes(15);
     expect(wait).toHaveBeenCalledWith(1000);
   });

--- a/apps/mobile/scripts/native-dev-shell.js
+++ b/apps/mobile/scripts/native-dev-shell.js
@@ -2209,14 +2209,8 @@ async function waitForNativeAppStartup({
         elapsed += 1000
       ) {
         await wait(1000);
-        runForOutputCommand('xcrun', [
-          'simctl',
-          'spawn',
-          deviceId,
-          '/bin/kill',
-          '-0',
-          String(launch.processId),
-        ]);
+        // Simulator app PIDs belong to the host; newer runtimes omit /bin/kill.
+        runForOutputCommand('/bin/kill', ['-0', String(launch.processId)]);
       }
     }
   } catch (error) {

--- a/packages/components/src/primitives/Image/ImageV2.native.test.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.native.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render } from '@testing-library/react';
+import { Platform } from 'react-native';
 
 import { ImageV2 } from './ImageV2.native';
 
@@ -13,6 +14,7 @@ type INativeImageProps = Pick<
 >;
 
 const mockNativeImage = jest.fn<null, [INativeImageProps]>(() => null);
+const fallback = <span>No image</span>;
 const privateSource = {
   uri: 'https://uni.onekey-asset.com/private.png',
   headers: { Authorization: 'test' },
@@ -42,7 +44,52 @@ jest.mock('@onekeyhq/components/src/shared/tamagui', () => ({
 }));
 
 describe('native ImageV2 rendition ownership', () => {
-  beforeEach(() => mockNativeImage.mockClear());
+  beforeEach(() => {
+    mockNativeImage.mockClear();
+    Platform.OS = 'ios';
+  });
+
+  it.each([undefined, '', '   '])(
+    'renders the fallback without sending an empty source (%s) to iOS',
+    (src) => {
+      const { getByText, container } = render(
+        <ImageV2 src={src} fallback={fallback} />,
+      );
+
+      expect(getByText('No image')).toBeTruthy();
+      expect(container.firstElementChild?.getAttribute('style')).toBe(
+        'width: 40px; height: 40px;',
+      );
+      expect(mockNativeImage).not.toHaveBeenCalled();
+    },
+  );
+
+  it('replaces a loaded iOS image with the fallback and accepts a new source', () => {
+    const { rerender, queryByText } = render(
+      <ImageV2 src="https://example.com/aapl.png" />,
+    );
+    mockNativeImage.mockClear();
+
+    rerender(<ImageV2 fallback={fallback} />);
+    expect(queryByText('No image')).toBeTruthy();
+    expect(mockNativeImage).not.toHaveBeenCalled();
+
+    rerender(<ImageV2 src="https://example.com/aaplx.png" />);
+    expect(queryByText('No image')).toBeNull();
+    expect(mockNativeImage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        source: { uri: 'https://example.com/aaplx.png' },
+      }),
+    );
+  });
+
+  it('keeps empty-source handling on the native Android image', () => {
+    Platform.OS = 'android';
+    render(<ImageV2 />);
+    expect(mockNativeImage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: undefined }),
+    );
+  });
 
   it('keeps the original URL and layout while forwarding resize hints', () => {
     const uri = 'https://uni.onekey-asset.com/token.png';

--- a/packages/components/src/primitives/Image/ImageV2.native.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.native.tsx
@@ -17,6 +17,7 @@ import {
   Image as ReactNativeImage,
   StyleSheet,
   View,
+  type ViewProps,
 } from 'react-native';
 
 import { usePropsAndStyle } from '@onekeyhq/components/src/shared/tamagui';
@@ -310,6 +311,16 @@ export function ImageV2({ style: defaultStyle, ...props }: IImageV2Props) {
     },
     [onError, scheduleRetry],
   );
+
+  // Fabric clears removed props with null, which Nitro's optional string
+  // converter rejects. Unmount the iOS image before clearing its source URI.
+  if (Platform.OS === 'ios' && !activeSource?.uri?.trim()) {
+    return (
+      <View {...(viewProps as ViewProps)} style={style}>
+        {fallbackOverlay}
+      </View>
+    );
+  }
 
   return (
     <OneKeyImage


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62654](<https://onekeyhq.atlassian.net/browse/OK-62654>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary

Fixes the iOS image crash reported in OK-62654 when searching for and selecting a stock token from a stock detail page. Also fixes a simulator startup check that incorrectly reported the app as terminated on newer iOS simulator runtimes.

## Problem and root cause

### Stock detail image crash

The reported flow opens the AAPL detail page, searches for AAPLX, and selects the result. During the transition, the image source can become empty.

The native image wrapper forwards the missing URI as `undefined`. When React Native Fabric clears the existing native property, it sends `null`. Nitro’s optional string converter does not accept that value, causing:

`Exception in HostFunction: OneKeyImage.sourceUri: Value is null, expected a String`

The exception occurs while updating the native image props, before the normal image error handler or fallback can handle it.

### Simulator startup detection

The development launcher checked whether the iOS app survived startup by executing `/bin/kill -0 <pid>` inside the simulator through `simctl spawn`.

On the installed simulator runtime, that command failed even though the app process was still running. The launcher interpreted the command failure as an app crash and shut down Metro, leaving the app unable to load its JavaScript bundle.

## Changes

### Handle empty image sources on iOS

- Render a regular `View` with the existing fallback overlay when the active image URI is missing, empty, or whitespace-only.
- Unmount the native image instead of clearing its source property, preventing the invalid `null` update.
- Preserve the image container’s layout and view props.
- Mount the native image again when a valid source becomes available.
- Keep Android’s existing empty-source handling unchanged.

### Check simulator processes on the host

- Run `/bin/kill -0 <pid>` on macOS, where simulator app processes reside.
- Preserve the existing startup grace period and process-exit detection.
- Update the startup tests to verify the host-side process check.

## Validation

- **67 tests passed** across the image component and native development launcher suites.
- Image coverage includes:
  - Missing, empty, and whitespace-only source URIs.
  - Transition from a valid image to a fallback and back to a new image.
  - Fallback container dimensions.
  - Unchanged Android empty-source behavior.
  - Existing resize hints and custom request identity handling.
- Launcher coverage includes successful startup and detection of a process that exits during the startup grace period.
- `yarn agent:check --profile commit` passed, including lint, formatting, and TypeScript checks.
- The app successfully launched on an **iPhone 16 Pro simulator running iOS 26.5**, and a market detail page rendered.

## Remaining verification

The complete AAPL → search AAPLX → select result flow still requires manual regression testing. Successful startup and detail-page rendering do not establish that the full reported flow has passed.

RevenueCat anonymous-user logout errors and a separate debug error notification were observed during the simulator session; these are not resolved by this change.

## Related issue

[OK-62654](https://onekeyhq.atlassian.net/browse/OK-62654)

[OK-62654]: https://onekeyhq.atlassian.net/browse/OK-62654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ