### PR TITLE
fix: avoid duplicate NFT collection error toast(OK-62767)

### DIFF
--- a/packages/kit/src/views/AssetDetails/pages/NFTDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/NFTDetails.tsx
@@ -19,6 +19,7 @@ import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/He
 import type { IDBDevice } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import type { IPro2NftUploadParams } from '@onekeyhq/kit-bg/src/services/ServiceNFT';
 import { OneKeyAppError } from '@onekeyhq/shared/src/errors';
+import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -354,7 +355,7 @@ export default function NFTDetails() {
           }),
         });
       } catch (e) {
-        Toast.error({ title: (e as Error).message });
+        errorToastUtils.showToastOfError(e);
       } finally {
         setIsCollecting(false);
       }


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62767](<https://onekeyhq.atlassian.net/browse/OK-62767>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary
- Show a single error when collecting an NFT that already exists on the hardware wallet.

## Intent & Context
[OK-62767](https://onekeyhq.atlassian.net/browse/OK-62767) reports duplicate "File already exists" messages: the hardware interaction capsule at the top and an error toast at the bottom right.

## Root Cause
The hardware processing layer displays the failure in DeviceStage and sets `autoToast = false`. The NFT details upload catch unconditionally called `Toast.error`, bypassing that flag and displaying the same failure again.

## Design Decisions
Reuse `errorToastUtils.showToastOfError` so the page respects the existing suppression and deduplication rules. Keep the hardware error handling, upload logic, success feedback, and loading cleanup unchanged.

## Changes Detail
- `packages/kit/src/views/AssetDetails/pages/NFTDetails.tsx`: route upload failures through the shared error toast utility.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Mobile, Extension; this is a shared page, and NFT collection is disabled on Web.
- **Risk Areas**: Error presentation after NFT upload failure. No changes to hardware commands or asset transfers.

## Test plan
- [x] Run `yarn agent:check --profile commit`.
- [x] Run the existing `ServiceNFT.pro2.test.ts` and `ErrorToastContainer.test.tsx` suites: 19 tests passed.
- [x] On the running Electron development app, inject `FileAlreadyExistError` at the hardware upload boundary and exercise the collection flow. Confirm the top error remains, the toast container is empty, and the collection menu becomes available again. Restore the original upload method after verification; no NFT was written during this check.
- [ ] Repeat duplicate NFT collection on a physical device without fault injection.


[OK-62767]: https://onekeyhq.atlassian.net/browse/OK-62767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ