### PR TITLE
fix: select wallet scheme for iOS EAS builds

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -21,6 +21,7 @@
         }
       },
       "ios": {
+        "scheme": "OneKeyWallet",
         "image": "macos-tahoe-26.4-xcode-26.4",
         "resourceClass": "medium",
         "env": {


### PR DESCRIPTION
## Summary
- Set the shared iOS EAS build scheme to `OneKeyWallet`.

## Intent & Context
Investigating [the failed release-ios run](https://github.com/OneKeyHQ/app-monorepo/actions/runs/34544059030) exposed an unintended scheme selection after App Clip was introduced in #13044. The run's immediate malformed-profile failure was addressed separately by configuring the App Clip distribution profile secrets.

## Root Cause
`eas.json` did not specify an iOS scheme. With both `OneKeyAppClip` and `OneKeyWallet` available, the run log shows non-interactive EAS selecting the standalone `OneKeyAppClip` scheme.

## Design Decisions
Set `build.base.ios.scheme` once so all iOS profiles inherit the existing wallet scheme. The wallet target continues to embed its App Clip. Local physical-device signing still requires a matching App Clip development profile; this change does not resolve missing development credentials.

## Changes Detail
- `apps/mobile/eas.json`: add `"scheme": "OneKeyWallet"` to the shared iOS base configuration.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS EAS builds)
- **Risk Areas**: Scheme selection across inherited build profiles; no signing credentials or native targets changed.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] Verify all seven build profiles resolve to the existing wallet scheme and the remaining configuration is unchanged.
- [ ] Run an iOS EAS build and verify the wallet archive embeds the App Clip.
