### PR TITLE
perf: overlap badges request with address validation in queryAddress

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
@@ -96,8 +96,14 @@ jest.mock('../dbs/simple/simpleDb', () => ({
 
 /* eslint-disable import/first, import/order */
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  EAddressInteractionStatus,
+  EServerInteractedStatus,
+} from '@onekeyhq/shared/types/address';
 
 import ServiceAccountProfile from './ServiceAccountProfile';
+
+import type { IServerAccountBadgeResp } from '@onekeyhq/shared/types/address';
 /* eslint-enable import/first, import/order */
 
 const NETWORK_ID = 'evm--1';
@@ -126,16 +132,25 @@ async function flushMicrotasks() {
   }
 }
 
+// Node only emits `unhandledRejection` after the microtask queue drains and
+// control returns to the event loop, so assertions on it need a macrotask
+// boundary, not just microtask flushes.
+async function flushMacrotask() {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 function makeService({
   localValid = true,
   badgesResp = {
-    interacted: 'true',
+    interacted: EServerInteractedStatus.TRUE,
     badges: [{ type: 'success', label: 'ok' }],
   },
   getAccount,
 }: {
   localValid?: boolean;
-  badgesResp?: Record<string, unknown>;
+  badgesResp?: Partial<IServerAccountBadgeResp>;
   getAccount?: jest.Mock;
 } = {}) {
   const validate = deferred<'valid' | 'invalid'>();
@@ -228,6 +243,9 @@ describe('ServiceAccountProfile.queryAddress request overlap', () => {
 
     expect(result.validStatus).toBe('valid');
     expect(result.addressBadges).toEqual([{ type: 'success', label: 'ok' }]);
+    expect(result.addressInteractionStatus).toBe(
+      EAddressInteractionStatus.INTERACTED,
+    );
     // The speculative response is reused; no second badges round trip.
     expect(
       clientGet.mock.calls.filter(([path]) => path === BADGES_PATH),
@@ -264,7 +282,8 @@ describe('ServiceAccountProfile.queryAddress request overlap', () => {
     await flushMicrotasks();
     validate.resolve('invalid');
     const result = await pending;
-    await flushMicrotasks();
+    // A rejection only becomes "unhandled" once Node reaches the event loop.
+    await flushMacrotask();
 
     expect(result.validStatus).toBe('invalid');
     expect(unhandled).toHaveLength(0);

--- a/packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
@@ -100,10 +100,10 @@ import {
   EAddressInteractionStatus,
   EServerInteractedStatus,
 } from '@onekeyhq/shared/types/address';
+import type { IServerAccountBadgeResp } from '@onekeyhq/shared/types/address';
 
 import ServiceAccountProfile from './ServiceAccountProfile';
 
-import type { IServerAccountBadgeResp } from '@onekeyhq/shared/types/address';
 /* eslint-enable import/first, import/order */
 
 const NETWORK_ID = 'evm--1';

--- a/packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
@@ -1,0 +1,301 @@
+/*
+yarn jest packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts
+
+Latency guard for the recipient AddressInput:
+
+`queryAddress` used to run `/wallet/v1/account/validate-address` and
+`/wallet/v1/account/badges` strictly one after the other, so the input spinner
+lasted the sum of both round trips (~1.1 s observed). Once the local validator
+accepts the input, the badges request no longer depends on the server
+validation result, so it is started speculatively and awaited later. These
+tests pin that ordering and the cases where speculation must NOT fire.
+*/
+
+// --- mocks MUST be defined before the import of ServiceAccountProfile below ---
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => () => undefined,
+  backgroundMethod: () => (_t: unknown, _k: unknown, d: PropertyDescriptor) =>
+    d,
+  toastIfError: () => (_t: unknown, _k: unknown, d: PropertyDescriptor) => d,
+}));
+
+jest.mock('./ServiceBase', () => ({
+  __esModule: true,
+  default: class ServiceBase {
+    backgroundApi: any;
+
+    constructor({ backgroundApi }: { backgroundApi: any }) {
+      this.backgroundApi = backgroundApi;
+    }
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/locale', () => ({
+  ETranslations: {},
+}));
+
+jest.mock('@onekeyhq/shared/src/locale/appLocale', () => ({
+  appLocale: { intl: { formatMessage: (m: { id: string }) => m.id } },
+}));
+
+jest.mock('@onekeyhq/shared/src/request/utils', () => ({
+  parseRPCResponse: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/errors', () => ({
+  OneKeyLocalError: Error,
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/cexDepositSupportUtils', () => ({
+  mergeCexSupportedInfo: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/promiseUtils', () => ({
+  promiseAllSettledEnhanced: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/networkUtils', () => ({
+  __esModule: true,
+  default: {
+    isAllNetwork: ({ networkId }: { networkId: string }) =>
+      networkId === 'onekeyall--0',
+    isEvmNetwork: ({ networkId }: { networkId: string }) =>
+      networkId.startsWith('evm--'),
+    isBTCNetwork: () => false,
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/accountUtils', () => ({
+  __esModule: true,
+  default: {
+    isOwnAccount: () => false,
+    isWatchingAccount: () => false,
+    isOthersAccount: () => false,
+    isSimilarAddress: () => false,
+  },
+}));
+
+jest.mock('../vaults/factory', () => ({
+  vaultFactory: {},
+}));
+
+jest.mock('../vaults/impls/btc/sdkBtc/findAddressUtils', () => ({
+  mergeClaimedUtxos: jest.fn(),
+}));
+
+jest.mock('../states/jotai/atoms', () => ({
+  activeAccountValueAtom: { get: jest.fn(), set: jest.fn() },
+  currencyPersistAtom: { get: jest.fn() },
+}));
+
+jest.mock('../dbs/simple/simpleDb', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+/* eslint-disable import/first, import/order */
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+import ServiceAccountProfile from './ServiceAccountProfile';
+/* eslint-enable import/first, import/order */
+
+const NETWORK_ID = 'evm--1';
+const ACCOUNT_ID = "hd-1--m/44'/60'/0'/0/0";
+const SENDER = '0x1111111111111111111111111111111111111111';
+const RECIPIENT = '0xF501EECfc96Aa9f9393BbEDf4f324bf33d4ABafa';
+
+const VALIDATE_PATH = '/wallet/v1/account/validate-address';
+const BADGES_PATH = '/wallet/v1/account/badges';
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Let every already-queued microtask (and the ones they queue) settle.
+async function flushMicrotasks() {
+  for (let i = 0; i < 20; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
+
+function makeService({
+  localValid = true,
+  badgesResp = {
+    interacted: 'true',
+    badges: [{ type: 'success', label: 'ok' }],
+  },
+  getAccount,
+}: {
+  localValid?: boolean;
+  badgesResp?: Record<string, unknown>;
+  getAccount?: jest.Mock;
+} = {}) {
+  const validate = deferred<'valid' | 'invalid'>();
+  const clientGet = jest.fn(async (path: string) => {
+    if (path === BADGES_PATH) {
+      return { data: { data: badgesResp } };
+    }
+    throw new OneKeyLocalError(`unexpected GET ${path}`);
+  });
+
+  const backgroundApi = {
+    serviceValidator: {
+      localValidateAddress: jest.fn(async () => ({
+        isValid: localValid,
+        displayAddress: localValid ? RECIPIENT : '',
+        normalizedAddress: localValid ? RECIPIENT : '',
+      })),
+      // Stands in for the server round trip; the test decides when it settles.
+      validateAddress: jest.fn(() => validate.promise),
+    },
+    serviceNetwork: {
+      isCustomNetwork: jest.fn(async () => false),
+    },
+    serviceAccount: {
+      getAccount:
+        getAccount ??
+        jest.fn(async () => ({ address: SENDER, id: ACCOUNT_ID })),
+      safeGetAccountXpubsForAllDeriveTypes: jest.fn(async () => []),
+      getAccountNameFromAddress: jest.fn(async () => []),
+    },
+    serviceAddressBook: {
+      findItem: jest.fn(async () => undefined),
+      getItemsByNetwork: jest.fn(async () => []),
+    },
+    serviceHistory: {
+      fetchTransferRecipients: jest.fn(async () => ({ data: [] })),
+      getAccountsLocalHistoryTxs: jest.fn(async () => []),
+    },
+    serviceSetting: {
+      getIsEnableTransferAllowList: jest.fn(async () => false),
+    },
+  };
+
+  const service = new ServiceAccountProfile({ backgroundApi } as any);
+  (service as any).getClient = jest.fn(async () => ({ get: clientGet }));
+
+  return { service, backgroundApi, clientGet, validate };
+}
+
+const baseArgs = {
+  networkId: NETWORK_ID,
+  address: RECIPIENT,
+  accountId: ACCOUNT_ID,
+  enableAddressBook: true,
+  enableWalletName: true,
+  enableAddressInteractionStatus: true,
+  enableAddressContract: true,
+};
+
+describe('ServiceAccountProfile.queryAddress request overlap', () => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+
+  beforeEach(() => {
+    unhandled.length = 0;
+    process.on('unhandledRejection', onUnhandled);
+  });
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandled);
+  });
+
+  it('starts the badges request before server validation settles', async () => {
+    const { service, backgroundApi, clientGet, validate } = makeService();
+
+    const pending = service.queryAddress(baseArgs);
+    await flushMicrotasks();
+
+    // Server validation is still in flight...
+    expect(
+      backgroundApi.serviceValidator.validateAddress,
+    ).toHaveBeenCalledTimes(1);
+    // ...and the badges request must already be on the wire.
+    expect(clientGet.mock.calls.map(([path]) => path)).toContain(BADGES_PATH);
+
+    validate.resolve('valid');
+    const result = await pending;
+
+    expect(result.validStatus).toBe('valid');
+    expect(result.addressBadges).toEqual([{ type: 'success', label: 'ok' }]);
+    // The speculative response is reused; no second badges round trip.
+    expect(
+      clientGet.mock.calls.filter(([path]) => path === BADGES_PATH),
+    ).toHaveLength(1);
+    expect(clientGet.mock.calls.map(([path]) => path)).not.toContain(
+      VALIDATE_PATH,
+    );
+  });
+
+  it('drops the speculative badges result when server validation rejects the address', async () => {
+    const { service, clientGet, validate } = makeService();
+
+    const pending = service.queryAddress(baseArgs);
+    await flushMicrotasks();
+    validate.resolve('invalid');
+    const result = await pending;
+
+    expect(result.validStatus).toBe('invalid');
+    expect(result.addressBadges).toBeUndefined();
+    expect(result.addressInteractionStatus).toBeUndefined();
+    // Speculation is allowed to have fired; it just must not leak into result.
+    expect(
+      clientGet.mock.calls.filter(([path]) => path === BADGES_PATH).length,
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it('does not surface an unhandled rejection when the unused speculative request fails', async () => {
+    const getAccount = jest.fn(async () => {
+      throw new OneKeyLocalError('db unavailable');
+    });
+    const { service, validate } = makeService({ getAccount });
+
+    const pending = service.queryAddress(baseArgs);
+    await flushMicrotasks();
+    validate.resolve('invalid');
+    const result = await pending;
+    await flushMicrotasks();
+
+    expect(result.validStatus).toBe('invalid');
+    expect(unhandled).toHaveLength(0);
+  });
+
+  it('does not fire badges speculatively for input the local validator rejects', async () => {
+    const { service, clientGet, validate } = makeService({ localValid: false });
+
+    const pending = service.queryAddress(baseArgs);
+    await flushMicrotasks();
+
+    expect(clientGet).not.toHaveBeenCalled();
+
+    validate.resolve('invalid');
+    const result = await pending;
+    expect(result.validStatus).toBe('invalid');
+    expect(clientGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire badges when neither contract nor interaction checks are enabled', async () => {
+    const { service, clientGet, validate } = makeService();
+
+    const pending = service.queryAddress({
+      ...baseArgs,
+      enableAddressContract: false,
+      enableAddressInteractionStatus: false,
+    });
+    await flushMicrotasks();
+    validate.resolve('valid');
+    await pending;
+
+    expect(clientGet).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -433,6 +433,7 @@ class ServiceAccountProfile extends ServiceBase {
     checkAddressContract,
     tokenAddress,
     result,
+    pendingBadges,
   }: {
     accountId?: string;
     fromAddress?: string;
@@ -442,14 +443,18 @@ class ServiceAccountProfile extends ServiceBase {
     toAddress: string;
     tokenAddress?: string;
     result: IAddressQueryResult;
+    // A /badges request already in flight for this address; when given,
+    // it is awaited instead of issuing a new one.
+    pendingBadges?: Promise<IAccountBadgeResult>;
   }): Promise<void> {
-    const merged = await this.fetchBadgesDeduped({
-      networkId,
-      accountId,
-      toAddress,
-      checkInteractionStatus,
-      tokenAddress,
-    });
+    const merged = await (pendingBadges ??
+      this.fetchBadgesDeduped({
+        networkId,
+        accountId,
+        toAddress,
+        checkInteractionStatus,
+        tokenAddress,
+      }));
 
     const {
       isContract,
@@ -531,6 +536,7 @@ class ServiceAccountProfile extends ServiceBase {
       input: rawAddress,
     };
 
+    let isLocalValid = false;
     try {
       const { displayAddress, isValid } =
         await this.backgroundApi.serviceValidator.localValidateAddress({
@@ -540,6 +546,7 @@ class ServiceAccountProfile extends ServiceBase {
       if (isValid) {
         address = displayAddress;
         result.validAddress = address;
+        isLocalValid = true;
       }
     } catch (_e) {
       // noop
@@ -547,6 +554,34 @@ class ServiceAccountProfile extends ServiceBase {
 
     if (!networkId) {
       return result;
+    }
+
+    const shouldCheckBadges = Boolean(
+      enableAddressContract || (enableAddressInteractionStatus && accountId),
+    );
+    const checkInteractionStatus = Boolean(
+      enableAddressInteractionStatus && accountId,
+    );
+
+    // Server validation and /badges are independent round trips (~0.5 s each).
+    // Once the local validator accepts the input, start /badges right away so
+    // it overlaps with /validate-address instead of running after it. The
+    // promise is only consumed if the address survives validation and name
+    // resolution; otherwise it is dropped (the catch below keeps an unused
+    // rejection from surfacing as unhandled).
+    let speculativeBadges:
+      | { toAddress: string; promise: Promise<IAccountBadgeResult> }
+      | undefined;
+    if (isLocalValid && shouldCheckBadges) {
+      const promise = this.fetchBadgesDeduped({
+        networkId,
+        accountId,
+        toAddress: address,
+        checkInteractionStatus,
+        tokenAddress,
+      });
+      promise.catch(() => undefined);
+      speculativeBadges = { toAddress: address, promise };
     }
 
     if (!skipValidateAddress) {
@@ -704,10 +739,7 @@ class ServiceAccountProfile extends ServiceBase {
         }
       }
     }
-    if (
-      resolveAddress &&
-      (enableAddressContract || (enableAddressInteractionStatus && accountId))
-    ) {
+    if (resolveAddress && shouldCheckBadges) {
       let senderAddress: string | undefined;
       if (accountId) {
         try {
@@ -726,11 +758,15 @@ class ServiceAccountProfile extends ServiceBase {
         toAddress: resolveAddress,
         fromAddress: senderAddress,
         checkAddressContract: enableAddressContract,
-        checkInteractionStatus: Boolean(
-          enableAddressInteractionStatus && accountId,
-        ),
+        checkInteractionStatus,
         tokenAddress,
         result,
+        // Reuse the early request only when it targeted the same address
+        // (name resolution may have swapped the input for a resolved one).
+        pendingBadges:
+          speculativeBadges?.toAddress === resolveAddress
+            ? speculativeBadges.promise
+            : undefined,
       });
 
       // For EVM networks, override interaction status with transfer-recipient data


### PR DESCRIPTION
## Summary
- Start the `/wallet/v1/account/badges` request as soon as the local validator accepts the recipient input, instead of waiting for `/wallet/v1/account/validate-address` to finish.
- Thread the in-flight badges promise into `checkAccountBadges` via a new `pendingBadges` param so the early result is reused rather than re-fetched.
- Add `ServiceAccountProfile.queryAddress.test.ts` pinning the request ordering and the cases where speculation must not fire.

## Intent & Context
Reported on Slack (#C02207B6FNC, 2026-09-11): after pasting a recipient address in the Send address picker, the input spinner stayed visible for over 1 s. The network panel showed `validate-address` (572 ms) followed by `badges` (578 ms) back to back, and the reporter asked whether the two calls could run in parallel.

## Root Cause
`ServiceAccountProfile.queryAddress` awaited `serviceValidator.validateAddress` (server round trip) before reaching `checkAccountBadges` (second server round trip). The badges call only depends on the target address, account and token, not on the server validation verdict, so the serialisation was incidental to code order rather than a data dependency. Total spinner time was the sum of both round trips plus the 300 ms UI debounce.

## Design Decisions
- **Speculate only after local validation passes.** `localValidateAddress` already runs first and is a strong predictor of the server verdict, so the only wasted badges call is local-valid + server-invalid (or prohibit-send-to-self). Garbage input never fires an extra request.
- **Explicit promise threading instead of relying on `fetchBadgesDeduped`.** The dedup map drops entries on completion, so if the badges response arrived before validation finished, a second call would re-fetch. Passing the promise directly makes reuse deterministic.
- **Name-resolution guard.** The early promise is reused only when `speculativeBadges.toAddress === resolveAddress`; if a domain resolved to a different address the original fetch path runs unchanged.
- **Error semantics preserved.** A noop `.catch` prevents an unhandled rejection when the early promise is never consumed; when it is consumed, a rejection still propagates exactly as before (UI falls back to `validStatus: 'unknown'`).
- **Out of scope (left serial on purpose):** on EVM, when badges do not report INTERACTED, `serviceHistory.fetchTransferRecipients` still runs afterwards as a third hop. Parallelising it would add one request per query for already-interacted addresses unless it gets a short per-account cache; that is a traffic trade-off to decide separately.

## Changes Detail
- `packages/kit-bg/src/services/ServiceAccountProfile.ts`: track `isLocalValid`; hoist `shouldCheckBadges` / `checkInteractionStatus`; start `fetchBadgesDeduped` speculatively; `checkAccountBadges` accepts `pendingBadges` and awaits it when provided.
- `packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts`: 5 cases — badges fires before validation settles and is reused once; speculative result dropped on `invalid`; no unhandled rejection when the unused request fails; no speculation for locally invalid input; no badges call when neither contract nor interaction checks are enabled.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (shared `kit-bg` path used by Send AddressInput, Swap incognito recipient input and BulkSend)
- **Risk Areas**: the reuse guard for name-resolved addresses; slight increase in badges traffic for addresses the server rejects but the local validator accepts.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceAccountProfile.queryAddress.test.ts` (ordering case fails on `x`, passes with this change)
- [x] `yarn agent:check --profile commit` green
- [ ] Send flow: paste a valid EVM address, confirm in the network panel that `validate-address` and `badges` overlap and the spinner ends after the longer of the two
- [ ] Paste an ENS/domain name and a random invalid string: badges/labels still correct, no extra badges call for the invalid string
- [ ] Swap incognito recipient and BulkSend address inputs still show interaction/label badges
