### PR TITLE
fix: Ledger install dialog under the stage, and a smaller PIN stage (OK-62656, OK-62091)

### DIFF
--- a/apps/mobile/.rnstorybook/preview.tsx
+++ b/apps/mobile/.rnstorybook/preview.tsx
@@ -14,6 +14,7 @@ import { Portal } from '@onekeyhq/components/src/hocs/Portal';
 import { ConfigProvider } from '@onekeyhq/components/src/hocs/Provider';
 import { OverlayContainer } from '@onekeyhq/components/src/layouts/OverlayContainer';
 import { Stack } from '@onekeyhq/components/src/primitives/Stack';
+import { HARDWARE_STAGE_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
 
 import { HyperlinkTextStub } from './HyperlinkTextStub';
 
@@ -84,18 +85,25 @@ const preview: Preview = {
               FullWindowOverlay window, because that is where the app
               mounts it since 8c0391dfa8 (the stage must cover native
               modal pages on iOS). Keeping the shell on the same window
-              means on-device rounds exercise the real geometry — the
-              overlay window's own touch delivery included. The wrapper
-              gives the portal a viewport on the pass-through platforms:
-              OverlayContainer is a full-window host only on iOS, and
-              MorphOverlay's layer anchors absolute to fill it. */}
+              means on-device rounds exercise the window's geometry and
+              touch delivery; the app additionally nests the stage in its
+              own OverlayContainer with a raise token (OK-62422), which
+              this shell does not replay. The wrapper mirrors the app's
+              (FullWindowOverlayContainer): a viewport on the
+              pass-through platforms — OverlayContainer is a full-window
+              host only on iOS, and MorphOverlay's layer anchors absolute
+              to fill it — kept as a native view, since RN 0.86 Fabric
+              flattens a layout-only box-none container and kills
+              hit-testing for the whole portal subtree. */}
           <Stack
             position="absolute"
             top={0}
             left={0}
             right={0}
             bottom={0}
+            zIndex={HARDWARE_STAGE_Z_INDEX}
             pointerEvents="box-none"
+            collapsable={false}
           >
             <Portal.Container name={Portal.Constant.HARDWARE_UI_STATE_DIALOG} />
           </Stack>

--- a/apps/mobile/.rnstorybook/preview.tsx
+++ b/apps/mobile/.rnstorybook/preview.tsx
@@ -1,6 +1,10 @@
 import type { PropsWithChildren } from 'react';
 
 import { useColorScheme } from 'react-native';
+import {
+  SafeAreaInsetsContext,
+  initialWindowMetrics,
+} from 'react-native-safe-area-context';
 
 import {
   ShowToastProvider,
@@ -14,6 +18,13 @@ import { Stack } from '@onekeyhq/components/src/primitives/Stack';
 import { HyperlinkTextStub } from './HyperlinkTextStub';
 
 import type { Preview } from '@storybook/react';
+
+const WINDOW_INSETS = initialWindowMetrics?.insets ?? {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
 
 function ShellProvider({ children }: PropsWithChildren) {
   // Theme follows the system appearance — the on-device UI has no toolbar
@@ -30,7 +41,16 @@ function ShellProvider({ children }: PropsWithChildren) {
       locale="en-US"
       HyperlinkText={HyperlinkTextStub}
     >
-      {children}
+      {/* Window insets for the whole decorated tree: ConfigProvider's own
+          SafeAreaProvider measures the story canvas — a view already
+          under the Storybook chrome, so its top inset settles at 0 once
+          the native view reports — while components that seat
+          themselves against the real status bar band (the hardware
+          stage, the toasts) read the app's root provider in production.
+          The main window's launch metrics stand in for it here. */}
+      <SafeAreaInsetsContext.Provider value={WINDOW_INSETS}>
+        {children}
+      </SafeAreaInsetsContext.Provider>
     </ConfigProvider>
   );
 }
@@ -60,26 +80,28 @@ const preview: Preview = {
             Storybook UI. */}
         <OverlayContainer>
           <Portal.Container name={Portal.Constant.FULL_WINDOW_OVERLAY_PORTAL} />
+          {/* The hardware stage's mount point — INSIDE the
+              FullWindowOverlay window, because that is where the app
+              mounts it since 8c0391dfa8 (the stage must cover native
+              modal pages on iOS). Keeping the shell on the same window
+              means on-device rounds exercise the real geometry — the
+              overlay window's own touch delivery included. The wrapper
+              gives the portal a viewport on the pass-through platforms:
+              OverlayContainer is a full-window host only on iOS, and
+              MorphOverlay's layer anchors absolute to fill it. */}
+          <Stack
+            position="absolute"
+            top={0}
+            left={0}
+            right={0}
+            bottom={0}
+            pointerEvents="box-none"
+          >
+            <Portal.Container name={Portal.Constant.HARDWARE_UI_STATE_DIALOG} />
+          </Stack>
           <ShowToastProvider />
           <Toaster />
         </OverlayContainer>
-        {/* The hardware stage's mount point — deliberately OFF the
-            FullWindowOverlay window, matching the app's own container
-            order (FullWindowOverlayContainer mounts it beside, not
-            inside): the stage sits at the main window's dialog level, so
-            presentations opened over it — the in-app browser, system
-            sheets — actually cover it. Canvas-wide and box-none: the
-            stage positions itself, the UI behind stays live. */}
-        <Stack
-          position="absolute"
-          top={0}
-          left={0}
-          right={0}
-          bottom={0}
-          pointerEvents="box-none"
-        >
-          <Portal.Container name={Portal.Constant.HARDWARE_UI_STATE_DIALOG} />
-        </Stack>
       </ShellProvider>
     ),
   ],

--- a/packages/components/src/composite/DeviceStage/consts.ts
+++ b/packages/components/src/composite/DeviceStage/consts.ts
@@ -20,15 +20,16 @@ export const PORT_HEIGHT = 376;
 
 /**
  * The compact arrangement (the confirm step): the replica shrinks to a
- * full-body miniature. Scale is the flow spec's 80/290; the port height
- * covers the tallest shell the window means to show whole — the Touch,
- * 280 wide x its aspect x scale ≈ 129.6 — so the Classic, Pro, Pro 2 and
- * Touch miniatures all keep their feet, the foot dissolve below the box.
- * The Mini's tall body (~166.7 scaled) still overruns and loses its foot
- * to the window: accepted (2026-08-31). A per-model port is not a
- * drop-in: the port value is the height-arrange token in DeviceStage
- * (the compact/full discriminator is the arrangement kind), so that
- * role would need its own flag first.
+ * full-body miniature COMPACT_DEVICE_WIDTH wide — the flow spec's 80/290
+ * of the design stage — whatever width the full stage plays at. The port
+ * height covers the tallest shell the window means to show whole — the
+ * Touch, 77.28 wide x its aspect ≈ 129.6 — so the Classic, Pro, Pro 2
+ * and Touch miniatures all keep their feet, the foot dissolve below the
+ * box. The Mini's tall body (~166.7 scaled) still overruns and loses its
+ * foot to the window: accepted (2026-08-31). A per-model port is a plain
+ * number change: the compact/full discriminator and the height-arrange
+ * token in DeviceStage are the arrangement kind, not the port value.
  */
 export const COMPACT_SCALE = 0.276;
+export const COMPACT_DEVICE_WIDTH = STAGE_DESIGN_WIDTH * COMPACT_SCALE;
 export const COMPACT_PORT_HEIGHT = 130;

--- a/packages/components/src/composite/DeviceStage/consts.ts
+++ b/packages/components/src/composite/DeviceStage/consts.ts
@@ -1,10 +1,20 @@
-/** Replica width on the stage, in pt. */
-export const REPLICA_WIDTH = 280;
+/** The width the flow spec states the stage's numbers at, in pt: the
+ * port, the words' tuck and the compact scale below are all measured
+ * against a replica this wide, and DeviceStage scales them to the width
+ * in play. */
+export const STAGE_DESIGN_WIDTH = 280;
+
+/** Replica width on the stage, in pt — the width in play. Set under the
+ * spec's 280 since OK-62091 (the PIN card read as too big on phones:
+ * at 220 the card drops from 55% to 47% of an iPhone 17 Pro screen while
+ * the device's own screen stays 181pt wide, its keypad still readable).
+ * DeviceStage's `replicaWidth` prop overrides it per instance. */
+export const REPLICA_WIDTH = 220;
 
 /**
- * Port height: the crop keeps the screen and keys, and the port's mask
- * dissolves the foot — the device itself fades out, so the treatment works
- * over paint and glass alike.
+ * Port height at STAGE_DESIGN_WIDTH: the crop keeps the screen and keys,
+ * and the port's mask dissolves the foot — the device itself fades out,
+ * so the treatment works over paint and glass alike.
  */
 export const PORT_HEIGHT = 376;
 
@@ -16,9 +26,9 @@ export const PORT_HEIGHT = 376;
  * Touch miniatures all keep their feet, the foot dissolve below the box.
  * The Mini's tall body (~166.7 scaled) still overruns and loses its foot
  * to the window: accepted (2026-08-31). A per-model port is not a
- * drop-in: the port value doubles as the compact/full discriminator and
- * as the height-arrange token in DeviceStage, so those roles would need
- * their own flag first.
+ * drop-in: the port value is the height-arrange token in DeviceStage
+ * (the compact/full discriminator is the arrangement kind), so that
+ * role would need its own flag first.
  */
 export const COMPACT_SCALE = 0.276;
 export const COMPACT_PORT_HEIGHT = 130;

--- a/packages/components/src/composite/DeviceStage/index.tsx
+++ b/packages/components/src/composite/DeviceStage/index.tsx
@@ -70,6 +70,7 @@ import {
   COMPACT_SCALE,
   PORT_HEIGHT,
   REPLICA_WIDTH,
+  STAGE_DESIGN_WIDTH,
 } from './consts';
 import { PassphraseIntro } from './PassphraseIntro';
 import { QrPresent, QrScanFrame } from './QrPanels';
@@ -244,16 +245,13 @@ type IStageScene = (typeof STAGE_SCENES)[number];
 /** Idle beats between the staggered warm-up builds. */
 const SCENE_WARM_MS = 350;
 
-/** The capsule's device is the standing replica worn small: the spec's
- * thumbnail width over the stage's own. */
-const THUMB_SCALE = CAPSULE_ROW.thumbDeviceWidth / REPLICA_WIDTH;
 /** Where along the capsule↔card progress the device teleports between
  * its two seats — inside the cross-fade gap (capsule content is gone by
  * PILL_OUT_END, card content arrives from CARD_IN_START), so the jump is
  * never on screen. */
 const SEAT_SWAP_AT = 0.35;
-/** First-frame stand-in for the replica's natural height, corrected by
- * its first layout report. */
+/** First-frame stand-in for the replica's natural height at
+ * STAGE_DESIGN_WIDTH, corrected by its first layout report. */
 const DEVICE_ESTIMATED_HEIGHT = 560;
 
 /**
@@ -288,10 +286,11 @@ const FOG_LOCATIONS = [0, 0.58, 0.87] as const;
  * and the endings. Built off the two staged-step lists so membership is
  * stated once (see ./stepCopy).
  */
-const REPLICA_PORT = Object.fromEntries([
-  ...FULL_STAGED_STEPS.map((step) => [step, PORT_HEIGHT] as const),
-  ...COMPACT_STAGED_STEPS.map((step) => [step, COMPACT_PORT_HEIGHT] as const),
-]) as Partial<Record<IDeviceStageStep, number>>;
+type IReplicaArrangement = 'full' | 'compact';
+const REPLICA_ARRANGEMENT = Object.fromEntries([
+  ...FULL_STAGED_STEPS.map((step) => [step, 'full'] as const),
+  ...COMPACT_STAGED_STEPS.map((step) => [step, 'compact'] as const),
+]) as Partial<Record<IDeviceStageStep, IReplicaArrangement>>;
 
 /**
  * The staged row, to the design: the replica stands `top` under the
@@ -307,12 +306,35 @@ const STAGE_ROW = {
 };
 /** Where the replica layer's top sits on the face. */
 const REPLICA_TOP = CARD.padTop + STAGE_ROW.top;
-/** The words' margin over the spacer, per port: the full stage tucks
- * them into the foot, the miniature clears them. */
-function wordsMarginFor(port: number): number {
-  return port === PORT_HEIGHT
-    ? STAGE_ROW.fullHeight - STAGE_ROW.top - PORT_HEIGHT
-    : STAGE_ROW.bottom;
+/**
+ * The replica's geometry at the width in play (`replicaWidth`; the
+ * default is REPLICA_WIDTH, the OK-62091 call). The design states its
+ * numbers at STAGE_DESIGN_WIDTH; the full stage — its port and the
+ * words' tuck into the foot — keeps its proportion of the device, while
+ * the capsule thumbnail and the confirm miniature keep their own
+ * absolute widths, so the width only grows or shrinks the full stage.
+ */
+function replicaMetricsFor(replicaWidth: number) {
+  const scale = replicaWidth / STAGE_DESIGN_WIDTH;
+  return {
+    fullPort: Math.round(PORT_HEIGHT * scale),
+    fullWordsMargin: Math.round(
+      (STAGE_ROW.fullHeight - STAGE_ROW.top - PORT_HEIGHT) * scale,
+    ),
+    compactScale: COMPACT_SCALE / scale,
+    thumbScale: CAPSULE_ROW.thumbDeviceWidth / replicaWidth,
+    estimatedHeight: Math.round(DEVICE_ESTIMATED_HEIGHT * scale),
+  };
+}
+type IReplicaMetrics = ReturnType<typeof replicaMetricsFor>;
+
+/** The words' margin over the spacer, per arrangement: the full stage
+ * tucks them into the foot, the miniature clears them. */
+function wordsMarginFor(
+  kind: IReplicaArrangement,
+  metrics: IReplicaMetrics,
+): number {
+  return kind === 'full' ? metrics.fullWordsMargin : STAGE_ROW.bottom;
 }
 
 const styles = StyleSheet.create({
@@ -325,27 +347,24 @@ const styles = StyleSheet.create({
   // A transform costs the compositor nothing — the same lane the
   // shell's own positionStyle rides. (One cut off the per-frame commit
   // bill, not the whole bill — the 2026-08-28 audit's ledger.)
+  // Width rides in per instance (the replica width in play).
   replicaLayer: {
     position: 'absolute',
     top: REPLICA_TOP,
     left: 0,
-    width: REPLICA_WIDTH,
   },
   portWindow: {
-    width: REPLICA_WIDTH,
     overflow: 'hidden',
   },
   miniature: {
     transformOrigin: 'top',
   },
-  // Full-port geometry, so the fade stays put while the window above
-  // animates.
+  // Full-port geometry (sized per instance), so the fade stays put while
+  // the window above animates.
   fog: {
     position: 'absolute',
     left: 0,
     top: 0,
-    width: REPLICA_WIDTH,
-    height: PORT_HEIGHT,
   },
   fogFill: {
     flex: 1,
@@ -466,6 +485,7 @@ function fireStepHaptic(step: IDeviceStageStep) {
 export function DeviceStage({
   step,
   deviceType,
+  replicaWidth = REPLICA_WIDTH,
   deviceName,
   connectionType,
   waitStalled,
@@ -519,6 +539,11 @@ export function DeviceStage({
   onInstallConfirm,
 }: IDeviceStageProps) {
   const intl = useIntl();
+  const metrics = useMemo(
+    () => replicaMetricsFor(replicaWidth),
+    [replicaWidth],
+  );
+  const { fullPort, compactScale, thumbScale, estimatedHeight } = metrics;
   const errorCopy = ERROR_TEXT[errorReason ?? 'generic'];
   const localizedErrorMessage = resolveErrorMessage(
     intl,
@@ -624,7 +649,9 @@ export function DeviceStage({
   } = morph;
   const hidden = pose === 'hidden';
 
-  const shownPort = REPLICA_PORT[shownStep];
+  const shownKind = REPLICA_ARRANGEMENT[shownStep];
+  const shownPort =
+    shownKind && (shownKind === 'full' ? fullPort : COMPACT_PORT_HEIGHT);
 
   // A refused entry — inputError arriving — is a failure under the
   // person's fingers: the error buzz in sync with the panel's own
@@ -789,9 +816,9 @@ export function DeviceStage({
   // during the out beat and the land reveals them already true.
   // Render-time ref write on purpose: read in the same pass, idempotent.
   const stageWordsRef = useRef<IDeviceStageStep>(
-    REPLICA_PORT[step] ? step : 'enterPin',
+    REPLICA_ARRANGEMENT[step] ? step : 'enterPin',
   );
-  if (REPLICA_PORT[step]) {
+  if (REPLICA_ARRANGEMENT[step]) {
     stageWordsRef.current = step;
   }
   const stageWordsStep = stageWordsRef.current;
@@ -830,7 +857,7 @@ export function DeviceStage({
   const stageTailEpoch = stageTailEpochRef.current;
   // The replica's natural height, for seating the thumbnail arrangement;
   // scale transforms leave layout alone, so this reports once.
-  const [deviceHeight, setDeviceHeight] = useState(DEVICE_ESTIMATED_HEIGHT);
+  const [deviceHeight, setDeviceHeight] = useState(estimatedHeight);
   const handleDeviceLayout = useCallback((event: LayoutChangeEvent) => {
     setDeviceHeight(Math.ceil(event.nativeEvent.layout.height));
   }, []);
@@ -840,7 +867,7 @@ export function DeviceStage({
   // only when the shown step does: on the empty beat of a crossing, or
   // live inside the stage.
   const spacerTarget = shownPort ? STAGE_ROW.top + shownPort : 0;
-  const wordsMarginTarget = shownPort ? wordsMarginFor(shownPort) : 0;
+  const wordsMarginTarget = shownKind ? wordsMarginFor(shownKind, metrics) : 0;
   // While the card is on show `activeArrangement` IS the shown
   // arrangement; under the other poses the card height goes unused.
   const shownPanel = panelMeasures[activeArrangement];
@@ -963,13 +990,13 @@ export function DeviceStage({
   // port's own fact — the compact port IS the scaled replica — so one
   // derivation replaces a second step list.
   const replicaShown = useSharedValue(shownPort ? 1 : 0);
-  const portHeight = useSharedValue(shownPort ?? PORT_HEIGHT);
+  const portHeight = useSharedValue(shownPort ?? fullPort);
   const deviceScale = useSharedValue(
-    shownPort === COMPACT_PORT_HEIGHT ? COMPACT_SCALE : 1,
+    shownKind === 'compact' ? compactScale : 1,
   );
   const spacerHeight = useSharedValue(spacerTarget);
   const wordsMargin = useSharedValue(wordsMarginTarget);
-  const scaleTarget = shownPort === COMPACT_PORT_HEIGHT ? COMPACT_SCALE : 1;
+  const scaleTarget = shownKind === 'compact' ? compactScale : 1;
   const handleAim = useCallback(
     (facts: IMorphAimFacts) => {
       // The gate lands in one piece — the branch fades (swapFade and the
@@ -1051,11 +1078,11 @@ export function DeviceStage({
     // Layout-free centering: the box's live width in a transform,
     // snapped to the physical pixel grid — Yoga rounds layout but a
     // transform is applied verbatim, and window widths that leave
-    // morphWidth - REPLICA_WIDTH odd would otherwise rest the whole
+    // morphWidth - replicaWidth odd would otherwise rest the whole
     // replica, screen glyphs included, on a half-point boundary and
     // read as jagged text.
     const centerX =
-      Math.round(((morphWidth.value - REPLICA_WIDTH) / 2) * PIXEL_GRID) /
+      Math.round(((morphWidth.value - replicaWidth) / 2) * PIXEL_GRID) /
       PIXEL_GRID;
     if (progress.value < SEAT_SWAP_AT) {
       return {
@@ -1093,7 +1120,14 @@ export function DeviceStage({
           : Math.max(staged, REPLICA_HOLD_ALPHA),
       transform: [{ translateX: centerX }, { translateY: 0 }],
     };
-  }, [capsuleSeatShown, morphWidth, progress, replicaShown, swapFade]);
+  }, [
+    capsuleSeatShown,
+    morphWidth,
+    progress,
+    replicaShown,
+    replicaWidth,
+    swapFade,
+  ]);
   // At the thumbnail seat the window opens to the capsule's own height —
   // nothing to crop, the whole device is on show.
   const portWindowStyle = useAnimatedStyle(
@@ -1117,9 +1151,9 @@ export function DeviceStage({
               morphWidth.value / 2,
           },
           {
-            translateY: pillHeight / 2 - (deviceHeight * THUMB_SCALE) / 2,
+            translateY: pillHeight / 2 - (deviceHeight * thumbScale) / 2,
           },
-          { scale: THUMB_SCALE },
+          { scale: thumbScale },
         ],
       };
     }
@@ -1130,7 +1164,7 @@ export function DeviceStage({
         { scale: deviceScale.value },
       ],
     };
-  }, [deviceHeight, deviceScale, morphWidth, pillHeight, progress]);
+  }, [deviceHeight, deviceScale, morphWidth, pillHeight, progress, thumbScale]);
   // The fog belongs to the stage seats only: the capsule wears the whole
   // device, foot and all.
   const fogMotionStyle = useAnimatedStyle(
@@ -1146,21 +1180,31 @@ export function DeviceStage({
     [wordsMargin],
   );
 
+  // The replica width in play and the fog's full-port geometry ride in
+  // as plain styles beside the animated ones.
+  const replicaWidthStyle = useMemo(
+    () => ({ width: replicaWidth }),
+    [replicaWidth],
+  );
+  const fogSizeStyle = useMemo(
+    () => ({ width: replicaWidth, height: fullPort }),
+    [fullPort, replicaWidth],
+  );
   const replicaStyle = useMemo(
-    () => [styles.replicaLayer, replicaLayerStyle],
-    [replicaLayerStyle],
+    () => [styles.replicaLayer, replicaWidthStyle, replicaLayerStyle],
+    [replicaLayerStyle, replicaWidthStyle],
   );
   const portStyle = useMemo(
-    () => [styles.portWindow, portWindowStyle],
-    [portWindowStyle],
+    () => [styles.portWindow, replicaWidthStyle, portWindowStyle],
+    [portWindowStyle, replicaWidthStyle],
   );
   const deviceStyle = useMemo(
     () => [styles.miniature, deviceSeatStyle],
     [deviceSeatStyle],
   );
   const fogStyle = useMemo(
-    () => [styles.fog, fogMotionStyle],
-    [fogMotionStyle],
+    () => [styles.fog, fogSizeStyle, fogMotionStyle],
+    [fogMotionStyle, fogSizeStyle],
   );
   const wordsStyle = useMemo(
     () => [styles.wordsBlock, wordsFlowStyle],
@@ -2045,7 +2089,7 @@ export function DeviceStage({
           deviceType={deviceType ?? 'unknown'}
           animation={activeScene}
           warmScenes={builtScenes}
-          width={REPLICA_WIDTH}
+          width={replicaWidth}
           instantEntry={sceneEntryInstant}
           // Also paused through the pose flight: the scene clock drives
           // its keyframe worklets every frame, a fixed tax the flight's
@@ -2063,6 +2107,7 @@ export function DeviceStage({
       handleDeviceLayout,
       hidden,
       poseInFlight,
+      replicaWidth,
       sceneEntryInstant,
     ],
   );

--- a/packages/components/src/composite/DeviceStage/index.tsx
+++ b/packages/components/src/composite/DeviceStage/index.tsx
@@ -66,8 +66,8 @@ import { AuthChecklist, AuthFailureCard } from './AuthPanels';
 import { BluetoothBadge } from './BluetoothBadge';
 import { CardValue } from './CardValue';
 import {
+  COMPACT_DEVICE_WIDTH,
   COMPACT_PORT_HEIGHT,
-  COMPACT_SCALE,
   PORT_HEIGHT,
   REPLICA_WIDTH,
   STAGE_DESIGN_WIDTH,
@@ -318,23 +318,18 @@ function replicaMetricsFor(replicaWidth: number) {
   const scale = replicaWidth / STAGE_DESIGN_WIDTH;
   return {
     fullPort: Math.round(PORT_HEIGHT * scale),
-    fullWordsMargin: Math.round(
-      (STAGE_ROW.fullHeight - STAGE_ROW.top - PORT_HEIGHT) * scale,
-    ),
-    compactScale: COMPACT_SCALE / scale,
+    /** The words' margin over the spacer, per arrangement: the full
+     * stage tucks them into the foot, the miniature clears them. */
+    wordsMarginByKind: {
+      full: Math.round(
+        (STAGE_ROW.fullHeight - STAGE_ROW.top - PORT_HEIGHT) * scale,
+      ),
+      compact: STAGE_ROW.bottom,
+    } satisfies Record<IReplicaArrangement, number>,
+    compactScale: COMPACT_DEVICE_WIDTH / replicaWidth,
     thumbScale: CAPSULE_ROW.thumbDeviceWidth / replicaWidth,
     estimatedHeight: Math.round(DEVICE_ESTIMATED_HEIGHT * scale),
   };
-}
-type IReplicaMetrics = ReturnType<typeof replicaMetricsFor>;
-
-/** The words' margin over the spacer, per arrangement: the full stage
- * tucks them into the foot, the miniature clears them. */
-function wordsMarginFor(
-  kind: IReplicaArrangement,
-  metrics: IReplicaMetrics,
-): number {
-  return kind === 'full' ? metrics.fullWordsMargin : STAGE_ROW.bottom;
 }
 
 const styles = StyleSheet.create({
@@ -539,11 +534,13 @@ export function DeviceStage({
   onInstallConfirm,
 }: IDeviceStageProps) {
   const intl = useIntl();
-  const metrics = useMemo(
-    () => replicaMetricsFor(replicaWidth),
-    [replicaWidth],
-  );
-  const { fullPort, compactScale, thumbScale, estimatedHeight } = metrics;
+  const {
+    fullPort,
+    wordsMarginByKind,
+    compactScale,
+    thumbScale,
+    estimatedHeight,
+  } = replicaMetricsFor(replicaWidth);
   const errorCopy = ERROR_TEXT[errorReason ?? 'generic'];
   const localizedErrorMessage = resolveErrorMessage(
     intl,
@@ -867,7 +864,7 @@ export function DeviceStage({
   // only when the shown step does: on the empty beat of a crossing, or
   // live inside the stage.
   const spacerTarget = shownPort ? STAGE_ROW.top + shownPort : 0;
-  const wordsMarginTarget = shownKind ? wordsMarginFor(shownKind, metrics) : 0;
+  const wordsMarginTarget = shownKind ? wordsMarginByKind[shownKind] : 0;
   // While the card is on show `activeArrangement` IS the shown
   // arrangement; under the other poses the card height goes unused.
   const shownPanel = panelMeasures[activeArrangement];
@@ -986,17 +983,15 @@ export function DeviceStage({
 
   // The stage's own flow, aimed on the container's clock through onAim:
   // the replica gate, the staged port and miniature scale, and the
-  // column's spacer and words margin. The miniature's scale is the
-  // port's own fact — the compact port IS the scaled replica — so one
-  // derivation replaces a second step list.
+  // column's spacer and words margin. The arrangement kind picks the
+  // miniature's scale; the compact miniature keeps its absolute width,
+  // so its scale divides out the width in play.
+  const scaleTarget = shownKind === 'compact' ? compactScale : 1;
   const replicaShown = useSharedValue(shownPort ? 1 : 0);
   const portHeight = useSharedValue(shownPort ?? fullPort);
-  const deviceScale = useSharedValue(
-    shownKind === 'compact' ? compactScale : 1,
-  );
+  const deviceScale = useSharedValue(scaleTarget);
   const spacerHeight = useSharedValue(spacerTarget);
   const wordsMargin = useSharedValue(wordsMarginTarget);
-  const scaleTarget = shownKind === 'compact' ? compactScale : 1;
   const handleAim = useCallback(
     (facts: IMorphAimFacts) => {
       // The gate lands in one piece — the branch fades (swapFade and the
@@ -1182,29 +1177,25 @@ export function DeviceStage({
 
   // The replica width in play and the fog's full-port geometry ride in
   // as plain styles beside the animated ones.
-  const replicaWidthStyle = useMemo(
-    () => ({ width: replicaWidth }),
-    [replicaWidth],
-  );
-  const fogSizeStyle = useMemo(
-    () => ({ width: replicaWidth, height: fullPort }),
-    [fullPort, replicaWidth],
-  );
   const replicaStyle = useMemo(
-    () => [styles.replicaLayer, replicaWidthStyle, replicaLayerStyle],
-    [replicaLayerStyle, replicaWidthStyle],
+    () => [styles.replicaLayer, { width: replicaWidth }, replicaLayerStyle],
+    [replicaLayerStyle, replicaWidth],
   );
   const portStyle = useMemo(
-    () => [styles.portWindow, replicaWidthStyle, portWindowStyle],
-    [portWindowStyle, replicaWidthStyle],
+    () => [styles.portWindow, { width: replicaWidth }, portWindowStyle],
+    [portWindowStyle, replicaWidth],
   );
   const deviceStyle = useMemo(
     () => [styles.miniature, deviceSeatStyle],
     [deviceSeatStyle],
   );
   const fogStyle = useMemo(
-    () => [styles.fog, fogSizeStyle, fogMotionStyle],
-    [fogMotionStyle, fogSizeStyle],
+    () => [
+      styles.fog,
+      { width: replicaWidth, height: fullPort },
+      fogMotionStyle,
+    ],
+    [fogMotionStyle, fullPort, replicaWidth],
   );
   const wordsStyle = useMemo(
     () => [styles.wordsBlock, wordsFlowStyle],
@@ -2223,7 +2214,7 @@ export function DeviceStage({
       morph={morph}
       cardInnerHeight={cardInnerHeight}
       cardContentMeasured={shownPanelMeasured}
-      heightArrangeToken={shownPort}
+      heightArrangeToken={shownKind}
       onAim={handleAim}
       onDismiss={onClose}
       dismissLabel={dismissLabel}

--- a/packages/components/src/composite/DeviceStage/stories/Console.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Console.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
     passphraseMode: 'verify',
     errorReason: 'rejected',
     authFailureReason: 'unofficialDevice',
-    replicaWidth: 220,
+    replicaWidth: DEMO.replicaWidth,
   },
   argTypes: {
     step: ARG_TYPES.step,

--- a/packages/components/src/composite/DeviceStage/stories/Console.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Console.stories.tsx
@@ -23,6 +23,7 @@ const meta = {
     passphraseMode: 'verify',
     errorReason: 'rejected',
     authFailureReason: 'unofficialDevice',
+    replicaWidth: 220,
   },
   argTypes: {
     step: ARG_TYPES.step,
@@ -31,6 +32,7 @@ const meta = {
     errorReason: ARG_TYPES.errorReason,
     authFailureReason: ARG_TYPES.authFailureReason,
     qrValue: ARG_TYPES.qrValue,
+    replicaWidth: ARG_TYPES.replicaWidth,
   },
 } satisfies Meta<typeof DeviceStage>;
 

--- a/packages/components/src/composite/DeviceStage/stories/Passphrase.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Passphrase.stories.tsx
@@ -22,11 +22,13 @@ const meta = {
     // Add-hidden-wallet titling and its Keep-accessible switch. The
     // empty-entry refusal is common to both.
     passphraseMode: 'verify',
+    replicaWidth: 220,
   },
   argTypes: {
     step: ARG_TYPES.step,
     deviceType: ARG_TYPES.deviceType,
     passphraseMode: ARG_TYPES.passphraseMode,
+    replicaWidth: ARG_TYPES.replicaWidth,
   },
 } satisfies Meta<typeof DeviceStage>;
 

--- a/packages/components/src/composite/DeviceStage/stories/Passphrase.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Passphrase.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     // Add-hidden-wallet titling and its Keep-accessible switch. The
     // empty-entry refusal is common to both.
     passphraseMode: 'verify',
-    replicaWidth: 220,
+    replicaWidth: DEMO.replicaWidth,
   },
   argTypes: {
     step: ARG_TYPES.step,

--- a/packages/components/src/composite/DeviceStage/stories/Pin.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Pin.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     step: 'off',
     deviceType: 'pro2',
     deviceName: DEMO.deviceName,
-    replicaWidth: 220,
+    replicaWidth: DEMO.replicaWidth,
   },
   argTypes: {
     step: ARG_TYPES.step,

--- a/packages/components/src/composite/DeviceStage/stories/Pin.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Pin.stories.tsx
@@ -20,10 +20,12 @@ const meta = {
     step: 'off',
     deviceType: 'pro2',
     deviceName: DEMO.deviceName,
+    replicaWidth: 220,
   },
   argTypes: {
     step: ARG_TYPES.step,
     deviceType: ARG_TYPES.deviceType,
+    replicaWidth: ARG_TYPES.replicaWidth,
   },
 } satisfies Meta<typeof DeviceStage>;
 

--- a/packages/components/src/composite/DeviceStage/stories/harness.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/harness.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { Keyboard, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DeviceStage } from '@onekeyhq/components/src/composite/DeviceStage';
 import type {
@@ -311,11 +312,15 @@ export function StageHost({
   children: ReactNode;
 }) {
   const { height } = useWindowDimensions();
+  // The portal is the full window on device (the preview mounts the stage
+  // on the overlay window), so the bar clears the status bar band by the
+  // window's own inset; the web canvas reports none.
+  const { top: barTop } = useSafeAreaInsets();
   const bar = useMemo(
     () => (
       <XStack
         position="absolute"
-        top={0}
+        top={barTop}
         left={0}
         right={0}
         p="$2"
@@ -326,7 +331,7 @@ export function StageHost({
         {children}
       </XStack>
     ),
-    [children],
+    [barTop, children],
   );
   return (
     <Stack minHeight={height - 190}>
@@ -384,4 +389,9 @@ export const ARG_TYPES = {
     ],
   },
   qrValue: { control: 'text' },
+  // OK-62091's tuning knob: the full stage's device width; the port and
+  // the card height follow.
+  replicaWidth: {
+    control: { type: 'range', min: 160, max: 320, step: 4 },
+  },
 } as const;

--- a/packages/components/src/composite/DeviceStage/stories/harness.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/harness.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { Keyboard, useWindowDimensions } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DeviceStage } from '@onekeyhq/components/src/composite/DeviceStage';
 import type {
@@ -10,11 +9,13 @@ import type {
   IDeviceStageProps,
   IDeviceStageStep,
 } from '@onekeyhq/components/src/composite/DeviceStage';
+import { REPLICA_WIDTH } from '@onekeyhq/components/src/composite/DeviceStage/consts';
 import {
   useDeviceStageEscapeOwner,
   useDeviceStageExitPolicy,
 } from '@onekeyhq/components/src/composite/DeviceStage/useDeviceStageExitPolicy';
 import { Portal } from '@onekeyhq/components/src/hocs/Portal';
+import { useSafeAreaInsets } from '@onekeyhq/components/src/hooks/useLayout';
 import { Button } from '@onekeyhq/components/src/primitives/Button';
 import { Stack, XStack } from '@onekeyhq/components/src/primitives/Stack';
 
@@ -354,6 +355,9 @@ export const DEMO = {
     },
   ],
   qrValue: '0x627Ddbef61C811af05288Cd79db324fCac914AeF',
+  /** The range control's seed: the width that ships, so the stories
+   * follow the next retune instead of pinning a stale number. */
+  replicaWidth: REPLICA_WIDTH,
 };
 
 export const ARG_TYPES = {

--- a/packages/components/src/composite/DeviceStage/type.ts
+++ b/packages/components/src/composite/DeviceStage/type.ts
@@ -169,6 +169,13 @@ export interface IDeviceStageProps {
    * third-party flows (`vendor` set) omit it — their devices have no
    * code-drawn replica and the capsule wears the product shot instead. */
   deviceType?: IHardwareDeviceType;
+  /**
+   * The standing replica's width on the full stage, in pt — the design's
+   * tuning knob (OK-62091). The full port and the words' tuck scale with
+   * it; the capsule thumbnail and the confirm miniature keep their own
+   * widths. Defaults to REPLICA_WIDTH (see ./consts).
+   */
+  replicaWidth?: number;
   step: IDeviceStageStep;
   /**
    * Dresses the stage for a third-party device: the capsule's left seat

--- a/packages/components/src/composite/MorphOverlay/index.tsx
+++ b/packages/components/src/composite/MorphOverlay/index.tsx
@@ -698,10 +698,11 @@ export interface IMorphOverlayProps<T> {
    * The live in-card move the height should ride `ARRANGE_MS` for
    * instead of the spring: while the card stays put and this token
    * changes between two defined values, the height runs on the
-   * arrangement clock (DeviceStage passes its staged port height — the
-   * confirm shrink and back). Undefined-to-value edges keep the spring.
+   * arrangement clock (DeviceStage passes its staged arrangement kind —
+   * the confirm shrink and back). Compared, never measured.
+   * Undefined-to-value edges keep the spring.
    */
-  heightArrangeToken?: number;
+  heightArrangeToken?: string | number;
   /** The caller's own flow aimed on the container's clock — see
    * IMorphAimFacts. Its identity is an effect dependency on purpose:
    * wrap it in useCallback over the flow targets, and a target change

--- a/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.test.ts
@@ -10,7 +10,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { setDeviceStageBurstActive } from '@onekeyhq/shared/src/hardware/deviceStageOwnership';
-import { EFirmwareUpdateTipMessages } from '@onekeyhq/shared/types/device';
+import {
+  EFirmwareUpdateTipMessages,
+  EHardwareVendor,
+} from '@onekeyhq/shared/types/device';
 
 import {
   EHardwareUiStateAction,
@@ -729,6 +732,34 @@ describe('DeviceStageBurstScope', () => {
     await scope.endExplicit({ token });
     await letTheExitRun();
     expect(stage?.step).toBe('off');
+  });
+
+  it('takes down a wait a straggler paints while the yield reads the stage', async () => {
+    // The Ledger install sheet (OK-62656): the probe's call-end clear is
+    // still crossing the event queue when the dialog asks the stage to
+    // yield. Landing between the yield's read and its write, it repaints
+    // `processing` under the hold and bumps the claim, so a single exit
+    // would stand down and leave that capsule right under the sheet.
+    const scope = new DeviceStageBurstScope();
+    const token = await scope.beginExplicit({
+      connectId: CONNECT_ID,
+      vendor: EHardwareVendor.ledger,
+    });
+    await paintOpeningBeat();
+    expect(stage?.step).toBe('connecting');
+    stageAtom.get.mockImplementationOnce(async () => {
+      const read = stage;
+      await scope.onThirdPartyState({
+        ui: undefined,
+        install: undefined,
+        batch: undefined,
+      });
+      expect(stage?.step).toBe('processing');
+      return read;
+    });
+    await expect(scope.silence()).resolves.toBe(true);
+    expect(stage?.step).toBe('off');
+    await scope.endExplicit({ token });
   });
 
   it('leaves on a call-end close during the firmware workflow even behind a foreign hold', async () => {

--- a/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.test.ts
@@ -17,6 +17,7 @@ import {
 
 import {
   EHardwareUiStateAction,
+  EThirdPartyHardwareUiAction,
   deviceStageAtom,
   firmwareUpdateWorkflowRunningAtom,
 } from '../../states/jotai/atoms';
@@ -735,11 +736,13 @@ describe('DeviceStageBurstScope', () => {
   });
 
   it('takes down a wait a straggler paints while the yield reads the stage', async () => {
-    // The Ledger install sheet (OK-62656): the probe's call-end clear is
-    // still crossing the event queue when the dialog asks the stage to
-    // yield. Landing between the yield's read and its write, it repaints
-    // `processing` under the hold and bumps the claim, so a single exit
-    // would stand down and leave that capsule right under the sheet.
+    // The Ledger install sheet (OK-62656): the probe's last beat on the
+    // third-party rail is still crossing the event queue when the dialog
+    // asks the stage to yield. Landing between the yield's read and its
+    // write, a `ui` action claims the stage (clearOffTimer bumps the
+    // claim) and repaints `processing` under the hold, so a single exit
+    // stands down on the stale read and leaves that capsule right under
+    // the sheet.
     const scope = new DeviceStageBurstScope();
     const token = await scope.beginExplicit({
       connectId: CONNECT_ID,
@@ -750,7 +753,10 @@ describe('DeviceStageBurstScope', () => {
     stageAtom.get.mockImplementationOnce(async () => {
       const read = stage;
       await scope.onThirdPartyState({
-        ui: undefined,
+        ui: {
+          action: EThirdPartyHardwareUiAction.processing,
+          vendor: EHardwareVendor.ledger,
+        },
         install: undefined,
         batch: undefined,
       });

--- a/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.ts
@@ -1627,8 +1627,9 @@ export class DeviceStageBurstScope {
    * not at the end of the call that painted it. The burst's own
    * bookkeeping is untouched — its end() still releases the layer, and
    * finds nothing left to take down; a later beat from the same burst
-   * (the device speaking again) repaints as usual. */
-  async silence() {
+   * (the device speaking again) repaints as usual. Reports whether a
+   * stage actually left, so the surface can let the exit play first. */
+  async silence(): Promise<boolean> {
     this.clearOffTimer();
     this.clearPendingOpen();
     this.dismissSeq += 1;
@@ -1640,7 +1641,7 @@ export class DeviceStageBurstScope {
     // by the burst's own end, a user close, a new burst, or the device
     // asking again (see onHardwareUiEvent).
     this.yieldedToDialog = true;
-    await this.forceOff({ force: true });
+    return this.forceOff({ force: true });
   }
 
   /** A flow abandoned before any burst began — the checking beat a connect
@@ -1736,7 +1737,9 @@ export class DeviceStageBurstScope {
     }, delayMs);
   }
 
-  private async forceOff(options: { force?: boolean } = {}) {
+  /** Writes the off; false when nothing was on stage to take down (or a
+   * newer claim, an outcome, or a live burst kept it). */
+  private async forceOff(options: { force?: boolean } = {}): Promise<boolean> {
     const claim = this.claimSeq;
     const prev = await deviceStageAtom.get();
     // Re-checked after the await: a burst that claimed the stage while
@@ -1746,10 +1749,10 @@ export class DeviceStageBurstScope {
     // painted while its device call ran on without a PIN or confirm
     // surface.
     if (claim !== this.claimSeq || (!options.force && this.depth > 0)) {
-      return;
+      return false;
     }
     if (!prev || prev.step === 'off') {
-      return;
+      return false;
     }
     // An error outcome owns its own exit: the notice form leaves through
     // onClose after its readable hold, the ask form waits for the person.
@@ -1760,7 +1763,7 @@ export class DeviceStageBurstScope {
       (prev.step === 'error' || prev.step === 'deviceNotFound') &&
       !options.force
     ) {
-      return;
+      return false;
     }
     await deviceStageAtom.set({
       burstId: prev.burstId,
@@ -1776,6 +1779,7 @@ export class DeviceStageBurstScope {
     // Every exit announces itself: a flow awaiting a card's answer must
     // stop waiting on a card that is gone, whichever route took it.
     appEventBus.emit(EAppEventBusNames.DeviceStageOff, undefined);
+    return true;
   }
 
   private async setStep(

--- a/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.ts
@@ -1641,7 +1641,20 @@ export class DeviceStageBurstScope {
     // by the burst's own end, a user close, a new burst, or the device
     // asking again (see onHardwareUiEvent).
     this.yieldedToDialog = true;
-    return this.forceOff({ force: true });
+    // A paint racing this yield — a straggler landing between forceOff's
+    // read and its write — bumps the claim and keeps its own stage up,
+    // right where the dialog is about to rise. The yield outranks it, so
+    // the exit runs again; only the device asking again (which lifts the
+    // yield, see onHardwareUiEvent) may keep the stage.
+    let left = false;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const claim = this.claimSeq;
+      left = (await this.forceOff({ force: true })) || left;
+      if (claim === this.claimSeq || !this.yieldedToDialog) {
+        break;
+      }
+    }
+    return left;
   }
 
   /** A flow abandoned before any burst began — the checking beat a connect

--- a/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.sendUiResponse.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.sendUiResponse.test.ts
@@ -1348,7 +1348,7 @@ describe('ServiceHardwareUI.silenceDeviceStageForFirmwareWorkflow', () => {
     });
     const silence = jest
       .spyOn(service.deviceStageBurst, 'silence')
-      .mockResolvedValue();
+      .mockResolvedValue(true);
     return { service, silence, cancelStageAirGapScan };
   };
 

--- a/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.ts
@@ -622,10 +622,12 @@ class ServiceHardwareUI extends ServiceBase {
    * bootloader hand-off during onboarding, OK-62105): the stage leaves
    * first, whether or not a flow holds a burst — a stage standing behind
    * its own touch wall would otherwise cover the dialog until that hold
-   * ended. Burst bookkeeping is untouched (see DeviceStageBurst.silence). */
+   * ended. Burst bookkeeping is untouched (see DeviceStageBurst.silence).
+   * Returns whether a stage actually left, so the caller can let the exit
+   * play before its dialog rises. */
   @backgroundMethod()
   async deviceStageYieldToDialog() {
-    await this.deviceStageBurst.silence();
+    return this.deviceStageBurst.silence();
   }
 
   /**

--- a/packages/kit/src/provider/Container/DeviceStageContainer/waitForDeviceStageExit.ts
+++ b/packages/kit/src/provider/Container/DeviceStageContainer/waitForDeviceStageExit.ts
@@ -28,3 +28,19 @@ export async function waitForDeviceStageExit() {
     await timerUtils.wait(DEVICE_STAGE_EXIT_BEAT_MS);
   }
 }
+
+/**
+ * A dialog is about to take the screen over a live stage (the Ledger
+ * install sheet, OK-62656): the stage yields first — its burst's
+ * bookkeeping untouched, so the hold's own end still releases it and the
+ * device's next word repaints — and when a stage really left, its exit
+ * beat plays before the dialog rises. One background hop: the yield
+ * already knows whether it wrote the off.
+ */
+export async function yieldDeviceStageToDialog() {
+  const left =
+    await backgroundApiProxy.serviceHardwareUI.deviceStageYieldToDialog();
+  if (left) {
+    await timerUtils.wait(DEVICE_STAGE_EXIT_BEAT_MS);
+  }
+}

--- a/packages/kit/src/provider/Container/ThirdPartyHardwareUiStateContainer/LedgerInstallCoreAppsDialog.tsx
+++ b/packages/kit/src/provider/Container/ThirdPartyHardwareUiStateContainer/LedgerInstallCoreAppsDialog.tsx
@@ -26,7 +26,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
-import { waitForDeviceStageExit } from '../DeviceStageContainer/waitForDeviceStageExit';
+import { yieldDeviceStageToDialog } from '../DeviceStageContainer/waitForDeviceStageExit';
 
 import type {
   IEnsureLedgerCoreAppsReadyResult,
@@ -178,13 +178,9 @@ export async function showLedgerInstallCoreAppsDialog(params: {
 
   // A flow's hold (onboarding's, the accounts phase's) spans this dialog,
   // and on a phone the stage's capsule docks exactly where the sheet's
-  // Install button sits (OK-62656). The stage yields first — the bootloader
-  // hand-off's own move (OK-62105): the hold's bookkeeping is untouched,
-  // the install's progress and the device's next word bring the stage
-  // back, and the hold's own end still releases it. The sheet rises once
-  // the capsule has left, the entrance's mirror.
-  await backgroundApiProxy.serviceHardwareUI.deviceStageYieldToDialog();
-  await waitForDeviceStageExit();
+  // Install button sits (OK-62656): the stage leaves before the sheet
+  // rises; the install's progress brings it back.
+  await yieldDeviceStageToDialog();
 
   return new Promise<IInstallCoreAppsResult>((resolve) => {
     let settled = false;

--- a/packages/kit/src/provider/Container/ThirdPartyHardwareUiStateContainer/LedgerInstallCoreAppsDialog.tsx
+++ b/packages/kit/src/provider/Container/ThirdPartyHardwareUiStateContainer/LedgerInstallCoreAppsDialog.tsx
@@ -26,6 +26,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import { waitForDeviceStageExit } from '../DeviceStageContainer/waitForDeviceStageExit';
 
 import type {
   IEnsureLedgerCoreAppsReadyResult,
@@ -174,6 +175,16 @@ export async function showLedgerInstallCoreAppsDialog(params: {
     connectId =
       device?.connectId || device?.usbConnectId || device?.bleConnectId || '';
   }
+
+  // A flow's hold (onboarding's, the accounts phase's) spans this dialog,
+  // and on a phone the stage's capsule docks exactly where the sheet's
+  // Install button sits (OK-62656). The stage yields first — the bootloader
+  // hand-off's own move (OK-62105): the hold's bookkeeping is untouched,
+  // the install's progress and the device's next word bring the stage
+  // back, and the hold's own end still releases it. The sheet rises once
+  // the capsule has left, the entrance's mirror.
+  await backgroundApiProxy.serviceHardwareUI.deviceStageYieldToDialog();
+  await waitForDeviceStageExit();
 
   return new Promise<IInstallCoreAppsResult>((resolve) => {
     let settled = false;


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62656](<https://onekeyhq.atlassian.net/browse/OK-62656>) [OK-62091](<https://onekeyhq.atlassian.net/browse/OK-62091>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary

Two Device Stage fixes from the mobile QA round.

### OK-62656 — Ledger core-app install dialog covered by the stage
- Onboarding holds one stage burst across the whole wallet creation, and the Ledger core-app install dialog opens inside that hold, so the stage's **processing capsule stayed docked at the bottom of the phone screen right over the sheet's Install button**.
- The dialog helper now asks the stage to yield first (`deviceStageYieldToDialog`, the same hand-off the bootloader dialog uses since OK-62105) and waits for its exit before the sheet rises. The hold's bookkeeping is untouched: the install progress and the device's next word bring the stage back, and the hold's own end still releases it.
- Not a literal `endBurst`/`ensureBurst` pair: a vendor burst's `end()` closes a successful run with the ✓ "done" beat, which would flash before the install. Placing the yield in the dialog helper also covers the accounts-phase check that opens the same dialog under the same hold.

### OK-62091 — on-device PIN card too big on phones
- The replica width in play drops from the spec's 280pt to **220pt**: the PIN card goes from 481 to 408pt (55% → 47% of an iPhone 17 Pro screen) while the device's own screen stays 181pt wide, its keypad still readable.
- The spec's numbers stay stated at a new `STAGE_DESIGN_WIDTH` (280) and `DeviceStage` scales them to the width in play, so the confirm miniature and the capsule thumbnail keep their absolute sizes. The compact/full discriminator is now the arrangement kind rather than the port value.
- New `replicaWidth` prop with a range control in the Pin, Passphrase and Console stories for tuning.
- On-device storybook: the preview mounts the stage on the overlay window with the window's safe-area insets (matching the app's container order); the stories' driver bar now clears the status bar.

## Verification
- `yarn agent:check --profile commit` and `--profile pr` green.
- Unit tests: DeviceStage + MorphOverlay + kit DeviceStageContainer + ThirdPartyHardwareUiStateContainer (78 + 33) pass.
- OK-62091 checked on iPhone 17 Pro simulator storybook (Pin / Passphrase flows at 220).
- OK-62656 needs a device check: Ledger without apps through onboarding — the capsule should leave before the sheet rises and the Install button is tappable; tapping Install brings the stage back with the batch checklist; closing the sheet keeps the stage off and errors as before.

[OK-62656]: https://onekeyhq.atlassian.net/browse/OK-62656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-62091]: https://onekeyhq.atlassian.net/browse/OK-62091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ