### PR TITLE
fix: restore simulation asset layout and nft quantity (OK-62907)

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/TransactionPreview.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/TransactionPreview.tsx
@@ -29,19 +29,6 @@ import {
 
 import type { ISimulationAsset, ISimulationGroup } from './utils';
 
-const DESKTOP_ASSET_LIST_STYLE = {
-  alignSelf: 'flex-start',
-  width: 'auto',
-} as const;
-const DESKTOP_ASSET_ROW_STYLE = { justifyContent: 'flex-start' } as const;
-const DESKTOP_NAME_SLOT_STYLE = { flexGrow: 0, flexShrink: 0 } as const;
-const DESKTOP_NAME_TEXT_STYLE = {
-  width: 56,
-  flexGrow: 0,
-  flexShrink: 0,
-} as const;
-const DESKTOP_AMOUNT_STYLE = { textAlign: 'left' } as const;
-
 type IProps = {
   simulationComponents?: IDisplayComponentSimulation[];
 };
@@ -60,21 +47,18 @@ function SignGuardMark() {
 function SimulationAssetText({ asset }: { asset: ISimulationAsset }) {
   const amount = getSimulationAssetAmount(asset);
   const direction = getSimulationAssetDirection(asset);
-  // Assets.tsx renders the direction sign unconditionally and hides only the
-  // numeric amount for non-ERC1155 NFTs — keep the lone '-'/'+' so an outgoing
-  // unique NFT still reads as leaving the wallet.
   const sign = getSimulationAssetSign(asset);
   const color = direction === ETransferDirection.In ? '$textSuccess' : '$text';
   return (
     <SizableText
       size="$bodyMdMedium"
       color={color}
-      numberOfLines={1}
-      textAlign="right"
-      flexShrink={0}
-      $gtMd={DESKTOP_AMOUNT_STYLE}
+      $platform-web={{
+        wordBreak: 'break-all',
+        overflowWrap: 'break-word',
+      }}
     >
-      {`${sign}${amount}`}
+      {`${sign}${amount}  ${getSimulationAssetLabel(asset)}`}
     </SizableText>
   );
 }
@@ -113,7 +97,7 @@ function SimulationAssetGroups({
   networkNameById: Record<string, string>;
 }) {
   return (
-    <YStack gap="$2.5" width="100%" $gtMd={DESKTOP_ASSET_LIST_STYLE}>
+    <YStack gap="$2.5" width="100%">
       {simulationGroups.map((group) => (
         <YStack key={group.id} gap="$2.5">
           {simulationGroups.length > 1 &&
@@ -127,38 +111,21 @@ function SimulationAssetGroups({
               key={`${group.id}-${asset.type}-${getSimulationAssetLabel(
                 asset,
               )}-${getSimulationAssetAmount(asset)}-${index}`}
-              justifyContent="space-between"
               alignItems="flex-start"
-              gap="$3"
-              $gtMd={DESKTOP_ASSET_ROW_STYLE}
+              gap="$2"
             >
-              <XStack
-                gap="$2"
-                alignItems="flex-start"
-                flex={1}
-                minWidth={0}
-                $gtMd={DESKTOP_NAME_SLOT_STYLE}
-              >
-                <Token
-                  size="xs"
-                  flexShrink={0}
-                  {...getSimulationAssetIconProps(asset)}
+              <Token
+                size="xs"
+                flexShrink={0}
+                {...getSimulationAssetIconProps(asset)}
+              />
+              <YStack flex={1} minWidth={0}>
+                <SimulationAssetText asset={asset} />
+                <SimulationAssetNetworkName
+                  asset={asset}
+                  networkNameById={networkNameById}
                 />
-                <YStack flex={1} minWidth={0} $gtMd={DESKTOP_NAME_TEXT_STYLE}>
-                  <SizableText
-                    size="$bodyMdMedium"
-                    color="$text"
-                    numberOfLines={1}
-                  >
-                    {getSimulationAssetLabel(asset)}
-                  </SizableText>
-                  <SimulationAssetNetworkName
-                    asset={asset}
-                    networkNameById={networkNameById}
-                  />
-                </YStack>
-              </XStack>
-              <SimulationAssetText asset={asset} />
+              </YStack>
             </XStack>
           ))}
         </YStack>

--- a/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/utils.test.ts
+++ b/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/utils.test.ts
@@ -281,11 +281,6 @@ describe('SecurityCheckCard simulation asset display rules', () => {
       ['token uses symbol', buildTokenAsset(), 'ETH'],
       ['nft prefers metadata name', buildNFTAsset(), 'Cool Cat #42'],
       [
-        'nft falls back to collection name',
-        buildNFTAsset({}, { metadata: undefined }),
-        'Cool Cats',
-      ],
-      [
         'nft falls back to literal NFT',
         buildNFTAsset({}, { metadata: undefined, collectionName: '' }),
         'NFT',
@@ -313,6 +308,19 @@ describe('SecurityCheckCard simulation asset display rules', () => {
     ])('%s', (_title, asset, expected) => {
       expect(getSimulationAssetLabel(asset)).toBe(expected);
     });
+
+    it('shows collection name and quantity for an nft with empty metadata', () => {
+      const asset = buildNFTAsset(
+        { transferDirection: ETransferDirection.In },
+        {
+          collectionName: 'Uniswap v4 Positions NFT',
+          metadata: {} as IDisplayComponentNFT['nft']['metadata'],
+        },
+      );
+      expect(getSimulationAssetLabel(asset)).toBe('Uniswap v4 Positions NFT');
+      expect(getSimulationAssetSign(asset)).toBe('+');
+      expect(getSimulationAssetAmount(asset)).toBe('1');
+    });
   });
 
   describe('getSimulationAssetAmount', () => {
@@ -328,26 +336,24 @@ describe('SecurityCheckCard simulation asset display rules', () => {
         buildTokenAsset({ amountParsed: undefined, amount: '2' }),
         '',
       ],
-      // Canonical Assets.tsx rule: a unique (non-ERC1155) NFT shows no
-      // numeric quantity, an ERC1155 keeps its stack size.
-      ['erc721 nft hides amount', buildNFTAsset({ amount: '1' }), ''],
+      ['erc721 nft uses server amount', buildNFTAsset({ amount: '1' }), '1'],
       [
         'erc1155 nft keeps amount',
         buildNFTAsset({ amount: '5' }, { collectionType: ENFTType.ERC1155 }),
         '5',
       ],
       [
-        'internal erc721 nft hides amount',
+        'internal erc721 nft uses parsed quantity',
         buildInternalAsset({ isNFT: true, NFTType: ENFTType.ERC721 }),
-        '',
+        '1',
       ],
       [
-        'internal nft without NFTType hides amount',
+        'internal nft without NFTType uses parsed quantity',
         buildInternalAsset({ isNFT: true }),
-        '',
+        '1',
       ],
       [
-        'internal erc1155 nft keeps amount',
+        'internal erc1155 nft keeps parsed quantity',
         buildInternalAsset({
           isNFT: true,
           NFTType: ENFTType.ERC1155,
@@ -382,14 +388,12 @@ describe('SecurityCheckCard simulation asset display rules', () => {
       ).toBe(expected);
     });
 
-    it('keeps the lone sign for an outgoing unique NFT (amount hidden)', () => {
+    it('shows signed quantity for an outgoing unique NFT', () => {
       const asset = buildNFTAsset({
         transferDirection: ETransferDirection.Out,
       });
-      // Assets.tsx renders the direction sign unconditionally and hides only
-      // the numeric amount, so the row still reads as leaving the wallet.
       expect(getSimulationAssetSign(asset)).toBe('-');
-      expect(getSimulationAssetAmount(asset)).toBe('');
+      expect(getSimulationAssetAmount(asset)).toBe('1');
     });
   });
 

--- a/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/utils.ts
+++ b/packages/kit/src/views/SignatureConfirm/components/SecurityCheckCard/utils.ts
@@ -1,6 +1,5 @@
 import type { IBadgeType } from '@onekeyhq/components';
 import { ADDRESS_RISK_TAG_DISPLAY_TYPES } from '@onekeyhq/shared/src/utils/txActionUtils';
-import { ENFTType } from '@onekeyhq/shared/types/nft';
 import {
   EParseTxComponentType,
   ETransferDirection,
@@ -121,7 +120,7 @@ export const SIMULATION_GROUP_FALLBACK_ID = 'asset-changes';
 
 // These asset-display helpers are a compact, read-only variant of the canonical
 // simulation rendering in SignatureConfirmComponents/Assets.tsx. Keep the
-// direction-sign, NFT-amount, and color rules in sync with it to avoid drift
+// direction-sign and color rules in sync with it to avoid drift
 // (covered by utils.test.ts).
 export function getSimulationAssetLabel(asset: ISimulationAsset) {
   if (asset.type === EParseTxComponentType.Token) {
@@ -137,24 +136,14 @@ export function getSimulationAssetLabel(asset: ISimulationAsset) {
 }
 
 export function getSimulationAssetAmount(asset: ISimulationAsset) {
-  if (asset.type === EParseTxComponentType.Token) {
-    // `amount` is the raw base-unit value for fungible assets. Never fall back
-    // to it in a human-readable preview (for example, 1 ETH could otherwise
-    // be rendered as 1000000000000000000).
-    return asset.amountParsed ?? '';
+  if (asset.type === EParseTxComponentType.NFT) {
+    return asset.amount ?? '';
   }
-  if (asset.type === EParseTxComponentType.InternalAssets) {
-    if (asset.isNFT && asset.NFTType !== ENFTType.ERC1155) {
-      return '';
-    }
-    return asset.amountParsed ?? '';
-  }
-  // Match the canonical Assets renderer: a non-ERC1155 NFT shows only its name,
-  // never a numeric quantity (a unique token's "1" is noise).
-  if (asset.nft.collectionType !== ENFTType.ERC1155) {
-    return '';
-  }
-  return asset.amount;
+  // `amount` is the raw base-unit value for fungible assets. Never fall back
+  // to it in a human-readable preview (for example, 1 ETH could otherwise
+  // be rendered as 1000000000000000000). Internal NFTs also use the parsed
+  // quantity so a missing parse does not invent a count.
+  return asset.amountParsed ?? '';
 }
 
 export function getSimulationAssetDirection(asset: ISimulationAsset) {


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62907](<https://onekeyhq.atlassian.net/browse/OK-62907>)

----------
<!-- github-pr-monitor:jira-links:end -->

NFT transaction previews truncated collection names in a fixed desktop column and hid ERC-721 quantities, leaving a lone `+` or `-`.

Restore the previous left-aligned icon → signed quantity → asset name layout on desktop and mobile while keeping the current typography. Long names can wrap, and NFTs show their returned quantity. The reported empty-metadata Uniswap position now displays `+1  Uniswap v4 Positions NFT`. Fungible assets continue to use parsed amounts.

Issue: [OK-62907](https://onekeyhq.atlassian.net/browse/OK-62907)

## Validation

- Simulation utility tests: 46 passed, including the empty-metadata NFT regression, outgoing NFT quantity, and raw-unit guards.
- `yarn agent:check --profile commit`: passed on the committed changes.
- Tamagui static rendering confirmed the web wrapping CSS is generated.
- Desktop and mobile visual verification is pending.


[OK-62907]: https://onekeyhq.atlassian.net/browse/OK-62907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ