### PR TITLE
fix: prevent Android TradingView price worklet crash(OK-62918)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLayout.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLayout.ts
@@ -231,7 +231,9 @@ function compactTradingViewNativePriceLeadingZeros(value: string) {
 
 export function formatTradingViewNativePriceTick(
   price: number,
-  significantFractionDigits: 4 | 6 = PRICE_SIGNIFICANT_FRACTION_DIGITS,
+  // Worklet default parameters cannot read captured constants before __closure is initialized.
+  // Keep this literal in sync manually with PRICE_SIGNIFICANT_FRACTION_DIGITS.
+  significantFractionDigits: 4 | 6 = 4,
 ) {
   'worklet';
 


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62918](<https://onekeyhq.atlassian.net/browse/OK-62918>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary
- keep the TradingView Native price formatter default precision self-contained in its serialized worklet
- document why the literal must remain manually synchronized with `PRICE_SIGNIFICANT_FRACTION_DIGITS`

## Root cause
Worklets evaluates default parameters before the function body initializes captured values from `this.__closure`. When callers omitted the precision argument, the serialized UI-runtime function tried to resolve `PRICE_SIGNIFICANT_FRACTION_DIGITS` as a global and threw a fatal `ReferenceError` on Android.

## Validation
- `yarn agent:check --profile commit`
- existing `chartLayout.test.ts` suite: 46 tests passed, with no test-file changes in this PR
- reinstalled and launched on physical Android device; requester verified the original crash flow no longer crashes

[OK-62918]: https://onekeyhq.atlassian.net/browse/OK-62918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ