### PR TITLE
fix: declare Sentry asset lint dependencies

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -294,6 +294,10 @@ def prepareSentryNativeAssets = tasks.register("prepareSentryNativeAssets") {
     }
 }
 
+tasks.matching { it.name.toLowerCase().contains("lintvital") }.configureEach {
+    dependsOn(prepareSentryNativeAssets)
+}
+
 def prepareDevShellDebugAssets = tasks.register("prepareDevShellDebugAssets") {
     inputs.property("onekeyDevShellEnabled", useDevShell)
     outputs.dir(generatedDevShellAssetsDir)


### PR DESCRIPTION
## Summary

- make every Android `lintVital` task depend on `prepareSentryNativeAssets`
- prevent release lint model/analyze tasks from reading generated Sentry assets before they exist

## Validation

- `:app:assembleProdRelease` passed, including all prod release lint-vital tasks
- production APK was uninstalled/reinstalled on the dedicated Android emulator
- verified Sentry NDK fatal-signal replay and app-triggered Sentry crash export into the normal log ZIP
- `yarn agent:check --profile commit` passed