### PR TITLE
feat: rest the device stage's confirm step as the capsule (OK-62981)

### DIFF
--- a/packages/components/src/composite/DeviceStage/arrangements.test.ts
+++ b/packages/components/src/composite/DeviceStage/arrangements.test.ts
@@ -1,4 +1,5 @@
 import { arrangementOf, panelLeftBehind } from './arrangements';
+import { COMPACT_STAGED_STEPS, FULL_STAGED_STEPS, STEP_POSE } from './stepCopy';
 
 /**
  * The seat-reset rule (OK-59934). A stateful seat is never unmounted,
@@ -14,6 +15,18 @@ describe('arrangementOf', () => {
   it('seats the staged steps together', () => {
     expect(arrangementOf('enterPin')).toBe('stage');
     expect(arrangementOf('genuineCheck')).toBe('stage');
+    // The confirm capsule (2026-09-11) is not on the stage: a PIN card
+    // folding into it is a pose flight, never an in-stage port move.
+    expect(arrangementOf('confirm')).toBe('confirm');
+  });
+
+  // The stage arrangement exists on the card alone — the engine reads
+  // the scene map and seats the device badge only under the card pose —
+  // so a staged step with another pose would play a dark, bare seat.
+  it('stages only card-posed steps', () => {
+    for (const step of [...FULL_STAGED_STEPS, ...COMPACT_STAGED_STEPS]) {
+      expect(STEP_POSE[step]).toBe('card');
+    }
   });
 });
 

--- a/packages/components/src/composite/DeviceStage/consts.ts
+++ b/packages/components/src/composite/DeviceStage/consts.ts
@@ -19,16 +19,17 @@ export const REPLICA_WIDTH = 220;
 export const PORT_HEIGHT = 376;
 
 /**
- * The compact arrangement (the confirm step): the replica shrinks to a
- * full-body miniature COMPACT_DEVICE_WIDTH wide — the flow spec's 80/290
- * of the design stage — whatever width the full stage plays at. The port
- * height covers the tallest shell the window means to show whole — the
- * Touch, 77.28 wide x its aspect ≈ 129.6 — so the Classic, Pro, Pro 2
- * and Touch miniatures all keep their feet, the foot dissolve below the
- * box. The Mini's tall body (~166.7 scaled) still overruns and loses its
- * foot to the window: accepted (2026-08-31). A per-model port is a plain
- * number change: the compact/full discriminator and the height-arrange
- * token in DeviceStage are the arrangement kind, not the port value.
+ * The compact arrangement (the authenticity flow's staged steps): the
+ * replica shrinks to a full-body miniature COMPACT_DEVICE_WIDTH wide —
+ * the flow spec's 80/290 of the design stage — whatever width the full
+ * stage plays at. The port height covers the tallest shell the window
+ * means to show whole — the Touch, 77.28 wide x its aspect ≈ 129.6 —
+ * so the Classic, Pro, Pro 2 and Touch miniatures all keep their feet,
+ * the foot dissolve below the box. The Mini's tall body (~166.7 scaled)
+ * still overruns and loses its foot to the window: accepted
+ * (2026-08-31). A per-model port is a plain number change: the
+ * compact/full discriminator and the height-arrange token in
+ * DeviceStage are the arrangement kind, not the port value.
  */
 export const COMPACT_SCALE = 0.276;
 export const COMPACT_DEVICE_WIDTH = STAGE_DESIGN_WIDTH * COMPACT_SCALE;

--- a/packages/components/src/composite/DeviceStage/index.tsx
+++ b/packages/components/src/composite/DeviceStage/index.tsx
@@ -76,6 +76,7 @@ import { PassphraseIntro } from './PassphraseIntro';
 import { QrPresent, QrScanFrame } from './QrPanels';
 import { ShimmerTitle } from './ShimmerTitle';
 import {
+  CAPSULE_HAPTIC_STEPS,
   COMPACT_STAGED_STEPS,
   DEVICE_BADGE_STEPS,
   ERROR_TEXT,
@@ -115,11 +116,11 @@ import type { ImageSourcePropType, LayoutChangeEvent } from 'react-native';
  * and the per-step flow riding the container's clock through `onAim`.
  *
  * The pose table (./stepCopy's STEP_POSE): `off` is hidden — the stage
- * is simply not there, and entrances appear at their pose; `connecting`
- * and `processing` are capsule-class — waiting beats worn as the
- * flow-spec pill (device thumbnail, sweeping live title, the device's
- * name under it); every other step is card-class, its height hugging
- * that step's own content.
+ * is simply not there, and entrances appear at their pose; `connecting`,
+ * `processing` and `confirm` are capsule-class — the waiting beats and
+ * the device-side confirm, worn as the flow-spec pill (device thumbnail,
+ * sweeping live title, the device's name under it); every other step is
+ * card-class, its height hugging that step's own content.
  *
  * The replica is ONE standing device across every pose — the capsule's
  * thumbnail is the same instance worn small, its scenes a troupe parked
@@ -128,12 +129,13 @@ import type { ImageSourcePropType, LayoutChangeEvent } from 'react-native';
  * glass plays the handover between scenes — off, then a wake from
  * black — with arrivals from a hidden device granted instant entry.
  * Inside the stage arrangement the words are StepText swapping in place
- * and the confirm move re-arranges on the arrangement clock; a change
- * of arrangement runs the container's two-phase swap, landing content
- * and height target together on the empty beat; confirm's payload card
- * rides the words' beat. The panels are the scenes' twin troupe (see
- * CARD_ARRANGEMENTS): parked built in their seats, so no crossing or
- * pose flip ever builds native views mid-animation.
+ * and a port move (full stage to miniature and back) re-arranges on
+ * the arrangement clock; a change of arrangement runs the container's
+ * two-phase swap, landing content and height target together on the
+ * empty beat; the stage tail's cards ride the words' beat. The panels
+ * are the scenes' twin troupe (see CARD_ARRANGEMENTS): parked built in
+ * their seats, so no crossing or pose flip ever builds native views
+ * mid-animation.
  *
  * The stage is modal, and undimmed for asks and waits: while it is there
  * the app behind takes no touch — the person stays with the device — and
@@ -281,9 +283,9 @@ const FOG_LOCATIONS = [0, 0.58, 0.87] as const;
 
 /**
  * Which arrangement a card step gives the standing replica: the full
- * stage for the device-side asks, the miniature for confirm and the
- * authenticity flow, nothing for the app-side inputs, the air-gap pair
- * and the endings. Built off the two staged-step lists so membership is
+ * stage for the device-side asks, the miniature for the authenticity
+ * flow, nothing for the app-side inputs, the air-gap pair and the
+ * endings. Built off the two staged-step lists so membership is
  * stated once (see ./stepCopy).
  */
 type IReplicaArrangement = 'full' | 'compact';
@@ -296,8 +298,8 @@ const REPLICA_ARRANGEMENT = Object.fromEntries([
  * The staged row, to the design: the replica stands `top` under the
  * content's top edge; on the full stage the words begin `fullHeight`
  * under it — inside the port's fogged foot, the device running on
- * behind them — while the confirm miniature's row ends `bottom` under
- * the scaled device and the words sit clear below.
+ * behind them — while the miniature's row ends `bottom` under the
+ * scaled device and the words sit clear below.
  */
 const STAGE_ROW = {
   top: 16,
@@ -311,7 +313,7 @@ const REPLICA_TOP = CARD.padTop + STAGE_ROW.top;
  * default is REPLICA_WIDTH, the OK-62091 call). The design states its
  * numbers at STAGE_DESIGN_WIDTH; the full stage — its port and the
  * words' tuck into the foot — keeps its proportion of the device, while
- * the capsule thumbnail and the confirm miniature keep their own
+ * the capsule thumbnail and the compact miniature keep their own
  * absolute widths, so the width only grows or shrinks the full stage.
  */
 function replicaMetricsFor(replicaWidth: number) {
@@ -464,8 +466,12 @@ function useStageTailFlag(want: boolean, liveOnShow: boolean): boolean {
  * haptics setting, and is a no-op off the phones.
  */
 function fireStepHaptic(step: IDeviceStageStep) {
-  // `done` is the one capsule arrival that carries news rather than a
-  // wait — the burst's ✓ beat — so it buzzes like the outcome cards.
+  // Every card arrival speaks; of the capsule arrivals only the ones
+  // the vocabulary names (CAPSULE_HAPTIC_STEPS).
+  if (STEP_POSE[step] !== 'card' && !CAPSULE_HAPTIC_STEPS.has(step)) {
+    return;
+  }
+  // `done` is the burst's ✓ beat, so it buzzes like the outcome cards.
   if (step === 'authSuccess' || step === 'done') {
     Haptics.success();
     return;
@@ -568,10 +574,11 @@ export function DeviceStage({
   // large main-thread composite, and paying it mid-flight is the stutter.
   // (A shouldRasterizeIOS freeze was tried first and made it worse: the
   // raster's own on/off each cost a full offscreen pass.) So the pose
-  // flight defers the screen handover the way the confirm shrink always
-  // has — the scene holds until the geometry has landed (see sceneStep
-  // below). Render-phase state write on purpose: the hold must ship in
-  // the same commit that starts the springs.
+  // flight defers the screen handover the way the in-stage port move
+  // (the miniature shrink) always has — the scene holds until the
+  // geometry has landed (see sceneStep below). Render-phase state write
+  // on purpose: the hold must ship in the same commit that starts the
+  // springs.
   const [poseInFlight, setPoseInFlight] = useState(false);
   const prevPoseForFlightRef = useRef(pose);
   if (prevPoseForFlightRef.current !== pose) {
@@ -590,10 +597,9 @@ export function DeviceStage({
   // down; a refused entry keeps the step, so inline retry keeps typing.
   // ...and the arrival buzz rides the same step edge — this commit is
   // the one whose layout effect aims the springs, so the buzz and the
-  // first moving frame share the beat. Every card arrival speaks (news
-  // steps buzz their news through the grammar); of the capsule steps
-  // only `done`'s ✓ does — returning to a wait, and the leave, stay
-  // silent. The very first step is the opening state, not a transition.
+  // first moving frame share the beat (which arrivals speak is
+  // fireStepHaptic's). The very first step is the opening state, not a
+  // transition.
   const prevStepEdgeRef = useRef(step);
   useEffect(() => {
     const prev = prevStepEdgeRef.current;
@@ -604,9 +610,7 @@ export function DeviceStage({
     if (prev === 'passphraseOnApp' || prev === 'pairingCode') {
       Keyboard.dismiss();
     }
-    if (STEP_POSE[step] === 'card' || step === 'done') {
-      fireStepHaptic(step);
-    }
+    fireStepHaptic(step);
   }, [step]);
   // The system-keyboard steps own their lift: the shell already rides the
   // keyboard (MorphOverlay), so the Android window must not pan on top of
@@ -877,8 +881,8 @@ export function DeviceStage({
     (shownPanel?.tail ?? 0);
 
   // What the replica plays, on the stage's own lag: while the geometry
-  // is moving — a pose flight, or the confirm arrangement's port move —
-  // the scene holds until it has landed; a change on a resting box hands
+  // is moving — a pose flight, or an in-stage port move — the scene
+  // holds until it has landed; a change on a resting box hands
   // over right away. The capsule side always plays connecting — the
   // thumbnail IS the connecting-state device.
   const [sceneStep, setSceneStep] = useState(shownStep);
@@ -1011,8 +1015,8 @@ export function DeviceStage({
       // the arrangement it left in may not be the one it returns to.
       // Like the flow twins below, the pair lands the new arrangement in
       // one piece on a crossing or a pose arrival (otherwise a stale
-      // confirm miniature grows to full size under the reveal); only a
-      // live stage move — the confirm shrink and back, on show — runs on
+      // miniature grows to full size under the reveal); only a live
+      // stage move — the miniature shrink and back, on show — runs on
       // the clock.
       if (shownPort) {
         if (facts.landInPlace) {
@@ -1326,12 +1330,10 @@ export function DeviceStage({
       Boolean(authChecklist?.length),
     stageTailLive,
   );
-  // Confirm's payload card rides the same beat: on show together with
-  // the confirm words, never a delayed second landing — the tail's
-  // height re-aim already carries it, so entering confirm grows the box
-  // straight to its full size in one move. Any of the three content
-  // shapes summons it; the count pill rides its beat, it never calls
-  // the card up alone.
+  // Confirm's payload card, parked: confirm rests as the capsule, so
+  // the stage seat never speaks for it and this never lights. Kept
+  // wired with the rest of the confirm channel — see
+  // CONFIRM_PAYLOAD_HIDDEN in kit-bg's DeviceStageBurst.
   const confirmCardShown = useStageTailFlag(
     stageWordsStep === 'confirm' &&
       Boolean(confirmDetails?.length || confirmMessage || confirmDescription),
@@ -2105,7 +2107,7 @@ export function DeviceStage({
 
   // The standing set: ONE device across every pose, never rebuilt, only
   // re-seated — thumbnail-small beside the capsule's words, the full
-  // stage or the confirm miniature on the card. Its scenes live parked
+  // stage or the compact miniature on the card. Its scenes live parked
   // on its one glass (the troupe grant): a crossing flips which is lit
   // and nothing ever builds; only the visible scene's clock runs, from
   // 0. The fog paints the port fade over the opaque face, and rests

--- a/packages/components/src/composite/DeviceStage/stepCopy.ts
+++ b/packages/components/src/composite/DeviceStage/stepCopy.ts
@@ -406,6 +406,19 @@ export const DEVICE_BADGE_STEPS: ReadonlySet<IDeviceStageStep> =
     'authSuccess',
   ]);
 
+/**
+ * The capsule arrivals that buzz. Every card arrival speaks; the capsule
+ * waits stay silent (attention released, not demanded — see
+ * fireStepHaptic in the engine). `done` is the burst's ✓ beat, news
+ * rather than a wait; `confirm` keeps the buzz it had as a card. The
+ * vendor track's capsule asks (confirmOnDevice, openApp, unlockDevice)
+ * stay silent as before — untouched by confirm's move, not decided
+ * against; isDeviceStageAnsweredStep in shared is the classification
+ * that would unify them.
+ */
+export const CAPSULE_HAPTIC_STEPS: ReadonlySet<IDeviceStageStep> =
+  new Set<IDeviceStageStep>(['done', 'confirm']);
+
 /** A step's second line: its own informative line, empty when none. */
 export function resolveStepSub(
   intl: IntlShape,
@@ -489,7 +502,10 @@ export const STEP_POSE: Record<
   passphraseOnApp: 'card',
   showQr: 'card',
   scanQr: 'card',
-  confirm: 'card',
+  // The device-side confirm rests as the capsule (2026-09-11) — the
+  // vendor track's confirmOnDevice grammar. Its card stays wired but
+  // parked: see CONFIRM_PAYLOAD_HIDDEN in kit-bg's DeviceStageBurst.
+  confirm: 'capsule',
   genuineCheck: 'card',
   authVerifying: 'card',
   authSuccess: 'card',
@@ -517,17 +533,17 @@ export const STEP_POSE: Record<
 /**
  * The staged steps — the ones that keep the replica on stage. The full
  * stage crops the device to screen-and-keys for the device-side asks;
- * the compact list wears the confirm miniature instead — confirm's own
- * shrink, and the authenticity flow, which keeps the whole device in
- * view while the card talks. The engine derives its port map (and the
- * miniature's scale) from these two lists, so membership is stated once.
+ * the compact list wears the miniature instead — the authenticity flow,
+ * which keeps the whole device in view while the card talks. The engine
+ * derives its port map (and the miniature's scale) from these two
+ * lists, so membership is stated once. Only card-posed steps belong
+ * here: the stage arrangement exists on the card alone.
  */
 export const FULL_STAGED_STEPS: IDeviceStageStep[] = [
   'enterPin',
   'enterPassphrase',
 ];
 export const COMPACT_STAGED_STEPS: IDeviceStageStep[] = [
-  'confirm',
   'genuineCheck',
   'authVerifying',
   'authSuccess',

--- a/packages/components/src/composite/DeviceStage/stories/Confirm.stories.tsx
+++ b/packages/components/src/composite/DeviceStage/stories/Confirm.stories.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { DeviceStage } from '@onekeyhq/components/src/composite/DeviceStage';
 import type { IDeviceStageProps } from '@onekeyhq/components/src/composite/DeviceStage';
 
@@ -14,11 +12,10 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 /**
- * The confirm scenarios, one story each — the full inventory of what the
- * app asks the person to verify against the device, three content shapes:
- * rows (verify fields), a text block (the signed original), a description
- * (device actions with no payload). The values here are the scenario
- * board's demo data, verbatim.
+ * The confirm beat rests as the capsule (2026-09-11): the ask's title
+ * over the device's name beside the replica thumbnail. The payload card
+ * it used to play stays wired but parked — see CONFIRM_PAYLOAD_HIDDEN in
+ * kit-bg's DeviceStageBurst; git history keeps its scenario stories.
  */
 
 const meta = {
@@ -39,10 +36,9 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// The confirm move at full length: the neighbors for the shrink, the
-// miniature with the payload card queuing in last, the exit through
-// processing. The one story with the whole walk — the scene stories
-// below cut straight to the design.
+// The confirm move at full length: the neighbors on either side — the
+// PIN card folding into the capsule, the capsule's words swapping to
+// the processing wait — and the exit.
 function ConfirmStage(props: IDeviceStageProps) {
   const driver = useStageDriver(props);
   return (
@@ -66,180 +62,6 @@ function ConfirmStage(props: IDeviceStageProps) {
   );
 }
 
-// A scene story opens on the confirm card itself — the driver walks
-// off → confirm on mount, so the story shows the scenario's design
-// without any manual stepping. Two controls only: replay the arrival,
-// and the exit.
-function ConfirmScene(props: IDeviceStageProps) {
-  const driver = useStageDriver(props);
-  const { go } = driver;
-  useEffect(() => {
-    go('confirm');
-  }, [go]);
-  return (
-    <StageHost driver={driver} props={props}>
-      <StepButton driver={driver} step="off">
-        Off
-      </StepButton>
-      <StepButton driver={driver} step="confirm">
-        Confirm
-      </StepButton>
-    </StageHost>
-  );
-}
-
-/** The full walk, worn by scenario 01 (the receive page's address
- * verify — the address the device derives from its own seed, against
- * the app's stored copy). */
 export const Flow: Story = {
   render: ConfirmStage,
-  args: {
-    confirmDetails: DEMO.confirmDetails,
-  },
-};
-
-/* ------------------------------------------------------------------ */
-/* Family 1 — verify fields (rows)                                     */
-/* ------------------------------------------------------------------ */
-
-/** 02 · Plain transfer — the device pages address → amount → fee →
- * summary; the card lists the whole run at once. */
-export const Transfer: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [
-      {
-        label: 'To',
-        value: '0x627Ddbef61C811af05288Cd79db324fCac914AeF',
-        highlightEnds: true,
-      },
-      { label: 'Amount', value: '0.5 ETH' },
-      { label: 'Network fee', value: '0.00042 ETH' },
-    ],
-  },
-};
-
-/** 03 · Token approval — the unlimited allowance wears the warning ink. */
-export const Approve: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [
-      { label: 'Token', value: 'USDC' },
-      {
-        label: 'Spender',
-        value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
-        highlightEnds: true,
-      },
-      { label: 'Allowance', value: 'Unlimited', warning: true },
-    ],
-  },
-};
-
-/** 04 · Contract interaction the app cannot decode — the raw data,
- * truncated; the device screen stays the full read. */
-export const ContractData: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [
-      {
-        label: 'Contract',
-        value: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
-        highlightEnds: true,
-      },
-      { label: 'Amount', value: '0 ETH' },
-      { label: 'Data', value: '0x38ed1739000000000000000000000001a2…' },
-    ],
-  },
-};
-
-/** 05 · A run of confirmations (approve-then-swap, batch sends) — the
- * count pill beside the title tracks the burst's place. */
-export const Batch: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [
-      { label: 'Step', value: 'Swap USDC → ETH' },
-      { label: 'Amount', value: '1,200 USDC' },
-    ],
-    confirmCount: { current: 2, total: 3 },
-  },
-};
-
-/* ------------------------------------------------------------------ */
-/* Family 2 — the signed original (text block)                         */
-/* ------------------------------------------------------------------ */
-
-/** 06 · Message signing — the very text the person pages through on the
- * device; long content truncates, the device stays the full read. */
-export const Message: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmMessage: `Welcome to OpenSea!
-
-Click to sign in and accept the OpenSea Terms of Service. This request will not trigger a blockchain transaction or cost any gas fees.
-
-Wallet address: 0x627ddbef61c811af05288cd79db324fcac914aef
-Nonce: 2f8a1c90-77e4-4d1a-9c60-8f21b1a30d55`,
-  },
-};
-
-/** 07 · Structured data (typed-data requests) — origin, type and the key
- * address as summary rows; full fields stay the device's read. */
-export const TypedData: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [
-      { label: 'Origin', value: 'app.uniswap.org' },
-      { label: 'Type', value: 'PermitSingle' },
-      {
-        label: 'Spender',
-        value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
-        highlightEnds: true,
-      },
-    ],
-  },
-};
-
-/** 08 · Sign-in proof — the domain is the one fact to verify; a phishing
- * domain shows itself here. */
-export const SignIn: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [
-      { label: 'Website', value: 'stacker.news' },
-      { label: 'Account', value: 'Lightning #1' },
-    ],
-  },
-};
-
-/* ------------------------------------------------------------------ */
-/* Family 3 — device actions (description)                             */
-/* ------------------------------------------------------------------ */
-
-/** 09 · Wipe device — destructive, so the description panel inks danger. */
-export const WipeDevice: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDescription:
-      'All data on this device will be erased. Your assets remain recoverable only with the recovery phrase.',
-    confirmDescriptionDanger: true,
-  },
-};
-
-/** 10/11 · Settings-family confirms (passphrase toggle here; change PIN,
- * wallpaper and device preferences share the shape). */
-export const PassphraseOn: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDescription:
-      'Passphrase will be turned on. Each passphrase opens its own hidden wallet; the device may restart after confirming.',
-  },
-};
-
-/** 12 · Rename device — a single new value to verify, so still rows. */
-export const RenameDevice: Story = {
-  render: ConfirmScene,
-  args: {
-    confirmDetails: [{ label: 'Device name', value: 'Franco’s Pro' }],
-  },
 };

--- a/packages/components/src/composite/DeviceStage/type.ts
+++ b/packages/components/src/composite/DeviceStage/type.ts
@@ -25,7 +25,9 @@ import type { IHardwareDeviceType } from '../../content/HardwareDevice';
  * `off` is the stage at rest: the overlay is not there, and whichever
  * step follows enters at its own pose. `connecting` and `processing`
  * are the waiting beats — nothing is asked of the person, so the stage
- * rests as the floating capsule until the device answers. `pinOnApp`
+ * rests as the floating capsule until the device answers; `confirm`
+ * rests there too — a device-side ask with nothing to answer in the
+ * app, the vendor track's `confirmOnDevice` grammar. `pinOnApp`
  * and `passphraseOnApp` are the app-side inputs — the person types here
  * while the device waits, so the replica leaves the stage and the input
  * panel takes its place. `selectWalletType` is the wallet-creation fork
@@ -51,7 +53,7 @@ import type { IHardwareDeviceType } from '../../content/HardwareDevice';
  * person confirms the check on the device — then the wait while the
  * certificate (and, on capable firmware, each component hash: the
  * `authChecklist`) is verified, then a landing. The three staged steps
- * keep the replica on stage as the confirm miniature, screens per the
+ * keep the replica on stage as the compact miniature, screens per the
  * scene map; `authFailure` fronts an icon instead of the replica, worded
  * by `authFailureReason`, with retry/support and a developer override.
  *
@@ -269,9 +271,13 @@ export interface IDeviceStageProps {
    */
   onClose?: () => void;
   /**
-   * The confirm step's payload, three shapes — rows (`confirmDetails`),
-   * a text block (`confirmMessage`), or a description (`confirmDescription`)
-   * — one per burst, all on the same card and the same late fade-in.
+   * The confirm card's payload — parked: confirm rests as the capsule,
+   * which has no seat for it, so none of these render today (see
+   * CONFIRM_PAYLOAD_HIDDEN in kit-bg's DeviceStageBurst).
+   *
+   * Three shapes — rows (`confirmDetails`), a text block
+   * (`confirmMessage`), or a description (`confirmDescription`) — one
+   * per burst, all on the same card and the same late fade-in.
    * Copy rule for whichever shape rides in: the card is the app's half
    * of a comparison, never a mirror of the device — say "check this
    * against the device", never "this is what the device shows". The two

--- a/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/DeviceStageBurst.ts
@@ -87,8 +87,11 @@ const END_GRACE_MS = 250;
  * transactions, messages alike — keeping the surface clean; the device
  * screen is the one read of what is being confirmed. The whole confirm
  * channel stays wired (business registrations, the builders, the atom
- * fields, the component's card and its stories), so flipping this single
- * gate re-lights the card unchanged; the gate only keeps the payload out
+ * fields, the component's parked card). Since 2026-09-11 the component
+ * also rests confirm as the capsule, which has no seat for a payload, so
+ * re-lighting the card is this flip plus the pose: `STEP_POSE.confirm`
+ * back to 'card' and confirm back on `COMPACT_STAGED_STEPS`, both in
+ * components' DeviceStage/stepCopy. The gate only keeps the payload out
  * of the atom, at the one point every content path converges.
  */
 const CONFIRM_PAYLOAD_HIDDEN = true;


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62981](<https://onekeyhq.atlassian.net/browse/OK-62981>)

----------
<!-- github-pr-monitor:jira-links:end -->

## What

The device stage's `confirm` step ("Confirm on device") now rests as the **capsule** instead of the card: the ask's title over the device's name beside the replica thumbnail — the same grammar the third-party track's `confirmOnDevice` already uses.

Before: a card with the compact miniature and, in the design, a payload card. After: the capsule.

## Why

Production already hides the confirm payload behind `CONFIRM_PAYLOAD_HIDDEN` in `DeviceStageBurst.ts` (product call, 2026-09), so the live card was a bare "Confirm on device" title with a device-name pill. The capsule carries exactly that content in the lighter pose, so nothing the person sees is lost, and the PIN card → confirm move becomes a card→capsule flight instead of an in-stage shrink.

## How

Two data flips in `packages/components/src/composite/DeviceStage/stepCopy.ts`:

- `STEP_POSE.confirm`: `'card'` → `'capsule'`
- `confirm` removed from `COMPACT_STAGED_STEPS`

Everything else follows from existing engine rules (capsule text via `resolveCapsuleText`, thumbnail seat, the capsule's own close button under the unchanged `settle` exit rule). No new i18n keys.

Around it:

- **Haptics**: confirm keeps the arrival buzz it had as a card. The exception is stated once as `CAPSULE_HAPTIC_STEPS = {done, confirm}` and `fireStepHaptic` owns the gate. The vendor track's capsule asks (`confirmOnDevice`, `openApp`, `unlockDevice`) stay silent as before — untouched, not decided against.
- **Payload channel**: props, atom fields, burst registrations and the engine's tail-card seat stay wired but parked (they cannot light while confirm is a capsule). The re-light recipe is recorded once, beside the kit-bg gate. `SCENE_ANIMATION.confirm` and `DEVICE_BADGE_STEPS` are deliberately left as they were so a re-light brings the card back unchanged.
- **Stories**: `Composite/DeviceStage/Confirm` keeps the full walk (`Flow`); the 12 payload scenario stories are removed since they all render the same capsule now (git history keeps them).
- **Test**: `arrangements.test.ts` pins the invariant that every staged step is card-posed, plus `arrangementOf('confirm') === 'confirm'`.

## Reviewer notes

- `yarn agent:check --profile commit` and `--profile pr` green; DeviceStage/MorphOverlay (63) and ServiceHardwareUI/kit stage (149) tests green.
- Visual verification on device pending (design owner).
- Will conflict lightly with the stage top-placement branch (`3e735fe164`, not yet merged) in adjacent `stepCopy.ts` / `index.tsx` comment blocks.


[OK-62981]: https://onekeyhq.atlassian.net/browse/OK-62981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ