### PR TITLE
fix: align network selector feedback and index

### DIFF
--- a/packages/kit/src/components/AccountSelector/hooks/useUnifiedNetworkSelectorTrigger.test.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useUnifiedNetworkSelectorTrigger.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { Haptics } from '@onekeyhq/components';
+
+import { useUnifiedNetworkSelectorTrigger } from './useUnifiedNetworkSelectorTrigger';
+
+const mockShowUnifiedNetworkSelector = jest.fn();
+const mockNavigation = {};
+
+jest.mock('@onekeyhq/components', () => ({
+  Haptics: {
+    selection: jest.fn(),
+  },
+}));
+
+jest.mock('../../../hooks/useAppNavigation', () => ({
+  __esModule: true,
+  default: () => mockNavigation,
+}));
+
+jest.mock('../../../states/jotai/contexts/accountSelector', () => ({
+  useAccountSelectorSceneInfo: () => ({
+    sceneName: 'home',
+    sceneUrl: undefined,
+  }),
+  useActiveAccount: () => ({ activeAccount: {} }),
+}));
+
+jest.mock('../../../states/jotai/contexts/accountSelector/actions', () => ({
+  useAccountSelectorActions: () => ({
+    current: {
+      showUnifiedNetworkSelector: mockShowUnifiedNetworkSelector,
+    },
+  }),
+}));
+
+jest.mock('./useAccountSelectorAvailableNetworks', () => ({
+  useAccountSelectorAvailableNetworks: () => ({
+    networkIds: ['network-1'],
+    defaultNetworkId: 'network-1',
+  }),
+}));
+
+describe('useUnifiedNetworkSelectorTrigger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('emits selection feedback when opening the network selector', () => {
+    const { result } = renderHook(() =>
+      useUnifiedNetworkSelectorTrigger({ num: 0 }),
+    );
+
+    act(() => {
+      result.current.showUnifiedNetworkSelector();
+    });
+
+    expect(Haptics.selection).toHaveBeenCalledTimes(1);
+    expect(mockShowUnifiedNetworkSelector).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit/src/components/AccountSelector/hooks/useUnifiedNetworkSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useUnifiedNetworkSelectorTrigger.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import { Haptics } from '@onekeyhq/components';
 import type { IUnifiedNetworkSelectorRouteParams } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
@@ -32,6 +33,7 @@ export function useUnifiedNetworkSelectorTrigger({ num }: { num: number }) {
       onNetworksChanged?: () => Promise<void>;
       defaultTab?: IUnifiedNetworkSelectorRouteParams['defaultTab'];
     } = {}) => {
+      Haptics.selection();
       actions.current.showUnifiedNetworkSelector({
         navigation,
         num,

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelectorV2/NetworkSectionListV2.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelectorV2/NetworkSectionListV2.tsx
@@ -324,7 +324,7 @@ export function NetworkSectionListV2({
       capabilities: {
         sectionIndex: {
           enabled: !searchText,
-          centeredInWindow: platformEnv.isNative,
+          centeredInWindow: platformEnv.isNative || platformEnv.isDesktop,
         },
       },
       selection: { mode: 'none', selectedKeys: [] },

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelectorV2/NetworksSectionListV2.test.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelectorV2/NetworksSectionListV2.test.tsx
@@ -49,6 +49,7 @@ const mockPresentation = {
 let mockMissingNetworks = [{ networkId: 'a' }];
 let mockSearch = '';
 let mockIsNative = false;
+let mockIsDesktop = false;
 let mockState = {
   enabledNetworks: { a: true } as Record<string, boolean>,
   disabledNetworks: {} as Record<string, boolean>,
@@ -70,6 +71,9 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   default: {
     get isNative() {
       return mockIsNative;
+    },
+    get isDesktop() {
+      return mockIsDesktop;
     },
   },
 }));
@@ -198,6 +202,7 @@ describe('portfolio NativeList selection adapter V2', () => {
     jest.clearAllMocks();
     mockSearch = '';
     mockIsNative = false;
+    mockIsDesktop = false;
     mockMissingNetworks = [{ networkId: 'a' }];
     mockState = { enabledNetworks: { a: true }, disabledNetworks: {} };
   });
@@ -229,6 +234,14 @@ describe('portfolio NativeList selection adapter V2', () => {
 
   it('centers the section index in the window on native platforms', () => {
     mockIsNative = true;
+    render(<HarnessV2 />);
+    expect(
+      getNativePropsV2().snapshot.capabilities?.sectionIndex?.centeredInWindow,
+    ).toBe(true);
+  });
+
+  it('centers the section index in the window on desktop', () => {
+    mockIsDesktop = true;
     render(<HarnessV2 />);
     expect(
       getNativePropsV2().snapshot.capabilities?.sectionIndex?.centeredInWindow,

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelectorV2/NetworksSectionListV2.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelectorV2/NetworksSectionListV2.tsx
@@ -290,7 +290,7 @@ export default function NetworksSectionListV2() {
       capabilities: {
         sectionIndex: {
           enabled: !searchKey.trim(),
-          centeredInWindow: platformEnv.isNative,
+          centeredInWindow: platformEnv.isNative || platformEnv.isDesktop,
         },
       },
       selection: {


### PR DESCRIPTION
## What
- trigger selection haptics when opening the unified network selector, matching the account selector
- request window-centered section indexes for both single-network and all-network lists on iOS and Desktop
- add focused regression coverage for the haptic trigger and Desktop capability

## Why
The network selector did not provide the same selection feedback as the account selector, and the section index could be centered relative to list content instead of the screen/window.

## Impact
The change is scoped to the unified network selector. Desktop window centering requires the upcoming `@onekeyfe/react-native-native-list` package update from app-modules; that dependency bump is intentionally left for follow-up.

## Checks
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- focused Jest: 2 suites, 9 tests passed
- runtime behavior previously checked on iOS and Desktop with the local NativeList implementation
