### PR TITLE
fix: register Pro2Black module ID

### DIFF
--- a/.github/workflows/startup-graph-budget.yml
+++ b/.github/workflows/startup-graph-budget.yml
@@ -48,14 +48,6 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=8192'
         run: yarn install --immutable
 
-      - name: Check development module ID registry
-        run: |
-          yarn workspace @onekeyhq/mobile dev-vendor:registry:update
-          if ! git diff --exit-code -- apps/mobile/bundle-registry/module-id-registry.json; then
-            echo "::error title=Stale module ID registry::Run yarn workspace @onekeyhq/mobile dev-vendor:registry:update and commit the registry update."
-            exit 1
-          fi
-
       - name: Union Build (three-bundle split)
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'

--- a/.github/workflows/startup-graph-budget.yml
+++ b/.github/workflows/startup-graph-budget.yml
@@ -48,6 +48,14 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=8192'
         run: yarn install --immutable
 
+      - name: Check development module ID registry
+        run: |
+          yarn workspace @onekeyhq/mobile dev-vendor:registry:update
+          if ! git diff --exit-code -- apps/mobile/bundle-registry/module-id-registry.json; then
+            echo "::error title=Stale module ID registry::Run yarn workspace @onekeyhq/mobile dev-vendor:registry:update and commit the registry update."
+            exit 1
+          fi
+
       - name: Union Build (three-bundle split)
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'

--- a/apps/mobile/bundle-registry/module-id-registry.json
+++ b/apps/mobile/bundle-registry/module-id-registry.json
@@ -23425,6 +23425,7 @@
     "packages/shared/src/assets/wallet/avatar/Panda.png": 467,
     "packages/shared/src/assets/wallet/avatar/Pig.png": 3085,
     "packages/shared/src/assets/wallet/avatar/PolarBear.png": 19828,
+    "packages/shared/src/assets/wallet/avatar/Pro2Black.png": 17399,
     "packages/shared/src/assets/wallet/avatar/ProBlack.png": 19462,
     "packages/shared/src/assets/wallet/avatar/ProWhite.png": 4469,
     "packages/shared/src/assets/wallet/avatar/Rabbit.png": 6128,


### PR DESCRIPTION
## Summary

- register the development-only `Pro2Black.png` asset in the mobile module ID registry

## Root cause

The Metro Dev Prebundle workflow reached the development-only Developer Gallery route and failed because `Pro2Black.png` did not have a stable module ID.

## Validation

- `yarn workspace @onekeyhq/mobile dev-vendor:registry:update` (added exactly one registry entry)
- `yarn workspace @onekeyhq/mobile dev-vendor:build --platform all`
- `git diff --check`
- `yarn agent:check --profile commit`

Original failing run: https://github.com/OneKeyHQ/app-monorepo/actions/runs/34588269522
