### PR TITLE
fix: handle Android dialog navbar inset OK-62769

### DIFF
--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -186,15 +186,19 @@ const useSafeKeyboardAnimationStyle = ({
     useInitialSafeAreaBottomInsetFallback && bottom === 0
       ? INITIAL_BOTTOM_INSET
       : bottom;
+  const androidBottomInset = platformEnv.isNativeAndroid ? safeAreaBottom : 0;
   const keyboardHeightValue = useSharedValue(0);
   // Keep the dialog clear of both the home indicator and the keyboard.
   // These are two independent concerns collapsed into one paddingBottom:
   //   - bottom safe-area inset: always required (static)
   //   - keyboard height: only while the keyboard is shown (dynamic)
-  // They must not stack — once the keyboard is up it already covers the
-  // safe area, so take the larger of the two instead of summing them.
+  // Android keyboard events exclude the bottom system-bar inset, while iOS
+  // keyboard events already include it. Only restore the inset on Android.
   const animatedStyles = useAnimatedStyle(() => ({
-    paddingBottom: Math.max(keyboardHeightValue.value, safeAreaBottom),
+    paddingBottom: Math.max(
+      keyboardHeightValue.value + androidBottomInset,
+      safeAreaBottom,
+    ),
   }));
 
   useKeyboardEventWithoutNavigation({


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-62769](<https://onekeyhq.atlassian.net/browse/OK-62769>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary

- preserve the Android bottom system-bar inset when a dialog keyboard is visible
- keep the existing iOS and web safe-area behavior unchanged
- prevent dialog footer actions from being clipped or appearing too short above the keyboard

Issue: [OK-62769](https://onekeyhq.atlassian.net/browse/OK-62769)

## Root cause

Android keyboard events report the IME height without the bottom system-bar inset. The previous `max(keyboardHeight, safeAreaBottom)` calculation discarded that inset while the keyboard was visible. This change restores it only on Android.

## QA verification

Please verify a bottom-sheet dialog with a focused text input and the keyboard open in all three Android system-navigation states:

- [ ] Three-button navigation bar
- [ ] Gesture navigation / bottom gesture indicator
- [ ] Navigation bar completely disabled or absent

For each state, confirm that:

- the full bottom action bar and both footer buttons remain visible
- the buttons are not clipped by the keyboard or system navigation area
- there is no excessive bottom gap, including after opening and closing the keyboard

## Validation

- Android 15 three-button navigation: passed
- Android 15 gesture navigation: passed
- Android 10 with `qemu.hw.mainkeys=1` and no navigation bar: passed
- `yarn agent:check --profile commit`
- `yarn jest packages/components/src/composite/Dialog/Dialog.focus.test.tsx --runInBand`


[OK-62769]: https://onekeyhq.atlassian.net/browse/OK-62769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ