### PR TITLE
fix: correct mobile Market banner height

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@onekeyhq/components', () => {
     role?: string;
     'aria-label'?: string;
     color?: string;
+    $gtMd?: { h?: number | string };
   }>;
   const Component = ({
     children,
@@ -26,6 +27,7 @@ jest.mock('@onekeyhq/components', () => {
     role,
     'aria-label': accessibilityLabel,
     color,
+    $gtMd,
   }: IProps) =>
     React.createElement(
       'div',
@@ -35,6 +37,7 @@ jest.mock('@onekeyhq/components', () => {
         onClick: onPress,
         role,
         'aria-label': accessibilityLabel,
+        'data-gt-md-height': $gtMd?.h,
       },
       children,
     );
@@ -51,6 +54,11 @@ jest.mock('@onekeyhq/components', () => {
 
 jest.mock('@onekeyhq/kit/src/views/Market/components/PerpsBadges', () => ({
   LeverageBadge: () => null,
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: { isNative: true },
 }));
 
 const makeToken = (
@@ -185,5 +193,10 @@ describe('Market theme banner', () => {
     render(<MarketBannerItem item={item} />);
     expect(screen.getByText('+1%')).toBeTruthy();
     expect(screen.queryAllByTestId('market-banner-token-row')).toHaveLength(0);
+    expect(
+      screen
+        .getByTestId('market-banner-item')
+        .parentElement?.getAttribute('data-gt-md-height'),
+    ).toBe('118');
   });
 });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
@@ -13,6 +13,7 @@ import {
 } from '@onekeyhq/components';
 import { ANIMATE_ONLY_BORDER_COLOR } from '@onekeyhq/components/src/utils/animationConstants';
 import { LeverageBadge } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EMarketBannerType,
   type IMarketBannerItem,
@@ -132,7 +133,7 @@ function LegacyMarketBannerItem({
         minWidth: 180,
         maxWidth: 256,
         width: 'auto',
-        h: 'auto',
+        h: platformEnv.isNative ? 118 : 'auto',
         minHeight: 96,
         p: '$4',
         gap: '$3',

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.test.tsx
@@ -16,7 +16,9 @@ jest.mock('./useToMarketBannerDetail', () => ({
   useToMarketBannerDetail: () => jest.fn(),
 }));
 jest.mock('./MarketBannerItem', () => ({
-  MarketBannerItem: () => <div data-testid="banner" />,
+  MarketBannerItem: ({ item }: { item: { _id: string } }) => (
+    <div data-testid="banner">{item._id}</div>
+  ),
 }));
 jest.mock('./MarketBannerItemSkeleton', () => ({
   MarketBannerItemSkeleton: () => <div data-testid="skeleton" />,
@@ -48,8 +50,8 @@ function Page() {
     </MarketBannerProvider>
   );
 }
-const populated = () => ({
-  bannerList: [{ _id: 'banner' }] as ReturnType<
+const populated = (id = 'banner') => ({
+  bannerList: [{ _id: id }] as ReturnType<
     typeof useMarketBannerList
   >['bannerList'],
   isLoading: false,
@@ -92,6 +94,19 @@ it('keeps the occupied header height when a refresh removes all banners', () => 
     scope: 'en-US:false',
   };
   rerender(<Page />);
+  expect(
+    screen.getByTestId('banner').closest('[aria-hidden=true]'),
+  ).toBeTruthy();
+});
+
+it('retains the latest successful banners when a refresh removes them', () => {
+  mockState = populated('legacy');
+  const { rerender } = render(<Page />);
+  mockState = populated('modern');
+  rerender(<Page />);
+  mockState = { ...populated(), bannerList: [] };
+  rerender(<Page />);
+  expect(screen.getByTestId('banner').textContent).toBe('modern');
   expect(
     screen.getByTestId('banner').closest('[aria-hidden=true]'),
   ).toBeTruthy();

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.test.tsx
@@ -8,6 +8,7 @@ import { MarketBannerList, MarketBannerProvider } from './MarketBannerList';
 import type { useMarketBannerList } from './useMarketBannerList';
 
 let mockState: ReturnType<typeof useMarketBannerList>;
+let mockIsSmallScreen = true;
 jest.mock('./useMarketBannerList', () => ({
   useMarketBannerList: () => mockState,
 }));
@@ -32,10 +33,12 @@ jest.mock('@onekeyhq/components', () => ({
   }: PropsWithChildren<{ opacity?: number }>) => (
     <div aria-hidden={opacity === 0 ? true : undefined}>{children}</div>
   ),
-  XStack: ({ children }: PropsWithChildren) => (
-    <div data-testid="reserved-space">{children}</div>
+  XStack: ({ children, pt }: PropsWithChildren<{ pt?: string }>) => (
+    <div data-testid="reserved-space" data-padding-top={pt}>
+      {children}
+    </div>
   ),
-  useMedia: () => ({ md: true }),
+  useMedia: () => ({ md: mockIsSmallScreen }),
 }));
 
 function Page() {
@@ -52,6 +55,17 @@ const populated = () => ({
   isLoading: false,
   isFetched: true,
   scope: 'en-US:false',
+});
+
+beforeEach(() => {
+  mockIsSmallScreen = true;
+});
+
+it('keeps native tablet banner padding aligned with the fixed header height', () => {
+  mockIsSmallScreen = false;
+  mockState = populated();
+  render(<Page />);
+  expect(screen.getByTestId('reserved-space').dataset.paddingTop).toBe('$2');
 });
 
 it('does not insert a banner after the native page has started without one', () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
@@ -78,7 +78,7 @@ function BannerContainerDesktop({
       pointerEvents={hidden ? 'none' : 'auto'}
       accessibilityElementsHidden={hidden}
       importantForAccessibility={hidden ? 'no-hide-descendants' : 'auto'}
-      pt="$4"
+      pt={platformEnv.isNative ? '$2' : '$4'}
       pb="$2"
       px="$5"
       gap="$3"

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
@@ -116,15 +116,19 @@ function MarketBannerListComponent() {
 
   // md = true when screen width <= 767px (small screen)
   const isSmallScreen = md;
-  // Commit only a successful response; a failed request can still recover.
-  // A successful empty response keeps the native header absent until re-entry.
-  const [initialBannerList, setInitialBannerList] = useState(
+  // Retain the latest successful non-empty response so an empty refresh keeps
+  // card dimensions aligned with the current native header height.
+  // A successful first empty response still locks that header absent.
+  const [retainedBannerList, setRetainedBannerList] = useState(
     isFetched ? bannerList : undefined,
   );
-  if (initialBannerList === undefined && isFetched) {
-    setInitialBannerList(bannerList);
+  const canRetainBannerList =
+    retainedBannerList === undefined ||
+    (retainedBannerList.length > 0 && bannerList.length > 0);
+  if (canRetainBannerList && isFetched && retainedBannerList !== bannerList) {
+    setRetainedBannerList(bannerList);
   }
-  if (platformEnv.isNative && !initialBannerList?.length) return null;
+  if (platformEnv.isNative && !retainedBannerList?.length) return null;
 
   // Only show skeleton on initial load (before first fetch completes).
   // Skip skeleton on re-fetch to avoid header height flicker when
@@ -137,7 +141,7 @@ function MarketBannerListComponent() {
   if (hidden && !platformEnv.isNative) return null;
   // Preserve the actual card dimensions (including tablet layouts) if a
   // reconnect removes the banners, without retaining interactive stale links.
-  const visibleBannerList = hidden ? (initialBannerList ?? []) : bannerList;
+  const visibleBannerList = hidden ? (retainedBannerList ?? []) : bannerList;
   const bannerItems = visibleBannerList.map((item) => (
     <MarketBannerItem
       key={item._id}

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -121,7 +121,7 @@ const EMPTY_MARKET_STOCK_CATEGORIES: IMarketCategoryItem[] = [];
 const MARKET_TAB_ITEM_PRESS_DRAG_GUARD_MS = platformEnv.isNativeIOS ? 700 : 350;
 const MARKET_TAB_ITEM_PRESS_IDLE_GUARD_MS = platformEnv.isNativeIOS ? 180 : 120;
 const MARKET_TAB_BAR_HEIGHT = 44;
-const MARKET_BANNER_HEADER_HEIGHT = 134;
+const MARKET_BANNER_HEADER_HEIGHT = 204;
 
 const STYLES = StyleSheet.create({
   pager: { flex: 1 },

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -70,6 +70,7 @@ import {
   getMarketMobileBannerHeaderHeight,
   getMarketMobileSecondaryHeaderHeight,
   resolveMarketBannerHeaderDecision,
+  resolveMarketBannerHeaderHeight,
 } from './mobileLayoutUtils';
 
 import type { IMarketPerpsDataCache } from '../components/MarketPerpsList/hooks/useMarketPerpsTokenList';
@@ -422,21 +423,12 @@ function MobileLayoutComponent({
     scope: bannerScope,
     height: getMarketMobileBannerHeaderHeight(bannerList),
   });
-  if (bannerHeaderHeightRef.current.scope !== bannerScope) {
-    bannerHeaderHeightRef.current = {
-      scope: bannerScope,
-      height: getMarketMobileBannerHeaderHeight([]),
-    };
-  }
-  if (
-    isBannerFetched &&
-    bannerList.length > 0 &&
-    (bannerDecisionRef.current.scope !== bannerScope ||
-      !bannerDecisionRef.current.isDecided)
-  ) {
-    bannerHeaderHeightRef.current.height =
-      getMarketMobileBannerHeaderHeight(bannerList);
-  }
+  bannerHeaderHeightRef.current = resolveMarketBannerHeaderHeight({
+    current: bannerHeaderHeightRef.current,
+    scope: bannerScope,
+    isFetched: isBannerFetched,
+    bannerList,
+  });
   bannerDecisionRef.current = resolveMarketBannerHeaderDecision({
     current: bannerDecisionRef.current,
     scope: bannerScope,

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -67,6 +67,7 @@ import { getDefaultMarketStockCategoryId } from './marketStockCategoryUtils';
 import { shouldHandleMarketPagerPageSelected } from './marketTabSelectionGuards';
 import {
   MARKET_MOBILE_COLUMN_HEADER_HEIGHT,
+  getMarketMobileBannerHeaderHeight,
   getMarketMobileSecondaryHeaderHeight,
   resolveMarketBannerHeaderDecision,
 } from './mobileLayoutUtils';
@@ -121,7 +122,6 @@ const EMPTY_MARKET_STOCK_CATEGORIES: IMarketCategoryItem[] = [];
 const MARKET_TAB_ITEM_PRESS_DRAG_GUARD_MS = platformEnv.isNativeIOS ? 700 : 350;
 const MARKET_TAB_ITEM_PRESS_IDLE_GUARD_MS = platformEnv.isNativeIOS ? 180 : 120;
 const MARKET_TAB_BAR_HEIGHT = 44;
-const MARKET_BANNER_HEADER_HEIGHT = 204;
 
 const STYLES = StyleSheet.create({
   pager: { flex: 1 },
@@ -418,6 +418,25 @@ function MobileLayoutComponent({
     isDecided: false,
     hasBanners: false,
   });
+  const bannerHeaderHeightRef = useRef({
+    scope: bannerScope,
+    height: getMarketMobileBannerHeaderHeight(bannerList),
+  });
+  if (bannerHeaderHeightRef.current.scope !== bannerScope) {
+    bannerHeaderHeightRef.current = {
+      scope: bannerScope,
+      height: getMarketMobileBannerHeaderHeight([]),
+    };
+  }
+  if (
+    isBannerFetched &&
+    bannerList.length > 0 &&
+    (bannerDecisionRef.current.scope !== bannerScope ||
+      !bannerDecisionRef.current.isDecided)
+  ) {
+    bannerHeaderHeightRef.current.height =
+      getMarketMobileBannerHeaderHeight(bannerList);
+  }
   bannerDecisionRef.current = resolveMarketBannerHeaderDecision({
     current: bannerDecisionRef.current,
     scope: bannerScope,
@@ -425,7 +444,7 @@ function MobileLayoutComponent({
     bannerCount: bannerList.length,
   });
   const headerHeight = bannerDecisionRef.current.hasBanners
-    ? MARKET_BANNER_HEADER_HEIGHT
+    ? bannerHeaderHeightRef.current.height
     : 1;
   const [stickyHeaderHeight, setStickyHeaderHeight] = useState(
     MARKET_TAB_BAR_HEIGHT + getMarketMobileSecondaryHeaderHeight(),

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
@@ -1,11 +1,24 @@
 import {
   getMarketEmptyWatchlistContainerProps,
+  getMarketMobileBannerHeaderHeight,
   getMarketMobileSecondaryHeaderHeight,
   getMarketNativeCompactListStyle,
   getMarketRecommendContainerPaddingTop,
   getMarketWebSecondaryHeaderHeight,
   resolveMarketBannerHeaderDecision,
 } from './mobileLayoutUtils';
+
+describe('getMarketMobileBannerHeaderHeight', () => {
+  it('uses the legacy height when every banner omits token previews', () => {
+    expect(getMarketMobileBannerHeaderHeight([{}, {}])).toBe(134);
+  });
+
+  it('uses the modern height when every banner renders token previews', () => {
+    expect(
+      getMarketMobileBannerHeaderHeight([{ tokens: [] }, { tokens: [] }]),
+    ).toBe(204);
+  });
+});
 
 describe('resolveMarketBannerHeaderDecision', () => {
   it('waits for recovery after an initial failure before locking banner height', () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
@@ -6,6 +6,7 @@ import {
   getMarketRecommendContainerPaddingTop,
   getMarketWebSecondaryHeaderHeight,
   resolveMarketBannerHeaderDecision,
+  resolveMarketBannerHeaderHeight,
 } from './mobileLayoutUtils';
 
 describe('getMarketMobileBannerHeaderHeight', () => {
@@ -17,6 +18,31 @@ describe('getMarketMobileBannerHeaderHeight', () => {
     expect(
       getMarketMobileBannerHeaderHeight([{ tokens: [] }, { tokens: [] }]),
     ).toBe(204);
+  });
+});
+
+describe('resolveMarketBannerHeaderHeight', () => {
+  it('updates a legacy height when a successful refresh becomes modern', () => {
+    expect(
+      resolveMarketBannerHeaderHeight({
+        current: { scope: 'en-US:false', height: 134 },
+        scope: 'en-US:false',
+        isFetched: true,
+        bannerList: [{ tokens: [] }],
+      }),
+    ).toEqual({ scope: 'en-US:false', height: 204 });
+  });
+
+  it('preserves the occupied height when a refresh returns no banners', () => {
+    const current = { scope: 'en-US:false', height: 204 };
+    expect(
+      resolveMarketBannerHeaderHeight({
+        current,
+        scope: 'en-US:false',
+        isFetched: true,
+        bannerList: [],
+      }),
+    ).toBe(current);
   });
 });
 

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
@@ -15,6 +15,34 @@ export function getMarketMobileBannerHeaderHeight(
     : MARKET_MOBILE_BANNER_LEGACY_HEIGHT;
 }
 
+export type IMarketBannerHeaderHeightState = {
+  scope: string;
+  height: number;
+};
+
+export function resolveMarketBannerHeaderHeight({
+  current,
+  scope,
+  isFetched,
+  bannerList,
+}: {
+  current: IMarketBannerHeaderHeightState;
+  scope: string;
+  isFetched: boolean;
+  bannerList: readonly { tokens?: unknown }[];
+}): IMarketBannerHeaderHeightState {
+  if (isFetched && bannerList.length > 0) {
+    const height = getMarketMobileBannerHeaderHeight(bannerList);
+    return current.scope === scope && current.height === height
+      ? current
+      : { scope, height };
+  }
+  if (current.scope !== scope) {
+    return { scope, height: MARKET_MOBILE_BANNER_LEGACY_HEIGHT };
+  }
+  return current;
+}
+
 export type IMarketBannerHeaderDecision = {
   scope: string;
   isDecided: boolean;

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
@@ -2,6 +2,19 @@ export const MARKET_MOBILE_SECONDARY_HEADER_HEIGHT = 74;
 export const MARKET_MOBILE_COLUMN_HEADER_HEIGHT = 32;
 export const MARKET_MOBILE_CONTENT_TOP_GAP = 16;
 
+const MARKET_MOBILE_BANNER_MODERN_HEIGHT = 204;
+const MARKET_MOBILE_BANNER_LEGACY_HEIGHT = 134;
+
+export function getMarketMobileBannerHeaderHeight(
+  bannerList: readonly { tokens?: unknown }[],
+) {
+  const isModernBannerList =
+    bannerList.length > 0 && bannerList.every((item) => Boolean(item.tokens));
+  return isModernBannerList
+    ? MARKET_MOBILE_BANNER_MODERN_HEIGHT
+    : MARKET_MOBILE_BANNER_LEGACY_HEIGHT;
+}
+
 export type IMarketBannerHeaderDecision = {
   scope: string;
   isDecided: boolean;


### PR DESCRIPTION
## Summary

- align the native Market pager header with the measured 188pt banner card plus 16pt vertical padding
- keep the loaded banner height consistent with the existing 204pt loading fallback
- prevent the third token row from being clipped or covered by the category tabs

## Validation

- `yarn agent:check --profile commit`
- focused Market banner Jest tests: 5 suites, 39 tests passed
- iOS 18.6 Simulator at 402x874 @3x: measured content height 204pt in portrait/mobile breakpoint
- verified light/dark rendering, Browser-to-Market return, and collapsed sticky-tab scrolling