### PR TITLE
fix: remove unwanted icon backgrounds(OK-54795)

### DIFF
--- a/packages/kit/src/views/Notifications/components/NotificationListView.tsx
+++ b/packages/kit/src/views/Notifications/components/NotificationListView.tsx
@@ -148,16 +148,7 @@ function NotificationItem({
   const imageElement = useMemo(() => {
     if (item.icon) {
       return (
-        <Stack
-          w={28}
-          h={28}
-          bg="$bgStrong"
-          borderColor="$borderSubdued"
-          borderWidth={StyleSheet.hairlineWidth}
-          borderRadius="$full"
-          ai="center"
-          jc="center"
-        >
+        <Stack w={28} h={28} borderRadius="$full" ai="center" jc="center">
           <Icon name={item.icon} color="$icon" size="$4.5" />
         </Stack>
       );

--- a/packages/kit/src/views/Setting/pages/AccountDerivation/index.tsx
+++ b/packages/kit/src/views/Setting/pages/AccountDerivation/index.tsx
@@ -6,6 +6,7 @@ import { Page, SizableText, Stack, XStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { DeriveTypeSelectorTriggerGlobalStandAlone } from '@onekeyhq/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { NetworkAvatarBase } from '@onekeyhq/kit/src/components/NetworkAvatar';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
@@ -55,7 +56,7 @@ const AccountDerivationListItem: FC<IAccountDerivationListItemProps> = ({
       <ListItem
         userSelect="none"
         title={title}
-        avatarProps={{ src: icon, size: '$8' }}
+        renderAvatar={<NetworkAvatarBase logoURI={icon ?? ''} size="$8" />}
       >
         <XStack>
           <SizableText mr="$3">{label}</SizableText>


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-54795](<https://onekeyhq.atlassian.net/browse/OK-54795>)

----------
<!-- github-pr-monitor:jira-links:end -->

## Summary
- render account derivation network logos with the shared network avatar used by Wallet
- remove the gray background and border from notification list icons while preserving layout and unread indicators

## Intent & Context
Account derivation network logos and notification icons showed unwanted gray containers. The expected presentation matches the Wallet module, where network logos appear without a contrasting tile.

## Root Cause
The account derivation list routed network logo URLs through the generic AccountAvatar, which supplies a strong background intended for account blockies. Notification list icon containers explicitly applied a strong background and subdued hairline border.

## Design Decisions
- Reuse NetworkAvatarBase for account derivation instead of changing shared AccountAvatar defaults and affecting unrelated account avatars.
- Remove only the notification icon container decoration, leaving dimensions, alignment, unread badge, and system notification thumbnail treatment unchanged.

## Changes Detail
- AccountDerivation/index.tsx: use NetworkAvatarBase for network logo rendering.
- NotificationListView.tsx: remove the left icon background and hairline border.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Shared cross-platform rendering of the two targeted list rows; no data or behavior changes.

## Visual Acceptance
- Built and launched the native Desktop app with `yarn app:desktop`, then connected to the running renderer over CDP.
- Account derivation: verified the EVM network logo renders as a clean circular network avatar without the unwanted gray tile.
- Notification list: verified real notification rows render icons without gray fills or borders, while unread red-dot indicators remain visible.
- CDP style probe confirmed the notification icon container uses a transparent background and `0px` borders on all four sides.
- Result: passed.

## PR Status
- CI: 26/26 checks successful; no pending checks.
- Auto-merge: enabled (squash).
- Remaining gate: required code review.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] `yarn app:desktop` (renderer compiled and Electron reached app-ready)
- [x] Confirm source-level preservation of notification icon sizing, alignment, unread badge, and system thumbnail styling
- [x] Confirm account derivation now reuses Wallet's `NetworkAvatarBase`
- [x] Native Desktop visual verification over CDP
  - Account derivation network logo renders without the unwanted gray tile
  - Notification icons render with transparent backgrounds and 0px borders; unread indicators remain visible

[OK-54795]: https://onekeyhq.atlassian.net/browse/OK-54795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ